### PR TITLE
DRILL-7855: Provide a secure mechanism for specifying storage plugin credentials

### DIFF
--- a/common/src/main/resources/drill-module.conf
+++ b/common/src/main/resources/drill-module.conf
@@ -24,7 +24,8 @@ drill {
     base.classes : ${?drill.classpath.scanning.base.classes} [
       org.apache.drill.common.logical.data.LogicalOperator,
       org.apache.drill.common.logical.FormatPluginConfig,
-      org.apache.drill.common.logical.StoragePluginConfig
+      org.apache.drill.common.logical.StoragePluginConfig,
+      org.apache.drill.common.logical.security.CredentialsProvider
     ],
 
     packages : ${?drill.classpath.scanning.packages} [

--- a/contrib/storage-cassandra/src/main/java/org/apache/drill/exec/store/cassandra/CassandraStorageConfig.java
+++ b/contrib/storage-cassandra/src/main/java/org/apache/drill/exec/store/cassandra/CassandraStorageConfig.java
@@ -21,19 +21,20 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.common.logical.AbstractSecuredStoragePluginConfig;
+import org.apache.drill.exec.store.security.CredentialProviderUtils;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 @JsonTypeName(CassandraStorageConfig.NAME)
-public class CassandraStorageConfig extends StoragePluginConfig {
+public class CassandraStorageConfig extends AbstractSecuredStoragePluginConfig {
   public static final String NAME = "cassandra";
 
   private final String host;
-  private final String username;
-  private final String password;
   private final int port;
 
   @JsonCreator
@@ -41,10 +42,11 @@ public class CassandraStorageConfig extends StoragePluginConfig {
       @JsonProperty("host") String host,
       @JsonProperty("port") int port,
       @JsonProperty("username") String username,
-      @JsonProperty("password") String password) {
+      @JsonProperty("password") String password,
+      @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider) {
+    super(CredentialProviderUtils.getCredentialsProvider(username, password, credentialsProvider),
+        credentialsProvider == null);
     this.host = host;
-    this.username = username;
-    this.password = password;
     this.port = port;
   }
 
@@ -52,26 +54,38 @@ public class CassandraStorageConfig extends StoragePluginConfig {
     return host;
   }
 
-  public String getUsername() {
-    return username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
   public int getPort() {
     return port;
   }
 
   @JsonIgnore
-  public Map<String, Object> toConfigMap() {
-    Map<String, Object> result = new HashMap<>();
+  public UsernamePasswordCredentials getUsernamePasswordCredentials() {
+    return new UsernamePasswordCredentials(credentialsProvider);
+  }
 
+  public String getUsername() {
+    if (directCredentials) {
+      return getUsernamePasswordCredentials().getUsername();
+    }
+    return null;
+  }
+
+  public String getPassword() {
+    if (directCredentials) {
+      return getUsernamePasswordCredentials().getPassword();
+    }
+    return null;
+  }
+
+  @JsonIgnore
+  public Map<String, Object> toConfigMap() {
+    UsernamePasswordCredentials credentials = getUsernamePasswordCredentials();
+
+    Map<String, Object> result = new HashMap<>();
     result.put("host", host);
     result.put("port", port);
-    result.put("username", username);
-    result.put("password", password);
+    result.put("username", credentials.getUsername());
+    result.put("password", credentials.getPassword());
     return result;
   }
 
@@ -85,12 +99,11 @@ public class CassandraStorageConfig extends StoragePluginConfig {
     }
     CassandraStorageConfig that = (CassandraStorageConfig) o;
     return Objects.equals(host, that.host)
-        && Objects.equals(username, that.username)
-        && Objects.equals(password, that.password);
+        && Objects.equals(credentialsProvider, that.credentialsProvider);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, username, password);
+    return Objects.hash(host, credentialsProvider);
   }
 }

--- a/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/BaseCassandraTest.java
+++ b/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/BaseCassandraTest.java
@@ -38,7 +38,8 @@ public class BaseCassandraTest extends ClusterTest {
         cassandra.getHost(),
         cassandra.getMappedPort(CassandraContainer.CQL_PORT),
         cassandra.getUsername(),
-        cassandra.getPassword());
+        cassandra.getPassword(),
+        null);
     config.setEnabled(true);
     cluster.defineStoragePlugin("cassandra", config);
   }

--- a/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidStoragePluginConfig.java
+++ b/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidStoragePluginConfig.java
@@ -20,14 +20,14 @@ package org.apache.drill.exec.store.druid;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.StoragePluginConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 
 @JsonTypeName(DruidStoragePluginConfig.NAME)
-public class DruidStoragePluginConfig extends StoragePluginConfigBase {
+public class DruidStoragePluginConfig extends StoragePluginConfig {
 
   private static final Logger logger = LoggerFactory.getLogger(DruidStoragePluginConfig.class);
   public static final String NAME = "druid";

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticComplexTypesTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticComplexTypesTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.elasticsearch;
 
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
@@ -56,7 +57,7 @@ public class ElasticComplexTypesTest extends ClusterTest {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
     ElasticsearchStorageConfig config = new ElasticsearchStorageConfig(
-        Collections.singletonList(HOST), null, null);
+        Collections.singletonList(HOST), null, null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     config.setEnabled(true);
     cluster.defineStoragePlugin("elastic", config);
 

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticInfoSchemaTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticInfoSchemaTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.elasticsearch;
 
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.http.HttpHost;
@@ -51,7 +52,7 @@ public class ElasticInfoSchemaTest extends ClusterTest {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
     ElasticsearchStorageConfig config = new ElasticsearchStorageConfig(
-        Collections.singletonList(HOST), null, null);
+        Collections.singletonList(HOST), null, null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     config.setEnabled(true);
     cluster.defineStoragePlugin("elastic", config);
 

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchPlanTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchPlanTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.elasticsearch;
 
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.http.HttpHost;
@@ -49,7 +50,7 @@ public class ElasticSearchPlanTest extends ClusterTest {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
     ElasticsearchStorageConfig config = new ElasticsearchStorageConfig(
-        Collections.singletonList(HOST), null, null);
+        Collections.singletonList(HOST), null, null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     config.setEnabled(true);
     cluster.defineStoragePlugin("elastic", config);
 

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchQueryTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchQueryTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.elasticsearch;
 
 import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.http.HttpHost;
@@ -56,7 +57,7 @@ public class ElasticSearchQueryTest extends ClusterTest {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
     ElasticsearchStorageConfig config = new ElasticsearchStorageConfig(
-        Collections.singletonList(HOST), null, null);
+        Collections.singletonList(HOST), null, null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     config.setEnabled(true);
     cluster.defineStoragePlugin("elastic", config);
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseStoragePluginConfig.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseStoragePluginConfig.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.store.hbase;
 
 import java.util.Map;
 
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HConstants;
@@ -35,7 +35,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 
 @JsonTypeName(HBaseStoragePluginConfig.NAME)
-public class HBaseStoragePluginConfig extends StoragePluginConfigBase implements DrillHBaseConstants {
+public class HBaseStoragePluginConfig extends StoragePluginConfig implements DrillHBaseConstants {
   private static final Logger logger = LoggerFactory.getLogger(HBaseStoragePluginConfig.class);
 
   private Map<String, String> config;

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePluginConfig.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePluginConfig.java
@@ -20,14 +20,14 @@ package org.apache.drill.exec.store.hive;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.StoragePluginConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName(HiveStoragePluginConfig.NAME)
-public class HiveStoragePluginConfig extends StoragePluginConfigBase {
+public class HiveStoragePluginConfig extends StoragePluginConfig {
 
   public static final String NAME = "hive";
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -32,6 +32,7 @@ import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBui
 import org.apache.drill.exec.store.http.util.HttpProxyConfig;
 import org.apache.drill.exec.store.http.util.HttpProxyConfig.ProxyBuilder;
 import org.apache.drill.exec.store.http.util.SimpleHttp;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 
 import java.io.File;
 import java.io.InputStream;
@@ -132,12 +133,13 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
         .fromConfigForURL(drillConfig, url.toString());
     final String proxyType = config.proxyType();
     if (proxyType != null && !"direct".equals(proxyType)) {
+      UsernamePasswordCredentials credentials = config.getUsernamePasswordCredentials();
       builder
         .type(config.proxyType())
         .host(config.proxyHost())
         .port(config.proxyPort())
-        .username(config.proxyUsername())
-        .password(config.proxyPassword());
+        .username(credentials.getUsername())
+        .password(credentials.getPassword());
     }
     return builder.build();
   }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
@@ -20,12 +20,15 @@ package org.apache.drill.exec.store.http;
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.map.CaseInsensitiveMap;
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.AbstractSecuredStoragePluginConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.exec.store.security.CredentialProviderUtils;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +38,7 @@ import java.util.Objects;
 
 
 @JsonTypeName(HttpStoragePluginConfig.NAME)
-public class HttpStoragePluginConfig extends StoragePluginConfigBase {
+public class HttpStoragePluginConfig extends AbstractSecuredStoragePluginConfig {
   private static final Logger logger = LoggerFactory.getLogger(HttpStoragePluginConfig.class);
   public static final String NAME = "http";
   public final Map<String, HttpApiConfig> connections;
@@ -43,8 +46,6 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
   public final String proxyHost;
   public final int proxyPort;
   public final String proxyType;
-  public final String proxyUsername;
-  public final String proxyPassword;
   /**
    * Timeout in seconds.
    */
@@ -58,9 +59,12 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
                                  @JsonProperty("proxyPort") Integer proxyPort,
                                  @JsonProperty("proxyType") String proxyType,
                                  @JsonProperty("proxyUsername") String proxyUsername,
-                                 @JsonProperty("proxyPassword") String proxyPassword
+                                 @JsonProperty("proxyPassword") String proxyPassword,
+                                 @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider
                                  ) {
-    this.cacheResults = cacheResults == null ? false : cacheResults;
+    super(CredentialProviderUtils.getCredentialsProvider(normalize(proxyUsername), normalize(proxyPassword), credentialsProvider),
+        credentialsProvider == null);
+    this.cacheResults = cacheResults != null && cacheResults;
 
     this.connections = CaseInsensitiveMap.newHashMap();
     if (connections != null) {
@@ -70,25 +74,21 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
     this.timeout = timeout == null ? 0 : timeout;
     this.proxyHost = normalize(proxyHost);
     this.proxyPort = proxyPort == null ? 0 : proxyPort;
-    this.proxyUsername = normalize(proxyUsername);
-    this.proxyPassword = normalize(proxyPassword);
     proxyType = normalize(proxyType);
     this.proxyType = proxyType == null
         ? "direct" : proxyType.trim().toLowerCase();
 
     // Validate Proxy Type
-    if (this.proxyType != null) {
-      switch (this.proxyType) {
-        case "direct":
-        case "http":
-        case "socks":
-          break;
-        default:
-          throw UserException
-            .validationError()
-            .message("Invalid Proxy Type: %s.  Drill supports 'direct', 'http' and 'socks' proxies.", proxyType)
-            .build(logger);
-      }
+    switch (this.proxyType) {
+      case "direct":
+      case "http":
+      case "socks":
+        break;
+      default:
+        throw UserException
+          .validationError()
+          .message("Invalid Proxy Type: %s.  Drill supports 'direct', 'http' and 'socks' proxies.", proxyType)
+          .build(logger);
     }
   }
 
@@ -107,7 +107,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
   public HttpStoragePluginConfig copyForPlan(String connectionName) {
     return new HttpStoragePluginConfig(
         cacheResults, configFor(connectionName), timeout,
-        proxyHost, proxyPort, proxyType, proxyUsername, proxyPassword);
+        proxyHost, proxyPort, proxyType, null, null, credentialsProvider);
   }
 
   private Map<String, HttpApiConfig> configFor(String connectionName) {
@@ -129,8 +129,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
            Objects.equals(proxyHost, thatConfig.proxyHost) &&
            Objects.equals(proxyPort, thatConfig.proxyPort) &&
            Objects.equals(proxyType, thatConfig.proxyType) &&
-           Objects.equals(proxyUsername, thatConfig.proxyUsername) &&
-           Objects.equals(proxyPassword, thatConfig.proxyPassword);
+           Objects.equals(credentialsProvider, thatConfig.credentialsProvider);
   }
 
   @Override
@@ -141,8 +140,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
       .field("timeout", timeout)
       .field("proxyHost", proxyHost)
       .field("proxyPort", proxyPort)
-      .field("proxyUsername", proxyUsername)
-      .maskedField("proxyPassword", proxyPassword)
+      .field("credentialsProvider", credentialsProvider)
       .field("proxyType", proxyType)
       .toString();
   }
@@ -150,7 +148,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
   @Override
   public int hashCode() {
     return Objects.hash(connections, cacheResults, timeout,
-        proxyHost, proxyPort, proxyType, proxyUsername, proxyPassword);
+        proxyHost, proxyPort, proxyType, credentialsProvider);
   }
 
   @JsonProperty("cacheResults")
@@ -169,10 +167,20 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
   public int proxyPort() { return proxyPort; }
 
   @JsonProperty("proxyUsername")
-  public String proxyUsername() { return proxyUsername; }
+  public String proxyUsername() {
+    if (directCredentials) {
+      return getUsernamePasswordCredentials().getUsername();
+    }
+    return null;
+  }
 
   @JsonProperty("proxyPassword")
-  public String proxyPassword() { return proxyPassword; }
+  public String proxyPassword() {
+    if (directCredentials) {
+      return getUsernamePasswordCredentials().getPassword();
+    }
+    return null;
+  }
 
   @JsonProperty("proxyType")
   public String proxyType() { return proxyType; }
@@ -180,5 +188,10 @@ public class HttpStoragePluginConfig extends StoragePluginConfigBase {
   @JsonIgnore
   public HttpApiConfig getConnection(String connectionName) {
     return connections.get(connectionName);
+  }
+
+  @JsonIgnore
+  public UsernamePasswordCredentials getUsernamePasswordCredentials() {
+    return new UsernamePasswordCredentials(credentialsProvider);
   }
 }

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
@@ -100,7 +101,8 @@ public class TestHttpPlugin extends ClusterTest {
     configs.put("sunrise", sunriseConfig);
     configs.put("sunrise2", sunriseWithParamsConfig);
 
-    HttpStoragePluginConfig mockStorageConfigWithWorkspace = new HttpStoragePluginConfig(false, configs, 10, "", 80, "", "", "");
+    HttpStoragePluginConfig mockStorageConfigWithWorkspace =
+        new HttpStoragePluginConfig(false, configs, 10, "", 80, "", "", "", PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("live", mockStorageConfigWithWorkspace);
   }
@@ -145,7 +147,8 @@ public class TestHttpPlugin extends ClusterTest {
     configs.put("mockcsv", mockCsvConfig);
     configs.put("mockxml", mockXmlConfig);
 
-    HttpStoragePluginConfig mockStorageConfigWithWorkspace = new HttpStoragePluginConfig(false, configs, 2, "", 80, "", "", "");
+    HttpStoragePluginConfig mockStorageConfigWithWorkspace =
+        new HttpStoragePluginConfig(false, configs, 2, "", 80, "", "", "", PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("local", mockStorageConfigWithWorkspace);
   }

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStoragePlugin.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStoragePlugin.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,8 +113,9 @@ public class JdbcStoragePlugin extends AbstractStoragePlugin {
 
       hikariConfig.setDriverClassName(config.getDriver());
       hikariConfig.setJdbcUrl(config.getUrl());
-      hikariConfig.setUsername(config.getUsername());
-      hikariConfig.setPassword(config.getPassword());
+      UsernamePasswordCredentials credentials = config.getUsernamePasswordCredentials();
+      hikariConfig.setUsername(credentials.getUsername());
+      hikariConfig.setPassword(credentials.getPassword());
 
       return new HikariDataSource(hikariConfig);
     } catch (RuntimeException e) {

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestDataSource.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestDataSource.java
@@ -53,7 +53,7 @@ public class TestDataSource extends BaseTest {
   @Test
   public void testInitWithoutUserAndPassword() {
     JdbcStorageConfig config = new JdbcStorageConfig(
-      DRIVER, url, null, null, false, null);
+      DRIVER, url, null, null, false, null, null);
     try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
       assertEquals(DRIVER, dataSource.getDriverClassName());
       assertEquals(url, dataSource.getJdbcUrl());
@@ -65,7 +65,7 @@ public class TestDataSource extends BaseTest {
   @Test
   public void testInitWithUserAndPassword() {
     JdbcStorageConfig config = new JdbcStorageConfig(
-      DRIVER, url, "user", "password", false, null);
+      DRIVER, url, "user", "password", false, null, null);
     try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
       assertEquals("user", dataSource.getUsername());
       assertEquals("password", dataSource.getPassword());
@@ -81,7 +81,7 @@ public class TestDataSource extends BaseTest {
     sourceParameters.put("dataSource.cachePrepStmts", true);
     sourceParameters.put("dataSource.prepStmtCacheSize", 250);
     JdbcStorageConfig config = new JdbcStorageConfig(
-      DRIVER, url, "user", "password", false, sourceParameters);
+      DRIVER, url, "user", "password", false, sourceParameters, null);
     try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
       assertEquals(5, dataSource.getMinimumIdle());
       assertFalse(dataSource.isAutoCommit());
@@ -96,7 +96,7 @@ public class TestDataSource extends BaseTest {
     Map<String, Object> sourceParameters = new HashMap<>();
     sourceParameters.put("abc", "abc");
     JdbcStorageConfig config = new JdbcStorageConfig(
-      DRIVER, url, "user", "password", false, sourceParameters);
+      DRIVER, url, "user", "password", false, sourceParameters, null);
 
     thrown.expect(UserException.class);
     thrown.expectMessage(UserBitShared.DrillPBError.ErrorType.CONNECTION.name());
@@ -109,7 +109,7 @@ public class TestDataSource extends BaseTest {
     Map<String, Object> sourceParameters = new HashMap<>();
     sourceParameters.put("minimumIdle", "abc");
     JdbcStorageConfig config = new JdbcStorageConfig(
-      DRIVER, url, "user", "password", false, sourceParameters);
+      DRIVER, url, "user", "password", false, sourceParameters, null);
 
     thrown.expect(UserException.class);
     thrown.expectMessage(UserBitShared.DrillPBError.ErrorType.CONNECTION.name());

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
@@ -64,7 +64,8 @@ public class TestJdbcPluginWithH2IT extends ClusterTest {
     }
     Map<String, Object> sourceParameters =  new HashMap<>();
     sourceParameters.put("minimumIdle", 1);
-    JdbcStorageConfig jdbcStorageConfig = new JdbcStorageConfig("org.h2.Driver", connString, "root", "root", true, sourceParameters);
+    JdbcStorageConfig jdbcStorageConfig = new JdbcStorageConfig("org.h2.Driver", connString,
+        "root", "root", true, sourceParameters, null);
     jdbcStorageConfig.setEnabled(true);
     cluster.defineStoragePlugin("h2", jdbcStorageConfig);
     cluster.defineStoragePlugin("h2o", jdbcStorageConfig);

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
@@ -71,7 +71,7 @@ public class TestJdbcPluginWithMySQLIT extends ClusterTest {
 
     JdbcStorageConfig jdbcStorageConfig = new JdbcStorageConfig("com.mysql.cj.jdbc.Driver",
         String.format("jdbc:mysql://localhost:%s/%s?useJDBCCompliantTimezoneShift=true", mysqlPort, mysqlDBName),
-        "mysqlUser", "mysqlPass", false, null);
+        "mysqlUser", "mysqlPass", false, null, null);
     jdbcStorageConfig.setEnabled(true);
 
     cluster.defineStoragePlugin("mysql", jdbcStorageConfig);
@@ -80,7 +80,7 @@ public class TestJdbcPluginWithMySQLIT extends ClusterTest {
       // adds storage plugin with case insensitive table names
       JdbcStorageConfig jdbcCaseSensitiveStorageConfig = new JdbcStorageConfig("com.mysql.cj.jdbc.Driver",
           String.format("jdbc:mysql://localhost:%s/%s?useJDBCCompliantTimezoneShift=true", mysqlPort, mysqlDBName),
-          "mysqlUser", "mysqlPass", true, null);
+          "mysqlUser", "mysqlPass", true, null, null);
       jdbcCaseSensitiveStorageConfig.setEnabled(true);
       cluster.defineStoragePlugin("mysqlCaseInsensitive", jdbcCaseSensitiveStorageConfig);
     }

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduStoragePluginConfig.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduStoragePluginConfig.java
@@ -17,14 +17,14 @@
  */
 package org.apache.drill.exec.store.kudu;
 
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.StoragePluginConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName(KuduStoragePluginConfig.NAME)
-public class KuduStoragePluginConfig extends StoragePluginConfigBase {
+public class KuduStoragePluginConfig extends StoragePluginConfig {
 
   public static final String NAME = "kudu";
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
@@ -19,8 +19,6 @@ package org.apache.drill.exec.store.mongo;
 
 import java.util.List;
 
-import org.apache.drill.common.logical.StoragePluginConfig;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,9 +26,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
+import org.apache.drill.common.logical.AbstractSecuredStoragePluginConfig;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 
 @JsonTypeName(MongoStoragePluginConfig.NAME)
-public class MongoStoragePluginConfig extends StoragePluginConfig {
+public class MongoStoragePluginConfig extends AbstractSecuredStoragePluginConfig {
 
   public static final String NAME = "mongo";
 
@@ -40,7 +41,9 @@ public class MongoStoragePluginConfig extends StoragePluginConfig {
   private final MongoClientURI clientURI;
 
   @JsonCreator
-  public MongoStoragePluginConfig(@JsonProperty("connection") String connection) {
+  public MongoStoragePluginConfig(@JsonProperty("connection") String connection,
+      @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider) {
+    super(getCredentialsProvider(credentialsProvider), credentialsProvider == null);
     this.connection = connection;
     this.clientURI = new MongoClientURI(connection);
   }
@@ -79,5 +82,9 @@ public class MongoStoragePluginConfig extends StoragePluginConfig {
 
   public String getConnection() {
     return connection;
+  }
+
+  private static CredentialsProvider getCredentialsProvider(CredentialsProvider credentialsProvider) {
+    return credentialsProvider != null ? credentialsProvider : PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER;
   }
 }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestBase.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestBase.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.mongo;
 
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.junit.AfterClass;
@@ -37,7 +38,8 @@ public class MongoTestBase extends ClusterTest implements MongoTestConstants {
   }
 
   private static void initMongoStoragePlugin(String connectionURI) throws Exception {
-    MongoStoragePluginConfig storagePluginConfig = new MongoStoragePluginConfig(connectionURI);
+    MongoStoragePluginConfig storagePluginConfig = new MongoStoragePluginConfig(connectionURI,
+        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     storagePluginConfig.setEnabled(true);
     pluginRegistry.put(MongoStoragePluginConfig.NAME, storagePluginConfig);
 

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoStoragePluginUsesCredentialsStore.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoStoragePluginUsesCredentialsStore.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.mongo;
 import com.mongodb.MongoCredential;
 import org.apache.drill.categories.MongoStorageTest;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,8 +33,9 @@ import static org.junit.Assert.assertEquals;
 public class TestMongoStoragePluginUsesCredentialsStore extends BaseTest {
 
   private void test(String expectedUserName, String expectedPassword, String connection, String name) throws ExecutionSetupException {
-    MongoStoragePlugin plugin = new MongoStoragePlugin(new MongoStoragePluginConfig(
-      connection), null, name);
+    MongoStoragePlugin plugin = new MongoStoragePlugin(
+        new MongoStoragePluginConfig(connection, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER),
+        null, name);
     List<MongoCredential> creds = plugin.getClient().getCredentialsList();
     if (expectedUserName == null) {
       assertEquals(0, creds.size());

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/OpenTSDBStoragePluginConfig.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/OpenTSDBStoragePluginConfig.java
@@ -21,14 +21,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.StoragePluginConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 
 @JsonTypeName(OpenTSDBStoragePluginConfig.NAME)
-public class OpenTSDBStoragePluginConfig extends StoragePluginConfigBase {
+public class OpenTSDBStoragePluginConfig extends StoragePluginConfig {
 
   private static final Logger logger = LoggerFactory.getLogger(OpenTSDBStoragePluginConfig.class);
 

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
@@ -26,6 +26,7 @@ import com.splunk.SSLSecurityProtocol;
 import com.splunk.Service;
 import com.splunk.ServiceArgs;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,15 +37,13 @@ public class SplunkConnection {
 
   private static final Logger logger = LoggerFactory.getLogger(SplunkConnection.class);
 
-  private final String username;
-  private final String password;
+  private final UsernamePasswordCredentials credentials;
   private final String hostname;
   private final int port;
   private Service service;
 
   public SplunkConnection(SplunkPluginConfig config) {
-    this.username = config.getUsername();
-    this.password = config.getPassword();
+    this.credentials = config.getUsernamePasswordCredentials();
     this.hostname = config.getHostname();
     this.port = config.getPort();
     service = connect();
@@ -53,12 +52,9 @@ public class SplunkConnection {
 
   /**
    * This constructor is used for testing only
-   * @param config
-   * @param service
    */
   public SplunkConnection(SplunkPluginConfig config, Service service) {
-    this.username = config.getUsername();
-    this.password = config.getPassword();
+    this.credentials = config.getUsernamePasswordCredentials();
     this.hostname = config.getHostname();
     this.port = config.getPort();
     this.service = service;
@@ -73,8 +69,8 @@ public class SplunkConnection {
     ServiceArgs loginArgs = new ServiceArgs();
     loginArgs.setHost(hostname);
     loginArgs.setPort(port);
-    loginArgs.setPassword(password);
-    loginArgs.setUsername(username);
+    loginArgs.setPassword(credentials.getPassword());
+    loginArgs.setUsername(credentials.getUsername());
 
     try {
       service = Service.connect(loginArgs);

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkConnectionTest.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkConnectionTest.java
@@ -48,7 +48,8 @@ public class SplunkConnectionTest extends SplunkBaseTest {
               SPLUNK_STORAGE_PLUGIN_CONFIG.getHostname(),
               SPLUNK_STORAGE_PLUGIN_CONFIG.getPort(),
               SPLUNK_STORAGE_PLUGIN_CONFIG.getEarliestTime(),
-              SPLUNK_STORAGE_PLUGIN_CONFIG.getLatestTime()
+              SPLUNK_STORAGE_PLUGIN_CONFIG.getLatestTime(),
+              null
       );
       SplunkConnection sc = new SplunkConnection(invalidSplunkConfig);
       sc.connect();

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -71,7 +71,7 @@ public class SplunkTestSuite extends ClusterTest {
         String hostname = splunk.getHost();
         Integer port = splunk.getFirstMappedPort();
         StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
-        SPLUNK_STORAGE_PLUGIN_CONFIG = new SplunkPluginConfig(SPLUNK_LOGIN, SPLUNK_PASS, hostname, port, "1", "now");
+        SPLUNK_STORAGE_PLUGIN_CONFIG = new SplunkPluginConfig(SPLUNK_LOGIN, SPLUNK_PASS, hostname, port, "1", "now", null);
         SPLUNK_STORAGE_PLUGIN_CONFIG.setEnabled(true);
         pluginRegistry.put(SplunkPluginConfig.NAME, SPLUNK_STORAGE_PLUGIN_CONFIG);
         runningSuite = true;

--- a/docs/dev/PluginCredentialsProvider.md
+++ b/docs/dev/PluginCredentialsProvider.md
@@ -1,0 +1,164 @@
+# Plugin credentials provider
+
+Drill provides a variety of ways for specifying credentials for storage plugins.
+Though all storage plugin credentials may be stored in Zookeeper, it may be unsafe to specify them directly in the plugin configs.
+
+Here is the example for specifying storage plugin credentials directly:
+```json
+{
+  "type": "jdbc",
+  "driver": "xxx.Driver",
+  "url": "jdbc:xxx:xxx",
+  "username": "xxx",
+  "password": "xxx"
+}
+```
+
+Drill provides `credentialsProvider` property for specifying desired credential provider type and its configs
+instead of holding raw credentials in storage plugin configs.
+
+## Using credentials from Hadoop Configuration
+
+One of the implementations for credentials provider is `HadoopCredentialsProvider` that allows using Hadoop 
+Configuration property values as credentials.
+To use it, `credentialsProviderType` property should be set to `HadoopCredentialsProvider`:
+```json
+{
+  "type": "jdbc",
+  "driver": "xxx.Driver",
+  "url": "jdbc:xxx:xxx",
+  "credentialsProvider": {
+    "credentialsProviderType": "HadoopCredentialsProvider",
+    "propertyNames": {
+      "username": "hadoop.user.property",
+      "password": "hadoop.password.property"
+    }
+  }
+}
+```
+
+`propertyNames` map contains keys that specify which credential will be obtained from the Hadoop Configuration 
+property with the name of the `propertyNames` value.
+
+For example, user may create in drill config directory `core-site.xml` config file with the following content:
+```xml
+<configuration>
+
+    <property>
+        <name>hadoop.user.property</name>
+        <value>user1</value>
+    </property>
+
+    <property>
+        <name>hadoop.password.property</name>
+        <value>user1Pass</value>
+    </property>
+
+</configuration>
+```
+
+In this case, the storage `jdbc` plugin will use `user1` value as the `username` and `user1Pass` value as its `password`.
+
+## Using credentials from Environment Variables
+
+`EnvCredentialsProvider` credentials provider implementation allows using Environment Variable values as plugin credentials.
+This way for specifying credentials is consistent with the Kubernetes world, where different user secrets and configmaps may be exposed as environment variables to be used by a container.
+
+To use it, `credentialsProviderType` property should be set to `EnvCredentialsProvider`:
+```json
+{
+  "type": "jdbc",
+  "driver": "xxx.Driver",
+  "url": "jdbc:xxx:xxx",
+  "credentialsProvider": {
+    "credentialsProviderType": "EnvCredentialsProvider",
+    "envVariableNames": {
+      "username": "USER_NAME",
+      "password": "USER_PASSWORD"
+    }
+  }
+}
+```
+
+`propertyNames` map contains keys that specify which credential will be obtained from the Environment Variable
+value with the name of the `propertyNames` value.
+
+For example, user may export the following variables:
+```shell
+export USER_NAME='user1'
+export USER_PASSWORD='user1Pass'
+```
+
+In this case, the storage `jdbc` plugin will use `user1` value as the `username` and `user1Pass` value as its `password`.
+
+## Using credentials managed by Vault
+
+`VaultCredentialsProvider` credentials provider implementation allows using Vault secrets as plugin credentials.
+
+Before using this credential provider, the following Drill properties should be configured in `drill-override.conf`:
+```
+"drill.exec.storage.vault.address" - address of the Vault server
+"drill.exec.storage.vault.token" - token used to access Vault
+```
+
+Once it is set, we can configure storage plugin to use this way of obtaining credentials:
+```json
+{
+  "type": "jdbc",
+  "driver": "xxx.Driver",
+  "url": "jdbc:xxx:xxx",
+  "credentialsProvider": {
+    "credentialsProviderType": "VaultCredentialsProvider",
+    "secretPath": "secret/jdbc",
+    "propertyNames": {
+      "username": "usernameSecret",
+      "password": "passwordSecret"
+    }
+  }
+}
+```
+
+`secretPath` property specifies the Vault key value from which to read
+`propertyNames` map contains keys that specify which credential will be obtained from the Vault secret with the secret name of the `propertyNames` value.
+
+For example, user may store the following secrets in the Vault:
+```shell
+vault kv put secret/jdbc usernameSecret=muser passwordSecret=mpassword
+```
+
+In this case, the storage `jdbc` plugin will use `user1` value as the `username` and `user1Pass` value as its `password`.
+
+## Specifying credentials inlined using credentials provider
+
+To be consistent with credentials providers implementations, Drill provides a new way of specifying credentials directly in storage plugin config:
+```json
+{
+  "type": "jdbc",
+  "driver": "xxx.Driver",
+  "url": "jdbc:xxx:xxx",
+  "credentialsProvider": {
+    "credentialsProviderType": "PlainCredentialsProvider",
+    "credentials": {
+      "username": "user1",
+      "password": "user1Pass"
+    }
+  }
+}
+```
+
+This way of specifying credentials directly should be used instead of the old one since it groups credentials and
+makes it easier to replace `PlainCredentialsProvider` with a more secured alternative.
+
+# Developer notes
+
+`CredentialsProvider` is a base interface for all credential provider implementations.
+Users may create and use their own credential provider implementations without changing Drill code.
+To achieve that, just add dependency on the `drill-logical` jar (where `CredentialsProvider` interface is placed),
+create own implementation of this interface, and create `drill-module.conf` file that will add implementation class 
+to Drill classpath scanning, for example if the class will have the following full name: `foo.bar.package.ExampleCredentialsProvider`,
+`drill-module.conf` content should be the following:
+```
+drill.classpath.scanning: {
+  packages += "foo.bar.package"
+}
+```

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -312,6 +312,11 @@
       <version>1.30</version>
     </dependency>
     <dependency>
+      <groupId>com.bettercloud</groupId>
+      <artifactId>vault-java-driver</artifactId>
+      <version>5.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
     </dependency>
@@ -620,6 +625,12 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>vault</artifactId>
+      <version>1.15.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PhysicalPlanReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PhysicalPlanReader.java
@@ -76,6 +76,7 @@ public class PhysicalPlanReader {
     lpMapper.registerSubtypes(DynamicPojoRecordReader.class);
     InjectableValues injectables = new InjectableValues.Std()
         .addValue(StoragePluginRegistry.class, pluginRegistry)
+        .addValue(DrillConfig.class, config)
         .addValue(DrillbitEndpoint.class, endpoint);
 
     this.mapper = lpMapper;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -245,7 +245,7 @@ public class StorageResources {
       storage.putJson(name, storagePluginConfig);
       return message("Success");
     } catch (PluginEncodingException e) {
-      logger.debug("Error in JSON mapping: {}", storagePluginConfig, e);
+      logger.warn("Error in JSON mapping: {}", storagePluginConfig, e);
       return message("Invalid JSON");
     } catch (PluginException e) {
       return message(e.getMessage());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -33,6 +33,7 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
@@ -89,6 +90,10 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
       fsConf.set(FileSystem.FS_DEFAULT_NAME_KEY, config.getConnection());
       fsConf.set("fs.classpath.impl", ClassPathFileSystem.class.getName());
       fsConf.set("fs.drill-local.impl", LocalSyncableFileSystem.class.getName());
+      CredentialsProvider credentialsProvider = config.getCredentialsProvider();
+      if (credentialsProvider != null) {
+        credentialsProvider.getCredentials().forEach(fsConf::set);
+      }
 
       addCodecs(fsConf);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.security;
+
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+
+public class CredentialProviderUtils {
+
+  /**
+   * Returns specified {@code CredentialsProvider credentialsProvider}
+   * if it is not null or builds and returns {@link PlainCredentialsProvider}
+   * with specified {@code USERNAME} and {@code PASSWORD}.
+   */
+  public static CredentialsProvider getCredentialsProvider(
+      String username, String password,
+      CredentialsProvider credentialsProvider) {
+    if (credentialsProvider != null) {
+      return credentialsProvider;
+    }
+    ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
+    if (username != null) {
+      mapBuilder.put(UsernamePasswordCredentials.USERNAME, username);
+    }
+    if (password != null) {
+      mapBuilder.put(UsernamePasswordCredentials.PASSWORD, password);
+    }
+    return new PlainCredentialsProvider(mapBuilder.build());
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/HadoopCredentialsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/HadoopCredentialsProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Implementation of {@link CredentialsProvider} that obtains credential values from
+ * {@link Configuration} properties.
+ * <p>
+ * Its constructor accepts a map with credential names as keys and property names as values.
+ */
+public class HadoopCredentialsProvider implements CredentialsProvider {
+  private final Configuration configuration;
+  private final Map<String, String> propertyNames;
+
+  public HadoopCredentialsProvider(Configuration configuration, Map<String, String> propertyNames) {
+    this.configuration = configuration;
+    this.propertyNames = propertyNames;
+  }
+
+  @JsonCreator
+  public HadoopCredentialsProvider(@JsonProperty("propertyNames") Map<String, String> propertyNames) {
+    this.configuration = new Configuration();
+    this.propertyNames = propertyNames;
+  }
+
+  @Override
+  public Map<String, String> getCredentials() {
+    Map<String, String> credentials = new HashMap<>();
+    propertyNames.forEach((key, value) -> {
+      try {
+        char[] credValue = configuration.getPassword(value);
+        if (credValue != null) {
+          credentials.put(key, new String(credValue));
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Error while fetching credentials from configuration", e);
+      }
+    });
+
+    return credentials;
+  }
+
+  public Map<String, String> getPropertyNames() {
+    return propertyNames;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HadoopCredentialsProvider that = (HadoopCredentialsProvider) o;
+    return Objects.equals(propertyNames, that.propertyNames);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(propertyNames);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordCredentials.java
@@ -15,7 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.common.logical;
+package org.apache.drill.exec.store.security;
 
-public abstract class StoragePluginConfigBase extends StoragePluginConfig {
+import org.apache.drill.common.logical.security.CredentialsProvider;
+
+import java.util.Map;
+
+public class UsernamePasswordCredentials {
+  public static final String USERNAME = "username";
+  public static final String PASSWORD = "password";
+
+  private final String username;
+  private final String password;
+
+  public UsernamePasswordCredentials(CredentialsProvider credentialsProvider) {
+    Map<String, String> credentials = credentialsProvider.getCredentials();
+    this.username = credentials.get(USERNAME);
+    this.password = credentials.get(PASSWORD);
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/vault/VaultCredentialsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/vault/VaultCredentialsProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.security.vault;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.OptBoolean;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Implementation of {@link CredentialsProvider} that obtains credential values from
+ * {@link Vault}.
+ */
+public class VaultCredentialsProvider implements CredentialsProvider {
+
+  public static final String VAULT_ADDRESS = "drill.exec.storage.vault.address";
+  public static final String VAULT_TOKEN = "drill.exec.storage.vault.token";
+
+  private final String secretPath;
+
+  private final Map<String, String> propertyNames;
+
+  private final Vault vault;
+
+  /**
+   * @param secretPath The Vault key value from which to read
+   * @param propertyNames map with credential names as keys and vault keys as values.
+   * @param config drill config
+   * @throws VaultException if exception happens when connecting to Vault.
+   */
+  @JsonCreator
+  public VaultCredentialsProvider(
+      @JsonProperty("secretPath") String secretPath,
+      @JsonProperty("propertyNames") Map<String, String> propertyNames,
+      @JacksonInject(useInput = OptBoolean.FALSE) DrillConfig config) throws VaultException {
+    this.propertyNames = propertyNames;
+    this.secretPath = secretPath;
+    String vaultAddress = Objects.requireNonNull(config.getString(VAULT_ADDRESS),
+        String.format("Vault address is not specified. Please set [%s] config property.", VAULT_ADDRESS));
+    String token = Objects.requireNonNull(config.getString(VAULT_TOKEN),
+        String.format("Vault token is not specified. Please set [%s] config property.", VAULT_TOKEN));
+
+    VaultConfig vaultConfig = new VaultConfig()
+        .address(vaultAddress)
+        .token(token)
+        .build();
+    this.vault = new Vault(vaultConfig);
+  }
+
+  @Override
+  public Map<String, String> getCredentials() {
+    Map<String, String> credentials = new HashMap<>();
+    propertyNames.forEach((key, value) -> {
+      try {
+        String credValue = vault.logical()
+            .read(secretPath)
+            .getData()
+            .get(value);
+        credentials.put(key, credValue);
+      } catch (VaultException e) {
+        throw new RuntimeException("Error while fetching credentials from vault", e);
+      }
+    });
+
+    return credentials;
+  }
+
+  public String getSecretPath() {
+    return secretPath;
+  }
+
+  public Map<String, String> getPropertyNames() {
+    return propertyNames;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    VaultCredentialsProvider that = (VaultCredentialsProvider) o;
+    return Objects.equals(secretPath, that.secretPath) && Objects.equals(propertyNames, that.propertyNames);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(secretPath, propertyNames);
+  }
+}

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -48,7 +48,8 @@ drill {
       org.apache.drill.exec.rpc.user.security,
       org.apache.drill.exec.rpc.security,
       org.apache.drill.exec.server.rest.auth,
-      org.apache.drill.exec.coord.zk
+      org.apache.drill.exec.coord.zk,
+      org.apache.drill.exec.store.security
     ],
 
     # caches scanned result during build time

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/BaseTestImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/BaseTestImpersonation.java
@@ -130,7 +130,8 @@ public class BaseTestImpersonation extends PlanTestBase {
     String connection = dfsConf.get(FileSystem.FS_DEFAULT_NAME_KEY);
     createAndAddWorkspace("tmp", "/tmp", (short) 0777, processUser, processUser, workspaces);
 
-    FileSystemConfig miniDfsPluginConfig = new FileSystemConfig(connection, null, workspaces, lfsPluginConfig.getFormats());
+    FileSystemConfig miniDfsPluginConfig = new FileSystemConfig(connection, null,
+        workspaces, lfsPluginConfig.getFormats(), null);
     miniDfsPluginConfig.setEnabled(true);
     pluginRegistry.put(MINI_DFS_STORAGE_PLUGIN_NAME, miniDfsPluginConfig);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
@@ -33,6 +33,7 @@ import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.dfs.WorkspaceConfig;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
@@ -65,7 +66,8 @@ public class TestCTTAS extends BaseTestQuery {
         pluginConfig.getConnection(),
         pluginConfig.getConfig(),
         newWorkspaces,
-        pluginConfig.getFormats());
+        pluginConfig.getFormats(),
+        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     newPluginConfig.setEnabled(pluginConfig.isEnabled());
     pluginRegistry.put(DFS_PLUGIN_NAME, newPluginConfig);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
@@ -458,7 +458,6 @@ public class TestInfoSchema extends BaseTestQuery {
 
     // check some stable properties existence
     assertTrue(configMap.containsKey("connection"));
-    assertTrue(configMap.containsKey("config"));
     assertTrue(configMap.containsKey("formats"));
     assertFalse(configMap.containsKey("workspaces"));
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/BasePluginRegistryTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/BasePluginRegistryTest.java
@@ -51,7 +51,7 @@ public class BasePluginRegistryTest extends BaseTest {
 
   protected static final String RESOURCE_BASE = "plugins/";
 
-  protected class PluginRegistryContextFixture implements PluginRegistryContext {
+  protected static class PluginRegistryContextFixture implements PluginRegistryContext {
 
     private final DrillConfig drillConfig;
     private final ScanResult classpathScan;
@@ -171,7 +171,7 @@ public class BasePluginRegistryTest extends BaseTest {
     public void init() { }
 
     @Override
-    public StoragePlugins bootstrapPlugins() throws IOException {
+    public StoragePlugins bootstrapPlugins() {
       return null;
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestClassicLocator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestClassicLocator.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.apache.drill.common.logical.StoragePluginConfig;
-import org.apache.drill.common.logical.StoragePluginConfigBase;
+import org.apache.drill.common.logical.AbstractSecuredStoragePluginConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.logical.StoragePlugins;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
@@ -63,7 +63,7 @@ public class TestClassicLocator extends BasePluginRegistryTest {
 
       // Abstract classes do not appear
       assertFalse(result.contains(StoragePluginConfig.class));
-      assertFalse(result.contains(StoragePluginConfigBase.class));
+      assertFalse(result.contains(AbstractSecuredStoragePluginConfig.class));
 
       // The private plugin class does not appear
       assertFalse(result.contains(StoragePluginFixtureConfig.class));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestPluginRegistry.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestPluginRegistry.java
@@ -43,6 +43,7 @@ import org.apache.drill.exec.store.StoragePluginRegistry.PluginFilter;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.dfs.FileSystemPlugin;
 import org.apache.drill.exec.store.easy.text.TextFormatPlugin.TextFormatConfig;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.ClusterFixture;
@@ -83,7 +84,8 @@ public class TestPluginRegistry extends BaseTest {
 
   private FileSystemConfig myConfig1() {
     FileSystemConfig config = new FileSystemConfig("myConn",
-        new HashMap<>(), new HashMap<>(), new HashMap<>());
+        new HashMap<>(), new HashMap<>(), new HashMap<>(),
+        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     config.setEnabled(true);
     return config;
   }
@@ -92,7 +94,8 @@ public class TestPluginRegistry extends BaseTest {
     Map<String, String> props = new HashMap<>();
     props.put("foo", "bar");
     FileSystemConfig config = new FileSystemConfig("myConn",
-        props, new HashMap<>(), new HashMap<>());
+        props, new HashMap<>(), new HashMap<>(),
+        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     config.setEnabled(true);
     return config;
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -76,7 +77,8 @@ public class StoragePluginTestUtils {
         pluginConfig.getConnection(),
         pluginConfig.getConfig(),
         newWorkspaces,
-        pluginConfig.getFormats());
+        pluginConfig.getFormats(),
+        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     newPluginConfig.setEnabled(pluginConfig.isEnabled());
     pluginRegistry.put(pluginName, newPluginConfig);
   }
@@ -112,7 +114,8 @@ public class StoragePluginTestUtils {
         fileSystemConfig.getConnection(),
         fileSystemConfig.getConfig(),
         fileSystemConfig.getWorkspaces(),
-        newFormats);
+        newFormats,
+        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     newFileSystemConfig.setEnabled(fileSystemConfig.isEnabled());
 
     pluginRegistry.put(storagePlugin, newFileSystemConfig);

--- a/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderImplementationsTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderImplementationsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.storage;
+
+import com.bettercloud.vault.VaultException;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.exec.store.security.EnvCredentialsProvider;
+import org.apache.drill.exec.store.security.HadoopCredentialsProvider;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
+import org.apache.drill.exec.store.security.vault.VaultCredentialsProvider;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.vault.VaultContainer;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class CredentialsProviderImplementationsTest extends ClusterTest {
+
+  private static final String VAULT_TOKEN_VALUE = "vault-token";
+
+  private static final String SECRET_PATH = "secret/testing";
+
+  @ClassRule
+  public static final VaultContainer<?> vaultContainer =
+      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.1.3"))
+          .withVaultToken(VAULT_TOKEN_VALUE)
+          .withVaultPort(8200)
+          .withSecretInVault(SECRET_PATH,
+              "top_secret=password1",
+              "db_password=dbpassword1");
+
+  @BeforeClass
+  public static void init() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher)
+        .configProperty(VaultCredentialsProvider.VAULT_ADDRESS, "http://" + vaultContainer.getHost() + ":" + vaultContainer.getMappedPort(8200))
+    .configProperty(VaultCredentialsProvider.VAULT_TOKEN, VAULT_TOKEN_VALUE));
+  }
+
+  @Test
+  public void testEnvCredentialsProvider() {
+    String variableName = "USER";
+    String expectedValue = System.getenv(variableName);
+
+    CredentialsProvider envCredentialsProvider = new EnvCredentialsProvider(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, variableName));
+
+    Map<String, String> actualCredentials = envCredentialsProvider.getCredentials();
+
+    assertEquals(Collections.singletonMap(UsernamePasswordCredentials.USERNAME, expectedValue),
+        actualCredentials);
+  }
+
+  @Test
+  public void testHadoopCredentialsProvider() {
+    Configuration configuration = new Configuration();
+    String expectedUsernameValue = "user1";
+    String expectedPassValue = "pass123!@#";
+    String usernamePropertyName = "username_key";
+    String passwordPropertyName = "password_key";
+    configuration.set(usernamePropertyName, expectedUsernameValue);
+    configuration.set(passwordPropertyName, expectedPassValue);
+
+    CredentialsProvider envCredentialsProvider = new HadoopCredentialsProvider(configuration,
+        ImmutableMap.of(
+            UsernamePasswordCredentials.USERNAME, usernamePropertyName,
+            UsernamePasswordCredentials.PASSWORD, passwordPropertyName));
+
+    Map<String, String> actualCredentials = envCredentialsProvider.getCredentials();
+
+    assertEquals(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, expectedUsernameValue,
+        UsernamePasswordCredentials.PASSWORD, expectedPassValue),
+        actualCredentials);
+  }
+
+  @Test
+  public void testVaultCredentialsProvider() throws VaultException {
+    DrillConfig config = cluster.drillbit().getContext().getConfig();
+
+    CredentialsProvider envCredentialsProvider = new VaultCredentialsProvider(
+        SECRET_PATH,
+        ImmutableMap.of(UsernamePasswordCredentials.USERNAME, "top_secret",
+            UsernamePasswordCredentials.PASSWORD, "db_password"),
+        config);
+
+    Map<String, String> actualCredentials = envCredentialsProvider.getCredentials();
+
+    assertEquals(ImmutableMap.of(UsernamePasswordCredentials.USERNAME, "password1",
+        UsernamePasswordCredentials.PASSWORD, "dbpassword1"),
+        actualCredentials);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderSerDeTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderSerDeTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.storage;
+
+import com.bettercloud.vault.VaultException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.exec.store.security.EnvCredentialsProvider;
+import org.apache.drill.exec.store.security.HadoopCredentialsProvider;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
+import org.apache.drill.exec.store.security.vault.VaultCredentialsProvider;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.vault.VaultContainer;
+
+import static org.junit.Assert.assertEquals;
+
+public class CredentialsProviderSerDeTest extends ClusterTest {
+
+  private static final String VAULT_TOKEN_VALUE = "vault-token";
+
+  private static final String SECRET_PATH = "secret/testing";
+
+  @ClassRule
+  public static final VaultContainer<?> vaultContainer =
+      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.1.3"))
+          .withVaultToken(VAULT_TOKEN_VALUE)
+          .withVaultPort(8200)
+          .withSecretInVault(SECRET_PATH,
+              "top_secret=password1",
+              "db_password=dbpassword1");
+
+  @BeforeClass
+  public static void init() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher)
+        .configProperty(VaultCredentialsProvider.VAULT_ADDRESS, "http://" + vaultContainer.getHost() + ":" + vaultContainer.getMappedPort(8200))
+        .configProperty(VaultCredentialsProvider.VAULT_TOKEN, VAULT_TOKEN_VALUE));
+  }
+
+  @Test
+  public void testEnvCredentialsProviderSerDe() throws JsonProcessingException {
+    ObjectMapper mapper = cluster.drillbit().getContext().getLpPersistence().getMapper();
+
+    CredentialsProvider envCredentialsProvider = new EnvCredentialsProvider(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, "myLoginVar",
+        UsernamePasswordCredentials.PASSWORD, "myPassVar"));
+
+    String serialized = mapper.writerFor(CredentialsProvider.class).writeValueAsString(envCredentialsProvider);
+
+    String expected =
+        "{\n" +
+        "  \"credentialsProviderType\" : \"EnvCredentialsProvider\",\n" +
+        "  \"envVariables\" : {\n" +
+        "    \"username\" : \"myLoginVar\",\n" +
+        "    \"password\" : \"myPassVar\"\n" +
+        "  }\n" +
+        "}";
+
+    assertEquals(expected, serialized);
+
+    CredentialsProvider deserialized = mapper.readerFor(CredentialsProvider.class).readValue(serialized);
+
+    assertEquals(envCredentialsProvider, deserialized);
+  }
+
+  @Test
+  public void testPlainCredentialsProviderSerDe() throws JsonProcessingException {
+    ObjectMapper mapper = cluster.drillbit().getContext().getLpPersistence().getMapper();
+
+    CredentialsProvider credentialsProvider = new PlainCredentialsProvider(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, "myLogin",
+        UsernamePasswordCredentials.PASSWORD, "myPass"));
+
+    String serialized = mapper.writerFor(CredentialsProvider.class).writeValueAsString(credentialsProvider);
+
+    String expected =
+        "{\n" +
+        "  \"credentialsProviderType\" : \"PlainCredentialsProvider\",\n" +
+        "  \"credentials\" : {\n" +
+        "    \"username\" : \"myLogin\",\n" +
+        "    \"password\" : \"myPass\"\n" +
+        "  }\n" +
+        "}";
+
+    assertEquals(expected, serialized);
+
+    CredentialsProvider deserialized = mapper.readerFor(CredentialsProvider.class).readValue(serialized);
+
+    assertEquals(credentialsProvider, deserialized);
+  }
+
+  @Test
+  public void testPlainCredentialsProviderWithNoType() throws JsonProcessingException {
+    ObjectMapper mapper = cluster.drillbit().getContext().getLpPersistence().getMapper();
+
+    CredentialsProvider expected = new PlainCredentialsProvider(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, "myLogin",
+        UsernamePasswordCredentials.PASSWORD, "myPass"));
+
+    String serialized =
+        "{\n" +
+        "  \"credentials\" : {\n" +
+        "    \"username\" : \"myLogin\",\n" +
+        "    \"password\" : \"myPass\"\n" +
+        "  }\n" +
+        "}";
+
+    CredentialsProvider deserialized = mapper.readerFor(CredentialsProvider.class).readValue(serialized);
+
+    assertEquals(expected, deserialized);
+  }
+
+  @Test
+  public void testHadoopCredentialsProviderSerDe() throws JsonProcessingException {
+    ObjectMapper mapper = cluster.drillbit().getContext().getLpPersistence().getMapper();
+
+    CredentialsProvider credentialsProvider = new HadoopCredentialsProvider(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, "myLoginProp",
+        UsernamePasswordCredentials.PASSWORD, "myPassProp"));
+
+    String serialized = mapper.writerFor(CredentialsProvider.class).writeValueAsString(credentialsProvider);
+
+    String expected =
+        "{\n" +
+        "  \"credentialsProviderType\" : \"HadoopCredentialsProvider\",\n" +
+        "  \"propertyNames\" : {\n" +
+        "    \"username\" : \"myLoginProp\",\n" +
+        "    \"password\" : \"myPassProp\"\n" +
+        "  }\n" +
+        "}";
+
+    assertEquals(expected, serialized);
+
+    CredentialsProvider deserialized = mapper.readerFor(CredentialsProvider.class).readValue(serialized);
+
+    assertEquals(credentialsProvider, deserialized);
+  }
+
+  @Test
+  public void testVaultCredentialsProviderSerDe() throws JsonProcessingException, VaultException {
+    ObjectMapper mapper = cluster.drillbit().getContext().getLpPersistence().getMapper();
+
+    DrillConfig config = cluster.drillbit().getContext().getConfig();
+
+    CredentialsProvider credentialsProvider = new VaultCredentialsProvider(SECRET_PATH, ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, "myLoginProp",
+        UsernamePasswordCredentials.PASSWORD, "myPassProp"),
+        config);
+
+    String serialized = mapper.writerFor(CredentialsProvider.class).writeValueAsString(credentialsProvider);
+
+    String expected =
+        "{\n" +
+        "  \"credentialsProviderType\" : \"VaultCredentialsProvider\",\n" +
+        "  \"secretPath\" : \"secret/testing\",\n" +
+        "  \"propertyNames\" : {\n" +
+        "    \"username\" : \"myLoginProp\",\n" +
+        "    \"password\" : \"myPassProp\"\n" +
+        "  }\n" +
+        "}";
+
+    assertEquals(expected, serialized);
+
+    CredentialsProvider deserialized = mapper.readerFor(CredentialsProvider.class).readValue(serialized);
+
+    assertEquals(credentialsProvider, deserialized);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -57,6 +57,7 @@ import org.apache.drill.exec.store.StoragePluginRegistryImpl;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.dfs.WorkspaceConfig;
 import org.apache.drill.exec.store.mock.MockStorageEngineConfig;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.exec.store.sys.store.provider.ZookeeperPersistentStoreProvider;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
@@ -558,7 +559,8 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
       pluginConfig.getConnection(),
       pluginConfig.getConfig(),
       newWorkspaces == null ? pluginConfig.getWorkspaces() : newWorkspaces,
-      newFormats == null ? pluginConfig.getFormats() : newFormats);
+      newFormats == null ? pluginConfig.getFormats() : newFormats,
+      PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     newPluginConfig.setEnabled(pluginConfig.isEnabled());
 
     pluginRegistry.put(pluginName, newPluginConfig);

--- a/exec/vector/pom.xml
+++ b/exec/vector/pom.xml
@@ -58,6 +58,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringHashMap.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringHashMap.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 /*
  * Simple class that extends the regular java.util.HashMap but overrides the
@@ -30,12 +31,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JsonStringHashMap<K, V> extends LinkedHashMap<K, V> {
 
-  private static ObjectMapper mapper;
-
-  static {
-    mapper = new ObjectMapper();
-    mapper.registerModule(SerializationModule.getModule());
-  }
+  private static final ObjectMapper mapper = new ObjectMapper()
+      .registerModule(SerializationModule.getModule())
+      .registerModule(new JodaModule());
 
   @Override
   public boolean equals(Object obj) {

--- a/logical/src/main/java/org/apache/drill/common/config/LogicalPlanPersistence.java
+++ b/logical/src/main/java/org/apache/drill/common/config/LogicalPlanPersistence.java
@@ -19,6 +19,7 @@ package org.apache.drill.common.config;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
@@ -26,6 +27,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.common.logical.data.LogicalOperator;
 import org.apache.drill.common.scanner.persistence.ScanResult;
+import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +58,10 @@ public class LogicalPlanPersistence {
         .addDeserializer(LogicalExpression.class, new LogicalExpression.De(conf))
         .addDeserializer(SchemaPath.class, new SchemaPath.De());
 
+    InjectableValues injectables = new InjectableValues.Std()
+        .addValue(DrillConfig.class, conf);
+
+    mapper.setInjectableValues(injectables);
     mapper.registerModule(deserModule);
     mapper.enable(SerializationFeature.INDENT_OUTPUT);
     mapper.configure(Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
@@ -68,6 +74,7 @@ public class LogicalPlanPersistence {
     registerSubtypes(getSubTypes(scanResult, StoragePluginConfig.class));
     // For FormatPluginConfigBase
     registerSubtypes(getSubTypes(scanResult, FormatPluginConfig.class));
+    registerSubtypes(getSubTypes(scanResult, CredentialsProvider.class));
   }
 
   public ObjectMapper getMapper() {

--- a/logical/src/main/java/org/apache/drill/common/logical/AbstractSecuredStoragePluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/AbstractSecuredStoragePluginConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.logical;
+
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+
+public abstract class AbstractSecuredStoragePluginConfig extends StoragePluginConfig {
+
+  protected final CredentialsProvider credentialsProvider;
+  protected boolean directCredentials;
+
+  public AbstractSecuredStoragePluginConfig(CredentialsProvider credentialsProvider, boolean directCredentials) {
+    this.credentialsProvider = credentialsProvider;
+    this.directCredentials = directCredentials;
+  }
+
+  public AbstractSecuredStoragePluginConfig() {
+    this.credentialsProvider = PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER;
+    this.directCredentials = true;
+  }
+
+  public CredentialsProvider getCredentialsProvider() {
+    if (directCredentials) {
+      return null;
+    }
+    return credentialsProvider;
+  }
+}

--- a/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
@@ -19,9 +19,11 @@ package org.apache.drill.common.logical;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public abstract class StoragePluginConfig {
 
   // DO NOT include enabled status in equality and hash

--- a/logical/src/main/java/org/apache/drill/common/logical/security/CredentialsProvider.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/security/CredentialsProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.logical.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Map;
+
+/**
+ * Provider of authentication credentials.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+    property = "credentialsProviderType",
+    defaultImpl = PlainCredentialsProvider.class)
+public interface CredentialsProvider {
+  /**
+   * Returns map with authentication credentials. Key is the credential name, for example {@code "username"}
+   * and map value is corresponding credential value.
+   */
+  @JsonIgnore
+  Map<String, String> getCredentials();
+}

--- a/logical/src/main/java/org/apache/drill/common/logical/security/PlainCredentialsProvider.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/security/PlainCredentialsProvider.java
@@ -15,28 +15,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.mock;
-
-import org.apache.drill.common.logical.StoragePluginConfig;
+package org.apache.drill.common.logical.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 
-@JsonTypeName(MockStorageEngineConfig.NAME)
-public class MockStorageEngineConfig extends StoragePluginConfig {
-  public static final String NAME = "mock";
-  public static final MockStorageEngineConfig INSTANCE = new MockStorageEngineConfig("mock:///");
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 
-  private final String url;
+/**
+ * Implementation of {@link CredentialsProvider} that holds credentials provided by user.
+ * <p>
+ * Its constructor accepts a map with credential names as keys and values as corresponding credential values.
+ */
+public class PlainCredentialsProvider implements CredentialsProvider {
+  public static final CredentialsProvider EMPTY_CREDENTIALS_PROVIDER =
+      new PlainCredentialsProvider(Collections.emptyMap());
+
+  private final Map<String, String> credentials;
 
   @JsonCreator
-  public MockStorageEngineConfig(@JsonProperty("url") String url) {
-    this.url = url;
+  public PlainCredentialsProvider(@JsonProperty("credentials") Map<String, String> credentials) {
+    this.credentials = credentials;
   }
 
-  public String getUrl() {
-    return url;
+  @Override
+  @JsonIgnore(false)
+  public Map<String, String> getCredentials() {
+    return credentials;
   }
 
   @Override
@@ -47,18 +55,12 @@ public class MockStorageEngineConfig extends StoragePluginConfig {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    MockStorageEngineConfig that = (MockStorageEngineConfig) o;
-
-    if (url != null ? !url.equals(that.url) : that.url != null) {
-      return false;
-    }
-
-    return true;
+    PlainCredentialsProvider that = (PlainCredentialsProvider) o;
+    return Objects.equals(credentials, that.credentials);
   }
 
   @Override
   public int hashCode() {
-    return url != null ? url.hashCode() : 0;
+    return Objects.hash(credentials);
   }
 }

--- a/metastore/metastore-api/pom.xml
+++ b/metastore/metastore-api/pom.xml
@@ -49,7 +49,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <avatica.version>1.15.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.9.0</sqlline.version>
-    <jackson.version>2.10.3</jackson.version>
+    <jackson.version>2.12.1</jackson.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <mapr.release.version>6.1.0-mapr</mapr.release.version>
     <ojai.version>3.0-mapr-1808</ojai.version>
@@ -1596,6 +1596,11 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-joda</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
# [DRILL-7855](https://issues.apache.org/jira/browse/DRILL-7855): Provide a secure mechanism for specifying storage plugin credentials

## Description
Please see https://github.com/apache/drill/pull/2162/files?short_path=f46bd00#diff-f46bd001ba51b40d94a6988bbcb2e16357e4c423da3b8e681073f9b100aadc55 for a detailed description.

This PR preserves the backward compatibility with the previous versions of Drill unless plugin configuration will use `credentialsProvider` (it is a new field, so older versions cannot handle it).

## Documentation
Docs on the Drill Web site should be added for this feature.

## Testing
Added unit tests, tested locally storage plugins with all credential providers. Will also test providing a custom pluggable credential provider.
