### PR TITLE
DRILL-7875: Drill Fails to Splunk Indexes with no Timestamp

### DIFF
--- a/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java
+++ b/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java
@@ -125,7 +125,7 @@ public class ShpBatchReader implements ManagedReader<FileSchemaNegotiator> {
 
   private void openFile(FileSchemaNegotiator negotiator) {
     try {
-      fileReaderShp = negotiator.fileSystem().open(split.getPath());
+      fileReaderShp = negotiator.fileSystem().openPossiblyCompressedStream(split.getPath());
       byte[] shpBuf = new byte[fileReaderShp.available()];
       fileReaderShp.read(shpBuf);
 
@@ -135,10 +135,10 @@ public class ShpBatchReader implements ManagedReader<FileSchemaNegotiator> {
       ShapefileReader shpReader = new ShapefileReader();
       geomCursor = shpReader.getGeometryCursor(byteBuffer);
 
-      fileReaderDbf = negotiator.fileSystem().open(hadoopDbf);
+      fileReaderDbf = negotiator.fileSystem().openPossiblyCompressedStream(hadoopDbf);
       dbfReader = new DbfReader(fileReaderDbf);
 
-      fileReaderPrj = negotiator.fileSystem().open(hadoopPrj);
+      fileReaderPrj = negotiator.fileSystem().openPossiblyCompressedStream(hadoopPrj);
       byte[] prjBuf = new byte[fileReaderPrj.available()];
       fileReaderPrj.read(prjBuf);
       fileReaderPrj.close();

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
@@ -369,8 +369,12 @@ public class SplunkBatchReader implements ManagedReader<SchemaNegotiator> {
 
     @Override
     public void load(String[] record) {
-      int value = Integer.parseInt(record[columnIndex]);
-      columnWriter.setInt(value);
+      if (record[columnIndex] != null) {
+        int value = Integer.parseInt(record[columnIndex]);
+        columnWriter.setInt(value);
+      } else {
+        columnWriter.setNull();
+      }
     }
   }
 
@@ -385,8 +389,12 @@ public class SplunkBatchReader implements ManagedReader<SchemaNegotiator> {
 
     @Override
     public void load(String[] record) {
-      long value = Long.parseLong(record[columnIndex]) * 1000;
-      columnWriter.setTimestamp(Instant.ofEpochMilli(value));
+      if (record[columnIndex] != null) {
+        long value = Long.parseLong(record[columnIndex]) * 1000;
+        columnWriter.setTimestamp(Instant.ofEpochMilli(value));
+      } else {
+        columnWriter.setNull();
+      }
     }
   }
 }


### PR DESCRIPTION
# [DRILL-7875](https://issues.apache.org/jira/browse/DRILL-7875): Drill Fails to Splunk Indexes with no Timestamp

## Description
This PR addresses:
* https://issues.apache.org/jira/browse/DRILL-7875

DRILL-7875 adds a `null` check in the Splunk reader.  In the event that there is a Splunk index with no timestamp field, this will cause Drill to receive several `null` columns.  This rectifies that problem.

## Documentation
No user facing changes.

## Testing
Manual testing and existing unit tests.
