### PR TITLE
DRILL-7859: Junit test random failure when the numbers of splunk event was insufficient

### DIFF
--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkPluginTest.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkPluginTest.java
@@ -25,14 +25,17 @@ import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@FixMethodOrder(MethodSorters.JVM)
 @Category({SlowTest.class})
 public class SplunkPluginTest extends SplunkBaseTest {
 
@@ -177,7 +180,6 @@ public class SplunkPluginTest extends SplunkBaseTest {
   public void testExplicitFieldsWithOneFieldLimitQuery() throws Exception {
     String sql = "SELECT `component` FROM splunk.`_introspection` ORDER BY `component` LIMIT 2";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
-    results.print();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
       .add("component", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.OPTIONAL)

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -75,6 +75,8 @@ public class SplunkTestSuite extends ClusterTest {
         SPLUNK_STORAGE_PLUGIN_CONFIG.setEnabled(true);
         pluginRegistry.put(SplunkPluginConfig.NAME, SPLUNK_STORAGE_PLUGIN_CONFIG);
         runningSuite = true;
+        logger.info("Take a time to ready more Splunk events (3 sec)...");
+        Thread.sleep(3000);
       }
       initCount.incrementAndGet();
       runningSuite = true;


### PR DESCRIPTION
# [DRILL-7859](https://issues.apache.org/jira/browse/DRILL-7859): Junit test random failure when the numbers of splunk event was insufficient

## Description
  Since the use of `@Ignore` does not prevent the test failure(unless all are ignored), so increase the time to ready more Splunk events.

## Documentation
  There are no changes visible to the user.

## Testing
  1. Ran unit tests associated with the Splunk plugin.
  2. Ran CI more than 6 times without failure(Done).
