### PR TITLE
DRILL-7862: upgrade excel-streaming-reader

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>2.4.0</version>
+      <version>3.0.3</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
# [DRILL-7862](https://issues.apache.org/jira/browse/DRILL-7862): upgrade excel-streaming-reader

## Description

excel-streaming-reader v3.0.3 adds support for Strict OOXML format and some bug fixes

## Documentation
No changes expected

## Testing
CI build
