### PR TITLE
DRILL-7885: HDF5 Plugin not resolving links

### DIFF
--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
@@ -481,10 +481,7 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
             attribs = getAttributes(node.getPath());
             metadataRow.setAttributes(attribs);
             metadata.add(metadataRow);
-            if (!node.isLink()) {
-              // Links don't have metadata
-              getFileMetadata((Group) node, metadata);
-            }
+            getFileMetadata((Group) node, metadata);
             break;
           default:
             logger.warn("Unknown data type: {}", node.getType());

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5DrillMetadata.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5DrillMetadata.java
@@ -28,6 +28,8 @@ public class HDF5DrillMetadata {
 
   private Map<String, HDF5Attribute> attributes;
 
+  private boolean isLink;
+
   public HDF5DrillMetadata() {
     attributes = new HashMap<>();
   }
@@ -57,5 +59,13 @@ public class HDF5DrillMetadata {
 
   public void setAttributes(Map<String, HDF5Attribute> attribs) {
     this.attributes = attribs;
+  }
+
+  public boolean isLink() {
+    return isLink;
+  }
+
+  public void setLink(boolean linkStatus) {
+    isLink = linkStatus;
   }
 }

--- a/contrib/format-hdf5/src/test/java/org/apache/drill/exec/store/hdf5/TestHDF5Format.java
+++ b/contrib/format-hdf5/src/test/java/org/apache/drill/exec/store/hdf5/TestHDF5Format.java
@@ -86,8 +86,8 @@ public class TestHDF5Format extends ClusterTest {
     testBuilder()
       .sqlQuery("SELECT * FROM dfs.`hdf5/dset.h5`")
       .unOrdered()
-      .baselineColumns("path", "data_type", "file_name", "data_size", "element_count", "dataset_data_type", "dimensions", "int_data")
-      .baselineValues("/dset", "DATASET", "dset.h5", 96L, 24L, "int", "[4, 6]", finalList)
+      .baselineColumns("path", "data_type", "file_name", "data_size", "element_count", "dataset_data_type", "dimensions", "int_data", "is_link")
+      .baselineValues("/dset", "DATASET", "dset.h5", 96L, 24L, "int", "[4, 6]", finalList, false)
       .go();
   }
 
@@ -412,7 +412,6 @@ public class TestHDF5Format extends ClusterTest {
 
     new RowSetComparison(expected).unorderedVerifyAndClearAll(results);
   }
-
 
   @Test
   public void testUnicodeScalarQuery() throws Exception {


### PR DESCRIPTION
# [DRILL-7885](https://issues.apache.org/jira/browse/DRILL-7885): HDF5 Plugin not resolving links

## Description
This minor PR fixes a few minor issues with the HDF5 reader.   The reader was not following links properly.  Additionally, if the preview was a 2D array (or greater) the preview was using the incorrect dimensions and throwing NPEs. 

## Documentation
No user facing changes

## Testing
Manually Tested with client provided large test files.