### PR TITLE
DRILL-7867: Allow using required arguments for functions with nullable parameters

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/TypeCastRules.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/TypeCastRules.java
@@ -683,14 +683,16 @@ public class TypeCastRules {
     rules.put(MinorType.DICT, Sets.newHashSet(MinorType.DICT));
   }
 
-  public static boolean isCastableWithNullHandling(MajorType from, MajorType to, NullHandling nullHandling) {
-    if ((from.getMode() == DataMode.REPEATED || to.getMode() == DataMode.REPEATED) && from.getMode() != to.getMode()) {
+  public static boolean isCastableWithNullHandling(MajorType argumentType, MajorType paramType, NullHandling nullHandling) {
+    if ((argumentType.getMode() == DataMode.REPEATED || paramType.getMode() == DataMode.REPEATED) && argumentType.getMode() != paramType.getMode()) {
       return false;
     }
-    if (nullHandling == NullHandling.INTERNAL && from.getMode() != to.getMode()) {
+    // allow using functions with nullable parameters for required arguments only for the case of data mode mismatch
+    if (nullHandling == NullHandling.INTERNAL && argumentType.getMode() != paramType.getMode()
+        && (paramType.getMode() != DataMode.OPTIONAL || argumentType.getMode() != DataMode.REQUIRED)) {
       return false;
     }
-    return isCastable(from.getMinorType(), to.getMinorType());
+    return isCastable(argumentType.getMinorType(), paramType.getMinorType());
   }
 
   public static boolean isCastable(MinorType from, MinorType to) {


### PR DESCRIPTION
# [DRILL-7867](https://issues.apache.org/jira/browse/DRILL-7867): Allow using required arguments for functions with nullable parameters

## Description
Please see the ticket for details

## Documentation
Yes

## Testing
Removed implementation of function with required arguments and nullable one was used.
