### PR TITLE
DRILL-7866: Provide a helpful message when failure to decode plugin json

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -246,8 +246,9 @@ public class StorageResources {
       return message("Success");
     } catch (PluginEncodingException e) {
       logger.warn("Error in JSON mapping: {}", storagePluginConfig, e);
-      return message("Invalid JSON");
+      return message("Invalid JSON: " + e.getMessage());
     } catch (PluginException e) {
+      logger.error("Error while saving plugin", e);
       return message(e.getMessage());
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -49,6 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 /**
  * Plugin registry. Caches plugin instances which correspond to configurations
@@ -510,6 +512,8 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
       return context.mapper().reader()
           .forType(StoragePluginConfig.class)
           .readValue(json);
+    } catch (InvalidTypeIdException | UnrecognizedPropertyException e) {
+      throw new PluginEncodingException(e.getMessage(), e);
     } catch (IOException e) {
       throw new PluginEncodingException("Failure when decoding plugin JSON", e);
     }


### PR DESCRIPTION
# [DRILL-7866](https://issues.apache.org/jira/browse/DRILL-7866): Provide a helpful message when failure to decode plugin json

## Description
This is not helpful message on Web UI when failure to decode plugin json :
```
"Invalid JSON"
```
The PR provide a  user-friendly message in some case :
Case 1 : Missing the required property
```
Please retry: Invalid JSON: missing type id property 'type' at [Source: (String)"{ "driver": "xxx.Driver", "url": "jdbc:xxx:xxx", "enabled": false }"; line: 7, column: 1]
```
Case 2: Not supported the plugin name
```
Please retry: Invalid JSON: known type ids = [InfoSchemaConfig, MockBreakageStorage$MockBreakageStorageEngineConfig, SystemTablePluginConfig, file, mock] at [Source: (String)"{ "type": "ozone", "enabled": false }"; line: 2, column: 11]
```
Case 3: Unknow the parameters
```
Please retry: Invalid JSON: Unrecognized field "test"
```

## Documentation
N/A

## Testing
  1. Manual test on Web UI
