### PR TITLE
DRILL-7841: Need to exclude or shade netty lib to avoid [WARNING]

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -318,6 +318,8 @@
               <exclude>com.beust:*</exclude>
               <exclude>jline:*</exclude>
               <exclude>io.netty:netty:jar:3.7.0.Final</exclude>
+              <exclude>io.netty:netty-transport-native-epoll:*</exclude>
+              <exclude>io.netty:netty-transport-native-unix-common:*</exclude>
               <exclude>org.xerial.snappy:*</exclude>
               <exclude>org.apache.avro:*</exclude>
               <exclude>org.tukaani:*</exclude>


### PR DESCRIPTION
# [DRILL-7841](https://issues.apache.org/jira/browse/DRILL-7841): Need to exclude or shade netty lib to avoid [WARNING]

## Description
Exclude io.netty:netty-transport-native-epoll:* and io.netty:netty-transport-native-unix-common:* from shade plugin in drill-jdbc-all to avoid some build warnings

## Documentation
N/A

## Testing
Relevant errors not present in build, change does not cause additional Maven tests to fail