### PR TITLE
DRILL-7821: Treat Empty String as NULL in JSON Reader

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
@@ -407,11 +407,16 @@ public class JsonReader extends BaseJsonReader {
     }
   }
 
-  private void handleString(JsonParser parser, MapWriter writer,
-      String fieldName) throws IOException {
-    writer.varChar(fieldName).writeVarChar(0,
-        workingBuffer.prepareVarCharHolder(parser.getText()),
-        workingBuffer.getBuf());
+  private void handleString(JsonParser parser, MapWriter writer, String fieldName) throws IOException {
+    try {
+      writer.varChar(fieldName)
+          .writeVarChar(0, workingBuffer.prepareVarCharHolder(parser.getText()), workingBuffer.getBuf());
+    } catch (IllegalArgumentException e) {
+      if (parser.getText() == null || parser.getText().isEmpty()) {
+        return;
+      }
+      throw e;
+    }
   }
 
   private void handleString(JsonParser parser, ListWriter writer)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
@@ -804,4 +804,60 @@ public class TestJsonReader extends BaseTestQuery {
         .baselineValues("2", "abc")
         .go();
   }
+
+  @Test // DRILL-7821
+  public void testEmptyObjectInference() throws Exception {
+    String fileName = "emptyObject.json";
+
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(dirTestWatcher.getRootDir(), fileName)))) {
+      writer.write("{\"sample\": [{\"data\": {}},{\"data\": \"\"}]}");
+    }
+
+    String sql = "SELECT * from dfs.`%s` t";
+
+    testBuilder()
+        .sqlQuery(sql, fileName)
+        .ordered()
+        .baselineColumns("sample")
+        .baselineValues(
+            listOf(
+                mapOf(
+                    "data", mapOf()
+                ),
+                mapOf(
+                    "data", mapOf()
+                )
+            )
+        )
+        .go();
+  }
+
+  @Test // DRILL-7821
+  public void testFilledObjectInference() throws Exception {
+    String fileName = "filledObject.json";
+
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(dirTestWatcher.getRootDir(), fileName)))) {
+      writer.write("{\"sample\": [{\"data\": {\"foo\": \"bar\"}},{\"data\": \"\"}]}");
+    }
+
+    String sql = "SELECT * from dfs.`%s` t";
+
+    testBuilder()
+        .sqlQuery(sql, fileName)
+        .ordered()
+        .baselineColumns("sample")
+        .baselineValues(
+            listOf(
+                mapOf(
+                    "data", mapOf(
+                        "foo", "bar"
+                    )
+                ),
+                mapOf(
+                    "data", mapOf()
+                )
+            )
+        )
+        .go();
+  }
 }


### PR DESCRIPTION
# [DRILL-7821](https://issues.apache.org/jira/browse/DRILL-7821): Treat Empty String as NULL in JSON Reader

## Description
Added try-catch to handleString() in JsonReader to allow empty string "" to be parsed as empty object {} when object type is inferred from earlier keys, as discussed with @cgivre 

## Documentation
Drill can now handle the scenario described without the use of `exec.enable.union.type=true`, perhaps user documentation should be updated to mention the limitation occurring when "" appears before {}, either a dummy entry must be added to the start of the JSON (so that the correct types are inferred) or the union type must be used

## Testing
Queried sample JSON files to verify new behavior, Maven tests

Edit: Added additional JUnit tests that trigger the new behavior