### PR TITLE
DRILL-7860: Suppress the transfer progress when downloading in CI maven build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Build and test
-        run: mvn install -DdirectMemoryMb=4500 -DmemoryMb=1300
+        run: mvn install -V -ntp -DdirectMemoryMb=4500 -DmemoryMb=1300
 
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs


### PR DESCRIPTION
# [DRILL-7860](https://issues.apache.org/jira/browse/DRILL-7860): Suppress the transfer progress when downloading in CI maven build

## Description
  For example : 
```
Downloading from jhdf5-repo: https://maven.scijava.org/content/repositories/public/org/apache/hbase/hbase-annotations/2.2.2/hbase-annotations-2.2.2.jar
Downloading from jhdf5-repo: https://maven.scijava.org/content/repositories/public/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar
Downloading from jhdf5-repo: https://maven.scijava.org/content/repositories/public/org/jruby/jcodings/jcodings/1.0.8/jcodings-1.0.8.jar
Downloading from jhdf5-repo: https://maven.scijava.org/content/repositories/public/org/jruby/joni/joni/2.1.2/joni-2.1.2.jar
Progress (1): 4.1/187 kB
Progress (1): 7.7/187 kB
Progress (2): 7.7/187 kB | 0/1.3 MB
Progress (3): 7.7/187 kB | 0/1.3 MB | 4.1/6.8 kB
Progress (3): 7.7/187 kB | 0/1.3 MB | 6.8 kB    
Progress (4): 7.7/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB
Progress (4): 12/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB 
Progress (4): 16/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB
Progress (4): 20/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB
Progress (4): 24/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB
Progress (4): 28/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB
Progress (4): 32/187 kB | 0/1.3 MB | 6.8 kB | 0/1.5 MB
.....
```
  Use an option : 
```
mvn --no-transfer-progress ....
```
See also [Release Notes – Maven 3.6.1](http://maven.apache.org/docs/3.6.1/release-notes.html#user-visible-changes)

## Documentation
  N/A

## Testing
  Check the CI build logs (Done).