### PR TITLE
DRILL-7820: Not Supporting Mongo DB Name Capital Letters

### DIFF
--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
@@ -37,19 +37,21 @@ public interface MongoTestConstants {
   String EMPLOYEE_DB = "employee";
   String AUTHENTICATION_DB = "admin";
   String DONUTS_DB = "donuts";
+  String DATATYPE_DB = "datatype";
+  String ISSUE7820_DB = "ISSUE7820"; // capital letters
 
   String DONUTS_COLLECTION = "donuts";
   String EMPINFO_COLLECTION = "empinfo";
   String EMPTY_COLLECTION = "empty";
   String SCHEMA_CHANGE_COLLECTION = "schema_change";
+  String DATATYPE_COLLECTION = "types";
+  String ISSUE7820_COLLECTION = "Issue7820";
 
   String DONUTS_DATA = "donuts.json";
   String EMP_DATA = "emp.json";
   String SCHEMA_CHANGE_DATA = "schema_change_int_to_string.json";
 
   String STORAGE_ENGINE = "wiredTiger";
-  String DATATYPE_DB = "datatype";
-  String DATATYPE_COLLECTION = "types";
   String DATATYPE_DATA = "datatype-oid.json";
 
   String CONFIG_REPLICA_SET = "config_replicas";

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuite.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuite.java
@@ -258,6 +258,7 @@ public class MongoTestSuite extends BaseTest implements MongoTestConstants {
         TestTableGenerator.importData(EMPLOYEE_DB, SCHEMA_CHANGE_COLLECTION, SCHEMA_CHANGE_DATA);
         TestTableGenerator.importData(DONUTS_DB, DONUTS_COLLECTION, DONUTS_DATA);
         TestTableGenerator.importData(DATATYPE_DB, DATATYPE_COLLECTION, DATATYPE_DATA);
+        TestTableGenerator.importData(ISSUE7820_DB, ISSUE7820_COLLECTION, EMP_DATA);
       }
       initCount.incrementAndGet();
     }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoDrillIssue.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoDrillIssue.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.mongo;
+
+import org.apache.drill.categories.MongoStorageTest;
+import org.apache.drill.categories.SlowTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({SlowTest.class, MongoStorageTest.class})
+public class TestMongoDrillIssue extends MongoTestBase {
+
+  // DRILL-7820: Not support database name in capital letters.
+  @Test
+  public void testIssue7820() throws Exception {
+    testBuilder()
+    .sqlQuery("show tables from mongo.ISSUE7820")
+    .unOrdered()
+    .baselineColumns("TABLE_SCHEMA", "TABLE_NAME")
+    .baselineValues("mongo.issue7820", "Issue7820")
+    .go();
+  }
+
+  // Add more test for DRILL-7820
+  @Test
+  public void testIssue7820Select() throws Exception {
+    testBuilder()
+    .sqlQuery("select employee_id, full_name from mongo.ISSUE7820.Issue7820 limit 5 offset 15")
+    .unOrdered()
+    .baselineColumns("employee_id", "full_name")
+    .baselineValues(1116, "Phil Munoz")
+    .baselineValues(1117, "Lori Lightfoot")
+    .baselineValues(1, "Kumar")
+    .baselineValues(2, "Kamesh")
+    .go();
+  }
+}


### PR DESCRIPTION
# [DRILL-7820](https://issues.apache.org/jira/browse/DRILL-7820): Not Supporting Mongo DB Name Capital Letters

## Description
  Mongo database name in capital letters is now supported.
  Used a map to support both schema lookup and `MongoScanSpec` definition.
  1. Schemas in Drill are case insensitive and stored in lower case, See also `SchemaUtilites#searchSchemaTree()`.
  2. Must be using origin database name(non-toLowerCase) to create `MongoScanSpec`.

## Documentation
  There are no changes visible to the user.

## Testing
  1. Ran unit tests associated with the Mongo plugin.
  2. Add the `TestMongoDrillIssue`.
  3. Manual test in real world(Done).
