### PR TITLE
DRILL-7874: Ensure DrillFSDataInputStream.read populates byte array of the requested length

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
@@ -467,7 +467,7 @@ public class Packet implements Comparable<Packet> {
     originalLength = getIntFileOrder(byteOrder, header, offset + PacketConstants.ORIGINAL_LENGTH_OFFSET);
     packetLength = getIntFileOrder(byteOrder, header, offset + PacketConstants.ACTUAL_LENGTH_OFFSET);
     Preconditions.checkState(originalLength <= maxLength,
-        "Packet too long (%d bytes)", originalLength);
+        "Packet too long (%s bytes)", originalLength);
   }
 
   private long getTimestampMicro(final byte[] header, final boolean byteOrder, final int offset) {


### PR DESCRIPTION
# [DRILL-7874](https://issues.apache.org/jira/browse/DRILL-7874): Ensure DrillFSDataInputStream.read populates byte array of the requested length

## Description

Documentation for the `InputStream.read(byte b[], int off, int len)` method doesn't guarantee that all requested (if available) bytes will be stored in the byte array, so some implementations indeed populate byte array only with partial data.
It causes issues for storage plugins that manipulate with byte arrays obtained from the stream by this way, for example, the PCAP plugin when files are stored at s3.

This PR updates the `DrillFSDataInputStream.read` method to ensure that all requested bytes were stored in the byte array to have the same behavior regardless of the `InputStream` implementation.

## Documentation
NA

## Testing
Checked manually, no unit tests provided because currently it is reproduced with s3 only.
