### PR TITLE
DRILL-7790 : Build Drill with Netty version 4.1.59.Final

### DIFF
--- a/common/src/main/java/org/apache/drill/common/collections/MapWithOrdinal.java
+++ b/common/src/main/java/org/apache/drill/common/collections/MapWithOrdinal.java
@@ -29,7 +29,6 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
 import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,12 +128,7 @@ public class MapWithOrdinal<K, V> implements Map<K, V> {
 
     @Override
     public Collection<V> values() {
-      return Lists.newArrayList(Iterables.transform(secondary.entries(), new Function<IntObjectMap.Entry<V>, V>() {
-        @Override
-        public V apply(IntObjectMap.Entry<V> entry) {
-          return Preconditions.checkNotNull(entry).value();
-        }
-      }));
+      return Lists.newArrayList(Iterables.transform(secondary.entries(), entry -> Preconditions.checkNotNull(entry).value()));
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.record;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufProcessor;
+import io.netty.util.ByteProcessor;
 import io.netty.buffer.DrillBuf;
 
 import java.io.IOException;
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
@@ -222,12 +223,27 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public short getShortLE(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public int getUnsignedShort(int index) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
+  public int getUnsignedShortLE(int index) {
+      throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public int getMedium(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public int getMediumLE(int index) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -237,7 +253,17 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public int getUnsignedMediumLE(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public int getInt(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public int getIntLE(int index) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -247,7 +273,22 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public long getUnsignedIntLE(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public long getLong(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public long getLongLE(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public CharSequence getCharSequence(int index, int length, Charset charset) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -263,6 +304,11 @@ public class DeadBuf extends ByteBuf {
 
   @Override
   public double getDouble(int index) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public int getBytes(int index, FileChannel out, long position, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -322,7 +368,17 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public ByteBuf setShortLE(int index, int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public ByteBuf setMedium(int index, int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public ByteBuf setMediumLE(int index, int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -332,7 +388,22 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public ByteBuf setIntLE(int index, int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public ByteBuf setLong(int index, long value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public ByteBuf setLongLE(int index, long value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public int setCharSequence(int index, CharSequence sequence, Charset charset) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -348,6 +419,11 @@ public class DeadBuf extends ByteBuf {
 
   @Override
   public ByteBuf setDouble(int index, double value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public int setBytes(int index, FileChannel in, long position, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
@@ -418,7 +494,11 @@ public class DeadBuf extends ByteBuf {
   @Override
   public short readShort() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public short readShortLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
@@ -428,39 +508,68 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public int readUnsignedShortLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public int readMedium() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public int readMediumLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public int readUnsignedMedium() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public int readUnsignedMediumLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public int readInt() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public int readIntLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public long readUnsignedInt() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public long readUnsignedIntLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public long readLong() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public long readLongLE() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public char readChar() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public CharSequence readCharSequence(int length, Charset charset) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
@@ -472,310 +581,314 @@ public class DeadBuf extends ByteBuf {
   @Override
   public double readDouble() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public int readBytes(FileChannel out, long position, int length) throws IOException {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf readBytes(int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readSlice(int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(ByteBuf dst) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(ByteBuf dst, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(byte[] dst) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(ByteBuffer dst) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf readBytes(OutputStream out, int length) throws IOException {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public int readBytes(GatheringByteChannel out, int length) throws IOException {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf skipBytes(int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeBoolean(boolean value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeByte(int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeShort(int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf writeShortLE(int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf writeMedium(int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf writeMediumLE(int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf writeInt(int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf writeIntLE(int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf writeLong(long value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf writeLongLE(long value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf writeChar(int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeFloat(float value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeDouble(double value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public int writeBytes(FileChannel in, long position, int length) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public int writeCharSequence(CharSequence sequence, Charset charset) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf writeBytes(ByteBuf src) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeBytes(ByteBuf src, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeBytes(byte[] src) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeBytes(byte[] src, int srcIndex, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeBytes(ByteBuffer src) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public int writeBytes(InputStream in, int length) throws IOException {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public int writeBytes(ScatteringByteChannel in, int length) throws IOException {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf writeZero(int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public int indexOf(int fromIndex, int toIndex, byte value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
 
   @Override
   public int bytesBefore(byte value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
     @Override
   public int bytesBefore(int length, byte value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
 
   @Override
   public int bytesBefore(int index, int length, byte value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
 
   @Override
   public ByteBuf copy() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuf copy(int index, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf readRetainedSlice(int length) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf slice() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf retainedSlice() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf slice(int index, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
+  @Override
+  public ByteBuf retainedSlice(int index, int length) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public ByteBuf retainedDuplicate() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
   @Override
   public ByteBuf duplicate() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public int nioBufferCount() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuffer nioBuffer() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuffer nioBuffer(int index, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuffer[] nioBuffers() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public ByteBuffer[] nioBuffers(int index, int length) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public boolean hasArray() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public byte[] array() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public int arrayOffset() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public boolean hasMemoryAddress() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public long memoryAddress() {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public String toString(Charset charset) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
   public String toString(int index, int length, Charset charset) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
-
   }
 
   @Override
@@ -793,33 +906,51 @@ public class DeadBuf extends ByteBuf {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }
 
+  @Override
+  public boolean isReadOnly() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public ByteBuf asReadOnly() {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
 
   @Override
   public boolean equals(Object arg0) {
     return false;
   }
 
+  @Override
+  public ByteBuf touch() {
+    return this;
+  }
 
   @Override
-  public int forEachByte(ByteBufProcessor arg0) {
+  public ByteBuf touch(Object hint) {
+    return this;
+  }
+
+  @Override
+  public int forEachByte(ByteProcessor arg0) {
     return 0;
   }
 
 
   @Override
-  public int forEachByte(int arg0, int arg1, ByteBufProcessor arg2) {
+  public int forEachByte(int arg0, int arg1, ByteProcessor arg2) {
     return 0;
   }
 
 
   @Override
-  public int forEachByteDesc(ByteBufProcessor arg0) {
+  public int forEachByteDesc(ByteProcessor arg0) {
     return 0;
   }
 
 
   @Override
-  public int forEachByteDesc(int arg0, int arg1, ByteBufProcessor arg2) {
+  public int forEachByteDesc(int arg0, int arg1, ByteProcessor arg2) {
     return 0;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/UserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/UserClientConnection.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.rpc;
 
-import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.Future;
 
 import org.apache.drill.exec.physical.impl.materialize.QueryDataPackage;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
@@ -60,10 +60,10 @@ public interface UserClientConnection {
   void sendData(RpcOutcomeListener<Ack> listener, QueryDataPackage data);
 
   /**
-   * Returns the {@link ChannelFuture} which will be notified when this
+   * Returns the {@link Future} which will be notified when this
    * channel is closed.  This method always returns the same future instance.
    */
-  ChannelFuture getChannelClosureFuture();
+  Future<Void> getClosureFuture();
 
   /**
    * @return Return the client node address.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
@@ -19,14 +19,12 @@ package org.apache.drill.exec.rpc.user;
 
 import com.google.protobuf.MessageLite;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.exception.DrillbitStartupException;
@@ -284,14 +282,9 @@ public class UserServer extends BasicServer<RpcType, BitToUserConnection> {
     }
 
     @Override
-    public ChannelFuture getChannelClosureFuture() {
+    public Future<Void> getClosureFuture() {
       return getChannel().closeFuture()
-          .addListener(new GenericFutureListener<Future<? super Void>>() {
-            @Override
-            public void operationComplete(Future<? super Void> future) throws Exception {
-              cleanup();
-            }
-          });
+          .addListener(future -> cleanup());
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/BaseWebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/BaseWebUserConnection.java
@@ -19,12 +19,11 @@ package org.apache.drill.exec.server.rest;
 
 import java.net.SocketAddress;
 
+import io.netty.util.concurrent.Future;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.exec.rpc.AbstractDisposableUserClientConnection;
 import org.apache.drill.exec.rpc.ConnectionThrottle;
 import org.apache.drill.exec.rpc.user.UserSession;
-
-import io.netty.channel.ChannelFuture;
 
 public abstract class BaseWebUserConnection extends AbstractDisposableUserClientConnection implements ConnectionThrottle {
 
@@ -40,7 +39,7 @@ public abstract class BaseWebUserConnection extends AbstractDisposableUserClient
   }
 
   @Override
-  public ChannelFuture getChannelClosureFuture() {
+  public Future<Void> getClosureFuture() {
     return webSessionResources.getCloseFuture();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -29,8 +29,8 @@ import freemarker.cache.TemplateLoader;
 import freemarker.cache.WebappTemplateLoader;
 import freemarker.core.HTMLOutputFormat;
 import freemarker.template.Configuration;
-import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelPromise;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.EventExecutor;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
@@ -221,11 +221,11 @@ public class DrillRestServer extends ResourceConfig {
                 config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
                 config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
 
-        // Create a dummy close future which is needed by Foreman only. Foreman uses this future to add a close
+        // Create a future which is needed by Foreman only. Foreman uses this future to add a close
         // listener to known about channel close event from underlying layer. We use this future to notify Foreman
         // listeners when the Web session (not connection) between Web Client and WebServer is closed. This will help
         // Foreman to cancel all the running queries for this Web Client.
-        final ChannelPromise closeFuture = new DefaultChannelPromise(null, executor);
+        final Promise<Void> closeFuture = new DefaultPromise<>(executor);
 
         // Create a WebSessionResource instance which owns the lifecycle of all the session resources.
         // Set this instance as an attribute of HttpSession, since it will be used until session is destroyed
@@ -283,12 +283,12 @@ public class DrillRestServer extends ResourceConfig {
         logger.trace("Failed to get the remote address of the http session request", ex);
       }
 
-      // Create a dummy close future which is needed by Foreman only. Foreman uses this future to add a close
+      // Create a close future which is needed by Foreman only. Foreman uses this future to add a close
       // listener to known about channel close event from underlying layer.
       //
       // The invocation of this close future is no-op as it will be triggered after query completion in unsecure case.
       // But we need this close future as it's expected by Foreman.
-      final ChannelPromise closeFuture = new DefaultChannelPromise(null, executor);
+      final Promise<Void> closeFuture = new DefaultPromise(executor);
 
       final WebSessionResources webSessionResources = new WebSessionResources(sessionAllocator, remoteAddress,
           drillUserSession, closeFuture);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebSessionResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebSessionResources.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.server.rest;
 
-import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.Promise;
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.rpc.ChannelClosedException;
@@ -40,10 +40,10 @@ public class WebSessionResources implements AutoCloseable {
 
   private final UserSession webUserSession;
 
-  private ChannelPromise closeFuture;
+  private Promise<Void> closeFuture;
 
   WebSessionResources(BufferAllocator allocator, SocketAddress remoteAddress,
-                      UserSession userSession, ChannelPromise closeFuture) {
+                      UserSession userSession, Promise<Void> closeFuture) {
     this.allocator = allocator;
     this.remoteAddress = remoteAddress;
     this.webUserSession = userSession;
@@ -58,7 +58,7 @@ public class WebSessionResources implements AutoCloseable {
     return allocator;
   }
 
-  public ChannelPromise getCloseFuture() {
+  public Promise<Void> getCloseFuture() {
     return closeFuture;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
@@ -45,12 +45,8 @@ import java.util.Set;
  * access to the {@code UserSession} executing the query. There is no actual physical
  * channel corresponding to this connection wrapper.
  *
- * It returns a close future with no actual underlying
- * {@link io.netty.channel.Channel} associated with it but do have an
- * {@code EventExecutor} out of BitServer EventLoopGroup. Since there is no actual
- * connection established using this class, hence the close event will never be
- * fired by underlying layer and close future is set only when the
- * {@link WebSessionResources} are closed.
+ * It returns a close future which do have an EventExecutor out of BitServer EventLoopGroup.
+ * Close future is set only when the {@link WebSessionResources} are closed.
  */
 public class WebUserConnection extends BaseWebUserConnection {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -22,7 +22,6 @@ import org.apache.drill.exec.work.filter.RuntimeFilterRouter;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import com.google.protobuf.InvalidProtocolBufferException;
-import io.netty.channel.ChannelFuture;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
@@ -116,7 +115,7 @@ public class Foreman implements Runnable {
 
   private final ResponseSendListener responseListener = new ResponseSendListener();
   private final GenericFutureListener<Future<Void>> closeListener = future -> cancel();
-  private final ChannelFuture closeFuture;
+  private final Future<Void> closeFuture;
   private final FragmentsRunner fragmentsRunner;
   private final QueryStateProcessor queryStateProcessor;
 
@@ -141,7 +140,7 @@ public class Foreman implements Runnable {
     this.queryRequest = queryRequest;
     this.drillbitContext = drillbitContext;
     this.initiatingClient = connection;
-    this.closeFuture = initiatingClient.getChannelClosureFuture();
+    this.closeFuture = initiatingClient.getClosureFuture();
     closeFuture.addListener(closeListener);
 
     // Apply AutoLimit on resultSet (Usually received via REST APIs)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.work.prepare;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 
-import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.Future;
 import org.apache.drill.common.exceptions.ErrorHelper;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
@@ -244,8 +244,8 @@ public class PreparedStatementProvider {
     }
 
     @Override
-    public ChannelFuture getChannelClosureFuture() {
-      return inner.getChannelClosureFuture();
+    public Future<Void> getClosureFuture() {
+      return inner.getClosureFuture();
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.server.rest;
 
-import io.netty.channel.DefaultChannelPromise;
+import io.netty.util.concurrent.Promise;
 import io.netty.channel.local.LocalAddress;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
@@ -30,6 +30,7 @@ import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
 import org.apache.drill.exec.work.WorkManager;
 import org.apache.drill.exec.work.foreman.Foreman;
 import org.apache.drill.test.ClusterTest;
+import org.mockito.Mockito;
 
 public class RestServerTest extends ClusterTest {
 
@@ -55,7 +56,7 @@ public class RestServerTest extends ClusterTest {
         .withOptionManager(systemOptions)
         .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(principal.getName()).build())
         .build(),
-      new DefaultChannelPromise(null));
+      Mockito.mock(Promise.class));
     WebUserConnection connection = new WebUserConnection.AnonWebUserConnection(webSessionResources);
     return new RestQueryRunner(q, cluster.drillbit().getManager(), connection).run();
   }

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -533,7 +533,7 @@
                   This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                   </message>
-                  <maxsize>46000000</maxsize>
+                  <maxsize>46300000</maxsize>
                   <minsize>15000000</minsize>
                   <files>
                    <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>
@@ -593,7 +593,7 @@
                           This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                         </message>
-                        <maxsize>46000000</maxsize>
+                        <maxsize>46300000</maxsize>
                         <minsize>15000000</minsize>
                         <files>
                           <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>

--- a/exec/memory/base/src/main/java/io/netty/buffer/MutableWrappedByteBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/MutableWrappedByteBuf.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
@@ -127,6 +128,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  protected short _getShortLE(int index) {
+    return buffer.getShortLE(index);
+  }
+
+  @Override
   public int getUnsignedMedium(int index) {
     return _getUnsignedMedium(index);
   }
@@ -134,6 +140,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected int _getUnsignedMedium(int index) {
     return buffer.getUnsignedMedium(index);
+  }
+
+  @Override
+  protected int _getUnsignedMediumLE(int index) {
+    return buffer.getUnsignedMediumLE(index);
   }
 
   @Override
@@ -147,6 +158,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  protected int _getIntLE(int index) {
+    return buffer.getIntLE(index);
+  }
+
+  @Override
   public long getLong(int index) {
     return _getLong(index);
   }
@@ -154,6 +170,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected long _getLong(int index) {
     return buffer.getLong(index);
+  }
+
+  @Override
+  protected long _getLongLE(int index) {
+    return buffer.getLongLE(index);
   }
 
   @Override
@@ -205,6 +226,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  protected void _setShortLE(int index, int value) {
+    buffer.setShortLE(index, value);
+  }
+
+  @Override
   public ByteBuf setMedium(int index, int value) {
     _setMedium(index, value);
     return this;
@@ -213,6 +239,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected void _setMedium(int index, int value) {
     buffer.setMedium(index, value);
+  }
+
+  @Override
+  protected void _setMediumLE(int index, int value) {
+    buffer.setMediumLE(index, value);
   }
 
   @Override
@@ -227,6 +258,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  protected void _setIntLE(int index, int value) {
+    buffer.setIntLE(index, value);
+  }
+
+  @Override
   public ByteBuf setLong(int index, long value) {
     _setLong(index, value);
     return this;
@@ -235,6 +271,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected void _setLong(int index, long value) {
     buffer.setLong(index, value);
+  }
+
+  @Override
+  protected void _setLongLE(int index, long value) {
+    buffer.setLongLE(index, value);
   }
 
   @Override
@@ -269,6 +310,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+    return buffer.getBytes(index, out, position, length);
+  }
+
+  @Override
   public int setBytes(int index, InputStream in, int length)
       throws IOException {
     return buffer.setBytes(index, in, length);
@@ -278,6 +324,11 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   public int setBytes(int index, ScatteringByteChannel in, int length)
       throws IOException {
     return buffer.setBytes(index, in, length);
+  }
+
+  @Override
+  public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+    return buffer.setBytes(index, in, position, length);
   }
 
   @Override
@@ -296,16 +347,6 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
-  public int forEachByte(int index, int length, ByteBufProcessor processor) {
-    return buffer.forEachByte(index, length, processor);
-  }
-
-  @Override
-  public int forEachByteDesc(int index, int length, ByteBufProcessor processor) {
-    return buffer.forEachByteDesc(index, length, processor);
-  }
-
-  @Override
   public final int refCnt() {
     return unwrap().refCnt();
   }
@@ -313,6 +354,18 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   public final ByteBuf retain() {
     unwrap().retain();
+    return this;
+  }
+
+  @Override
+  public ByteBuf touch() {
+    buffer.touch();
+    return this;
+  }
+
+  @Override
+  public ByteBuf touch(Object hint) {
+    buffer.touch(hint);
     return this;
   }
 

--- a/exec/memory/base/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -68,6 +68,14 @@ public class PooledByteBufAllocatorL {
     }
   }
 
+  public ByteBuf allocateHeap(int initialCapacity, int maxCapacity) {
+    try {
+      return allocator.heapBuffer(initialCapacity, maxCapacity);
+    } catch (OutOfMemoryError e) {
+      throw new OutOfMemoryException("Failure allocating heap buffer.", e);
+    }
+  }
+
   public int getChunkSize() {
     return allocator.chunkSize;
   }
@@ -199,12 +207,6 @@ public class PooledByteBufAllocatorL {
       }
       validate(initialCapacity, maxCapacity);
       return newDirectBufferL(initialCapacity, maxCapacity);
-    }
-
-    @Override
-    public ByteBuf heapBuffer(int initialCapacity, int maxCapacity) {
-      throw new UnsupportedOperationException(
-          "Drill doesn't support using heap buffers.");
     }
 
     private void validate(int initialCapacity, int maxCapacity) {

--- a/exec/memory/base/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -57,7 +57,7 @@ public final class UnsafeDirectLittleEndian extends WrappedByteBuf {
 
   private UnsafeDirectLittleEndian(AbstractByteBuf buf, boolean fake, AtomicLong bufferCount, AtomicLong bufferSize) {
     super(buf);
-    if (!NATIVE_ORDER || buf.order() != ByteOrder.BIG_ENDIAN) {
+    if (!NATIVE_ORDER) {
       throw new IllegalStateException("Drill only runs on LittleEndian systems.");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <surefire.version>3.0.0-M4</surefire.version>
     <commons.compress.version>1.20</commons.compress.version>
     <hikari.version>3.4.2</hikari.version>
-    <netty.version>4.0.48.Final</netty.version>
+    <netty.version>4.1.59.Final</netty.version>
     <httpclient.version>4.5.12</httpclient.version>
     <libthrift.version>0.13.0</libthrift.version>
     <derby.version>10.14.2.0</derby.version>
@@ -1827,6 +1827,10 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
# [DRILL-7790](https://issues.apache.org/jira/browse/DRILL-7790): Build Drill with Netty version 4.1.50.Final

`Netty` of version `4.0.48.Final` has vulnerabilities as CVE-2019-16869, CVE-2014-3488 and other. I want to update to the last available, stable version of `Netty` `4.1.59.Final`.

`ChannelPromise` and `ChannelFuture` were replaced with `DefaultPromise` and `Future` according. It was done in response to changes in https://github.com/netty/netty/commit/1740f366eb728ea5a0a63d18e9042161673414cd . `ChannelPromise` and `ChannelFuture` are wrong used and netty's changes are predict it.

Other one breaking `Netty` change is https://github.com/netty/netty/commit/39cc7a673939dec96258ff27f5b1874671838af0 . In Drill we have `ByteBuffAlocater` which doesn't support heap buffers. But in the netty's commit was changed internal behavior in `SslHandler`. Previously, regardless to chosen ssl engine, were using only `directBuffer()` or `buffer()`, which in our case both lid to the same - `directBuffer`. But now, behavior was changed and for JDK ssl engine is always used `heapBuffer()` which is not supported in Drill. So, to resolve this, I've used `InnerAllocator` from `PooledByteBufAllocatorL`. `InnerAllocator` extends `PooledByteBufAllocator` which has default netty implementation for `heapBuffer`.

## Documentation
No user visible changes

## Testing
Unit tests
