### PR TITLE
Minor Fix: Increase the Splunk ready time to 10 sec

### DIFF
--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -75,8 +75,8 @@ public class SplunkTestSuite extends ClusterTest {
         SPLUNK_STORAGE_PLUGIN_CONFIG.setEnabled(true);
         pluginRegistry.put(SplunkPluginConfig.NAME, SPLUNK_STORAGE_PLUGIN_CONFIG);
         runningSuite = true;
-        logger.info("Take a time to ready more Splunk events (3 sec)...");
-        Thread.sleep(3000);
+        logger.info("Take a time to ready more Splunk events (10 sec)...");
+        Thread.sleep(10000);
       }
       initCount.incrementAndGet();
       runningSuite = true;


### PR DESCRIPTION
# Minor Fix: Increase the Splunk ready time to 10 sec

## Description

  Due to the 3 seconds was no guarantee that Splunk's Junit test will 100% pass, So increase to 10 sec.

## Documentation
  N/A

## Testing
  N/A
