### PR TITLE
DRILL-6547: IllegalStateException: Tried to remove unmanaged buffer in concat function

### DIFF
--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/ComplexSchemaFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/ComplexSchemaFunctions.java
@@ -57,7 +57,7 @@ public class ComplexSchemaFunctions {
     @Override
     public void eval() {
       if (reader.isSet()) {
-        org.apache.drill.exec.udfs.ComplexSchemaUtils.getFields(reader, outWriter, outBuffer);
+        outBuffer = org.apache.drill.exec.udfs.ComplexSchemaUtils.getFields(reader, outWriter, outBuffer);
       } else {
         org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter queryMapWriter = outWriter.rootAsMap();
         // Return empty map

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/ComplexSchemaUtils.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/ComplexSchemaUtils.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 
 public class ComplexSchemaUtils {
 
-  public static void getFields(FieldReader reader, BaseWriter.ComplexWriter outWriter, DrillBuf buffer) {
+  public static DrillBuf getFields(FieldReader reader, BaseWriter.ComplexWriter outWriter, DrillBuf buffer) {
 
     BaseWriter.MapWriter queryMapWriter = outWriter.rootAsMap();
 
@@ -54,7 +54,7 @@ public class ComplexSchemaUtils {
 
       VarCharHolder rowHolder = new VarCharHolder();
       byte[] rowStringBytes = dataType.getBytes();
-      buffer.reallocIfNeeded(rowStringBytes.length);
+      buffer = buffer.reallocIfNeeded(rowStringBytes.length);
       buffer.setBytes(0, rowStringBytes);
 
       rowHolder.start = 0;
@@ -64,5 +64,6 @@ public class ComplexSchemaUtils {
       queryMapWriter.varChar(fieldName).write(rowHolder);
     }
     queryMapWriter.end();
+    return buffer;
   }
 }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentFunctions.java
@@ -69,7 +69,7 @@ public class UserAgentFunctions {
         String field = agent.getValue(fieldName);
 
         byte[] rowStringBytes = field.getBytes();
-        outBuffer.reallocIfNeeded(rowStringBytes.length);
+        outBuffer = outBuffer.reallocIfNeeded(rowStringBytes.length);
         outBuffer.setBytes(0, rowStringBytes);
 
         rowHolder.start = 0;
@@ -123,7 +123,7 @@ public class UserAgentFunctions {
         String field = agent.getValue(fieldName);
 
         byte[] rowStringBytes = field.getBytes();
-        outBuffer.reallocIfNeeded(rowStringBytes.length);
+        outBuffer = outBuffer.reallocIfNeeded(rowStringBytes.length);
         outBuffer.setBytes(0, rowStringBytes);
 
         rowHolder.start = 0;
@@ -166,7 +166,7 @@ public class UserAgentFunctions {
       String field = agent.getValue(requestedField);
 
       byte[] rowStringBytes = field.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-      outBuffer.reallocIfNeeded(rowStringBytes.length);
+      outBuffer = outBuffer.reallocIfNeeded(rowStringBytes.length);
       outBuffer.setBytes(0, rowStringBytes);
 
       out.start = 0;

--- a/exec/java-exec/src/main/codegen/templates/CastIntervalVarChar.java
+++ b/exec/java-exec/src/main/codegen/templates/CastIntervalVarChar.java
@@ -61,7 +61,7 @@ public class Cast${type.from}To${type.to} implements DrillSimpleFunc {
   @Output ${type.to}Holder out;
 
   public void setup() {
-    buffer.reallocIfNeeded(${type.bufferLength});
+    buffer = buffer.reallocIfNeeded(${type.bufferLength});
   }
 
   public void eval() {

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastDecimalVarDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastDecimalVarDecimal.java
@@ -83,7 +83,7 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
     out.start = 0;
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;
-    out.buffer = buffer.reallocIfNeeded(len);
+    out.buffer = buffer = buffer.reallocIfNeeded(len);
     out.buffer.setBytes(out.start, bytes);
     out.end = out.start + len;
   }

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastDecimalVarchar.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastDecimalVarchar.java
@@ -65,10 +65,9 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
   public void eval() {
     java.math.BigDecimal bigDecimal = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromDrillBuf(in.buffer, in.start, in.end - in.start, in.scale);
     String str = bigDecimal.toString();
-    out.buffer = buffer;
     out.start = 0;
     out.end = Math.min((int) len.value, str.length());
-    buffer = buffer.reallocIfNeeded((int) out.end);
+    out.buffer = buffer = buffer.reallocIfNeeded((int) out.end);
     out.buffer.setBytes(0, str.substring(0, out.end).getBytes());
   }
 }

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastFloatDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastFloatDecimal.java
@@ -79,7 +79,7 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
 
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;
-    out.buffer = buffer.reallocIfNeeded(len);
+    out.buffer = buffer = buffer.reallocIfNeeded(len);
     out.buffer.setBytes(out.start, bytes);
     out.end = out.start + len;
   }

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastIntDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastIntDecimal.java
@@ -66,7 +66,6 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
     out.precision = precision.value;
 
     out.start = 0;
-    out.buffer = buffer;
     java.math.BigDecimal bd = new java.math.BigDecimal(in.value);
 
     org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(bd, precision.value, scale.value);
@@ -75,7 +74,7 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
 
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;
-    out.buffer = out.buffer.reallocIfNeeded(len);
+    out.buffer = buffer = buffer.reallocIfNeeded(len);
     out.buffer.setBytes(out.start, bytes);
     out.end = out.start + len;
   }

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastVarCharDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastVarCharDecimal.java
@@ -101,7 +101,7 @@ public class CastEmptyString${type.from}To${type.to} implements DrillSimpleFunc 
 
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;
-    out.buffer = buffer.reallocIfNeeded(len);
+    out.buffer = buffer = buffer.reallocIfNeeded(len);
     out.buffer.setBytes(out.start, bytes);
     out.end = out.start + len;
   }

--- a/exec/java-exec/src/main/codegen/templates/Decimal/DecimalAggrTypeFunctions1.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/DecimalAggrTypeFunctions1.java
@@ -110,7 +110,7 @@ public class Decimal${aggrtype.className}Functions {
         value.obj = ((java.math.BigDecimal) value.obj).setScale(out.scale, java.math.BigDecimal.ROUND_HALF_UP);
         byte[] bytes = ((java.math.BigDecimal) value.obj).unscaledValue().toByteArray();
         int len = bytes.length;
-        out.buffer = buffer.reallocIfNeeded(len);
+        out.buffer = buffer = buffer.reallocIfNeeded(len);
         out.buffer.setBytes(0, bytes);
         out.end = len;
       } else {
@@ -180,7 +180,7 @@ public class Decimal${aggrtype.className}Functions {
         byte[] bytes = ((java.math.BigDecimal)value.obj).unscaledValue().toByteArray();
         int len = bytes.length;
         out.start  = 0;
-        out.buffer = buffer.reallocIfNeeded(len);
+        out.buffer = buffer = buffer.reallocIfNeeded(len);
         out.buffer.setBytes(0, bytes);
         out.end = len;
         out.scale = scale.value;

--- a/exec/java-exec/src/main/codegen/templates/Decimal/DecimalAggrTypeFunctions2.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/DecimalAggrTypeFunctions2.java
@@ -111,7 +111,7 @@ public static class ${type.inputType}${aggrtype.className} implements DrillAggFu
       out.precision = org.apache.drill.exec.planner.types.DrillRelDataTypeSystem.DRILL_REL_DATATYPE_SYSTEM.getMaxNumericPrecision();
       byte[] bytes = average.unscaledValue().toByteArray();
       int len = bytes.length;
-      out.buffer = buffer.reallocIfNeeded(len);
+      out.buffer = buffer = buffer.reallocIfNeeded(len);
       out.buffer.setBytes(0, bytes);
       out.end = len;
     } else {

--- a/exec/java-exec/src/main/codegen/templates/Decimal/DecimalAggrTypeFunctions3.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/DecimalAggrTypeFunctions3.java
@@ -158,7 +158,7 @@ public class Decimal${aggrtype.className}Functions {
           org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(result, out.precision, out.scale);
           byte[] bytes = result.unscaledValue().toByteArray();
           int len = bytes.length;
-          out.buffer = buffer.reallocIfNeeded(len);
+          out.buffer = buffer = buffer.reallocIfNeeded(len);
           out.buffer.setBytes(0, bytes);
           out.end = len;
         } else {

--- a/exec/java-exec/src/main/codegen/templates/Decimal/DecimalFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/DecimalFunctions.java
@@ -187,7 +187,7 @@ public class ${type.name}Functions {
 
       byte[] bytes = opResult.unscaledValue().toByteArray();
       int len = bytes.length;
-      result.buffer = buffer.reallocIfNeeded(len);
+      result.buffer = buffer = buffer.reallocIfNeeded(len);
       result.buffer.setBytes(0, bytes);
       result.end = len;
     }
@@ -246,7 +246,7 @@ public class ${type.name}Functions {
 
       byte[] bytes = opResult.unscaledValue().toByteArray();
       int len = bytes.length;
-      result.buffer = buffer.reallocIfNeeded(len);
+      result.buffer = buffer = buffer.reallocIfNeeded(len);
       result.buffer.setBytes(0, bytes);
       result.end = len;
     }
@@ -295,7 +295,7 @@ public class ${type.name}Functions {
                   .setScale(result.scale, java.math.BigDecimal.ROUND_DOWN);
       byte[] bytes = opResult.unscaledValue().toByteArray();
       int len = bytes.length;
-      result.buffer = buffer.reallocIfNeeded(len);
+      result.buffer = buffer = buffer.reallocIfNeeded(len);
       result.buffer.setBytes(0, bytes);
       result.end = len;
     }
@@ -324,7 +324,7 @@ public class ${type.name}Functions {
                   .setScale(result.scale, java.math.BigDecimal.ROUND_HALF_UP);
       byte[] bytes = bd.unscaledValue().toByteArray();
       int len = bytes.length;
-      result.buffer = buffer.reallocIfNeeded(len);
+      result.buffer = buffer = buffer.reallocIfNeeded(len);
       result.buffer.setBytes(0, bytes);
       result.end = len;
     }

--- a/exec/java-exec/src/main/codegen/templates/NewValueFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/NewValueFunctions.java
@@ -18,7 +18,7 @@
 <@pp.dropOutputFile />
 
 <#macro reassignHolder>
-        previous.buffer = buf.reallocIfNeeded(length);
+        previous.buffer = buf = buf.reallocIfNeeded(length);
         previous.buffer.setBytes(0, in.buffer, in.start, length);
         previous.end = length;
 </#macro>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/ParseQueryFunction.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/ParseQueryFunction.java
@@ -96,7 +96,7 @@ public class ParseQueryFunction {
         }
 
         byte[] valueBytes = keyValue[1].getBytes();
-        outBuffer.reallocIfNeeded(valueBytes.length);
+        outBuffer = outBuffer.reallocIfNeeded(valueBytes.length);
         outBuffer.setBytes(0, valueBytes);
 
         org.apache.drill.exec.expr.holders.VarCharHolder valueHolder =
@@ -170,7 +170,7 @@ public class ParseQueryFunction {
         }
 
         byte[] valueBytes = keyValue[1].getBytes();
-        outBuffer.reallocIfNeeded(valueBytes.length);
+        outBuffer = outBuffer.reallocIfNeeded(valueBytes.length);
         outBuffer.setBytes(0, valueBytes);
 
         org.apache.drill.exec.expr.holders.VarCharHolder valueHolder =

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/ParseUrlFunction.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/ParseUrlFunction.java
@@ -90,7 +90,7 @@ public class ParseUrlFunction {
           if (entry.getValue() != null) {
             // Explicit casting to String is required because of Janino's limitations regarding generics.
             byte[] protocolBytes = ((String) entry.getValue()).getBytes();
-            outBuffer.reallocIfNeeded(protocolBytes.length);
+            outBuffer = outBuffer.reallocIfNeeded(protocolBytes.length);
             outBuffer.setBytes(0, protocolBytes);
             rowHolder.start = 0;
             rowHolder.end = protocolBytes.length;
@@ -165,7 +165,7 @@ public class ParseUrlFunction {
           if (entry.getValue() != null) {
             // Explicit casting to String is required because of Janino's limitations regarding generics.
             byte[] protocolBytes = ((String) entry.getValue()).getBytes();
-            outBuffer.reallocIfNeeded(protocolBytes.length);
+            outBuffer = outBuffer.reallocIfNeeded(protocolBytes.length);
             outBuffer.setBytes(0, protocolBytes);
             rowHolder.start = 0;
             rowHolder.end = protocolBytes.length;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StatisticsAggrFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StatisticsAggrFunctions.java
@@ -202,7 +202,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -303,7 +303,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -364,7 +364,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -419,7 +419,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -474,7 +474,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -533,7 +533,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -588,7 +588,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -647,7 +647,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -702,7 +702,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -761,7 +761,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -816,7 +816,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -875,7 +875,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -930,7 +930,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -989,7 +989,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1044,7 +1044,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1103,7 +1103,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1158,7 +1158,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1217,7 +1217,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1272,7 +1272,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1331,7 +1331,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1386,7 +1386,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1445,7 +1445,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1509,7 +1509,7 @@ public class StatisticsAggrFunctions {
                 (com.clearspring.analytics.stream.cardinality.HyperLogLog) work.obj;
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1580,7 +1580,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1638,7 +1638,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1699,7 +1699,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1756,7 +1756,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1817,7 +1817,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1874,7 +1874,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);
@@ -1934,7 +1934,7 @@ public class StatisticsAggrFunctions {
 
         try {
           byte[] ba = hll.getBytes();
-          out.buffer = buffer.reallocIfNeeded(ba.length);
+          out.buffer = buffer = buffer.reallocIfNeeded(ba.length);
           out.start = 0;
           out.end = ba.length;
           out.buffer.setBytes(0, ba);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/TDigestFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/TDigestFunctions.java
@@ -87,7 +87,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -146,7 +146,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -201,7 +201,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -260,7 +260,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -315,7 +315,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -374,7 +374,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -429,7 +429,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -488,7 +488,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -543,7 +543,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -602,7 +602,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -657,7 +657,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -716,7 +716,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -771,7 +771,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -830,7 +830,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -885,7 +885,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -944,7 +944,7 @@ public class TDigestFunctions {
             int size = tdigest.smallByteSize();
             java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
             tdigest.asSmallBytes(byteBuf);
-            out.buffer = buffer.reallocIfNeeded(size);
+            out.buffer = buffer = buffer.reallocIfNeeded(size);
             out.start = 0;
             out.end = size;
             out.buffer.setBytes(0, byteBuf.array());
@@ -1125,7 +1125,7 @@ public class TDigestFunctions {
           int size = tdigest.smallByteSize();
           java.nio.ByteBuffer byteBuf = java.nio.ByteBuffer.allocate(size);
           tdigest.asSmallBytes(byteBuf);
-          out.buffer = buffer.reallocIfNeeded(size);
+          out.buffer = buffer = buffer.reallocIfNeeded(size);
           out.start = 0;
           out.end = size;
           out.buffer.setBytes(0, byteBuf.array());

--- a/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
@@ -24,8 +24,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.test.BaseTestQuery;
@@ -315,5 +317,20 @@ public class TestBugFixes extends BaseTestQuery {
 
     rows = testSql("SELECT FLATTEN(data) AS d FROM cp.`jsoninput/bug6318.json` LIMIT 3 OFFSET 5");
     Assert.assertEquals(3, rows);
+  }
+
+  @Test
+  public void testDRILL6547() throws Exception {
+    String str1 = StringUtils.repeat('a', Types.MAX_VARCHAR_LENGTH);
+    String str2 = StringUtils.repeat('b', Types.MAX_VARCHAR_LENGTH * 2);
+    testBuilder()
+        .sqlQuery("select\n" +
+            "concat(cast(null as varchar), EXPR$0) as c1\n" +
+            "from (values('%1$s'), ('%2$s'))", str1, str2)
+        .ordered()
+        .baselineColumns("c1")
+        .baselineValuesForSingleColumn(str1, str2)
+        .build()
+        .run();
   }
 }


### PR DESCRIPTION
# [DRILL-6547](https://issues.apache.org/jira/browse/DRILL-6547): IllegalStateException: Tried to remove unmanaged buffer in concat function

## Description

Certain overloads of the **concat** function do not override the current working buffer when calling **reallocIfNeeded**. Because of this, repeated calls to **reallocIfNeeded** on this buffer could lead to an error **Tried to remove unmanaged buffer**

## Testing
TestBugFixes#testDRILL6547 has been added
