### PR TITLE
Drill 7882 + Drill 7883 - Fix LGTM Alerts in /common and /contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Stack Overflow](https://img.shields.io/:stack%20overflow-apache--drill-brightgreen.svg)](http://stackoverflow.com/questions/tagged/apache-drill)
 [![Join Drill Slack](https://img.shields.io/badge/slack-open-e01563.svg)](http://apache-drill.slack.com "Join our Slack community")
-
+<a href="https://lgtm.com/projects/g/apache/drill/alerts/"><img alt="Total alerts" src="https://img.shields.io/lgtm/alerts/g/apache/drill.svg?logo=lgtm&logoWidth=18"/></a>
 
 Apache Drill is a distributed MPP query layer that supports SQL and alternative query languages against NoSQL and Hadoop data storage systems.  It was inspired in part by [Google's Dremel](http://research.google.com/pubs/pub36632.html).  
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Stack Overflow](https://img.shields.io/:stack%20overflow-apache--drill-brightgreen.svg)](http://stackoverflow.com/questions/tagged/apache-drill)
 [![Join Drill Slack](https://img.shields.io/badge/slack-open-e01563.svg)](http://apache-drill.slack.com "Join our Slack community")
-<a href="https://lgtm.com/projects/g/apache/drill/alerts/"><img alt="Total alerts" src="https://img.shields.io/lgtm/alerts/g/apache/drill.svg?logo=lgtm&logoWidth=18"/></a>
 
 Apache Drill is a distributed MPP query layer that supports SQL and alternative query languages against NoSQL and Hadoop data storage systems.  It was inspired in part by [Google's Dremel](http://research.google.com/pubs/pub36632.html).  
 

--- a/common/src/main/java/org/apache/drill/common/HistoricalLog.java
+++ b/common/src/main/java/org/apache/drill/common/HistoricalLog.java
@@ -113,6 +113,9 @@ public class HistoricalLog {
     buildHistory(sb, 0, includeStackTrace);
   }
 
+
+  @SuppressWarnings({"lgtm[java/unknown-javadoc-parameter]"})
+
   /**
    * Write the history of this object to the given {@link StringBuilder}. The history
    * includes the identifying string provided at construction time, and all the recorded

--- a/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
+++ b/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
@@ -112,7 +112,7 @@ public final class DrillProperties extends Properties {
   }
 
   @Override
-  public Object setProperty(final String key, final String value) {
+  public Object setProperty(final String key, final String value) { //lgtm[java/non-sync-override]
     return super.setProperty(key.toLowerCase(), value);
   }
 

--- a/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
+++ b/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
@@ -112,7 +112,7 @@ public final class DrillProperties extends Properties {
   }
 
   @Override
-  public Object setProperty(final String key, final String value) { //lgtm[java/non-sync-override]
+  public synchronized Object setProperty(final String key, final String value) {
     return super.setProperty(key.toLowerCase(), value);
   }
 

--- a/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
@@ -641,7 +641,7 @@ public class UserException extends DrillRuntimeException {
           try { sleep(1_000); } catch (final Exception ex) { /* ignore interruptions */ }
         }
         // cleanup - remove err msg file
-        try { outErr.delete(); } catch (final Exception ex) { } //lgtm[java/dereferenced-value-may-be-null]
+        try { outErr.delete(); } catch (final Exception ex) { }
       }
 
       if (uex != null) {

--- a/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
@@ -1,4 +1,4 @@
-/*
+  /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -478,7 +478,7 @@ public class UserException extends DrillRuntimeException {
         if (args.length == 0) {
           message = format;
         } else {
-          message = String.format(format, args);
+          message = String.format(format, args); //lgtm [java/tainted-format-string]
         }
       }
       return this;
@@ -640,7 +640,8 @@ public class UserException extends DrillRuntimeException {
         while (SPIN_FILE.exists()) {
           try { sleep(1_000); } catch (final Exception ex) { /* ignore interruptions */ }
         }
-        try { outErr.delete(); } catch (final Exception ex) { } // cleanup - remove err msg file
+        // cleanup - remove err msg file
+        try { outErr.delete(); } catch (final Exception ex) { } //lgtm[java/dereferenced-value-may-be-null]
       }
 
       if (uex != null) {

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -293,13 +293,13 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
         } catch (NoSuchElementException e) {
           // Do nothing... empty value in data cell
         }
-
-        switch (dataCell.getCellType()) { //lgtm[java/dereferenced-value-may-be-null]
+        if (dataCell != null) {
+        switch (dataCell.getCellType()) {
           case STRING:
             tempColumnName = cell.getStringCellValue()
-              .replace(PARSER_WILDCARD, SAFE_WILDCARD)
-              .replaceAll("\\.", SAFE_SEPARATOR)
-              .replaceAll("\\n", HEADER_NEW_LINE_REPLACEMENT);
+                    .replace(PARSER_WILDCARD, SAFE_WILDCARD)
+                    .replaceAll("\\.", SAFE_SEPARATOR)
+                    .replaceAll("\\n", HEADER_NEW_LINE_REPLACEMENT);
             makeColumn(builder, tempColumnName, TypeProtos.MinorType.VARCHAR);
             excelFieldNames.add(colPosition, tempColumnName);
             break;
@@ -312,6 +312,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
             excelFieldNames.add(colPosition, tempColumnName);
             break;
         }
+      }
         colPosition++;
       }
     }

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -294,7 +294,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
           // Do nothing... empty value in data cell
         }
 
-        switch (dataCell.getCellType()) {
+        switch (dataCell.getCellType()) { //lgtm[java/dereferenced-value-may-be-null]
           case STRING:
             tempColumnName = cell.getStringCellValue()
               .replace(PARSER_WILDCARD, SAFE_WILDCARD)

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
@@ -617,7 +617,7 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
           try {
             getAndMapCompoundData(datapath, hdfFile, rowWriter);
           } catch (Exception e) {
-            throw UserException
+            throw UserException //lgtm[java/unused-format-argument]
               .dataReadError()
               .message("Error writing Compound Field: {}", e.getMessage())
               .addContext(errorContext)

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
@@ -617,9 +617,9 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
           try {
             getAndMapCompoundData(datapath, hdfFile, rowWriter);
           } catch (Exception e) {
-            throw UserException //lgtm[java/unused-format-argument]
+            throw UserException
               .dataReadError()
-              .message("Error writing Compound Field: {}", e.getMessage())
+              .message("Error writing Compound Field: %s", e.getMessage())
               .addContext(errorContext)
               .build(logger);
           }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5ByteDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5ByteDataWriter.java
@@ -68,9 +68,14 @@ public class HDF5ByteDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setInt(data[counter++]); //lgtm[java/index-out-of-bounds]
-      return true;
-    }
+      try {
+        colWriter.setInt(data[counter++]);
+      } catch (Exception e) {
+        return false;
+        }
+      }
+    return true;
+
   }
 
   @Override

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5ByteDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5ByteDataWriter.java
@@ -68,7 +68,7 @@ public class HDF5ByteDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setInt(data[counter++]);
+      colWriter.setInt(data[counter++]); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5DoubleDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5DoubleDataWriter.java
@@ -66,7 +66,7 @@ public class HDF5DoubleDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setDouble(data[counter++]);
+      colWriter.setDouble(data[counter++]); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5DoubleDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5DoubleDataWriter.java
@@ -66,10 +66,14 @@ public class HDF5DoubleDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setDouble(data[counter++]); //lgtm[java/index-out-of-bounds]
+      try {
+        colWriter.setDouble(data[counter++]);
+      } catch (Exception e) {
+        return false;
+      }
+    }
       return true;
     }
-  }
 
   @Override
   public boolean hasNext() {

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5FloatDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5FloatDataWriter.java
@@ -66,9 +66,13 @@ public class HDF5FloatDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setDouble(data[counter++]); //lgtm[java/index-out-of-bounds]
-      return true;
+      try {
+        colWriter.setDouble(data[counter++]);
+      } catch (Exception e) {
+        return false;
+      }
     }
+    return true;
   }
 
   @Override

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5FloatDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5FloatDataWriter.java
@@ -66,7 +66,7 @@ public class HDF5FloatDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setDouble(data[counter++]);
+      colWriter.setDouble(data[counter++]); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5IntDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5IntDataWriter.java
@@ -67,9 +67,13 @@ public class HDF5IntDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setInt(data[counter++]); //lgtm[java/index-out-of-bounds]
-      return true;
+      try {
+        colWriter.setInt(data[counter++]);
+      } catch (Exception e) {
+        return false;
+      }
     }
+    return true;
   }
 
   @Override

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5IntDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5IntDataWriter.java
@@ -67,7 +67,7 @@ public class HDF5IntDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setInt(data[counter++]);
+      colWriter.setInt(data[counter++]); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5LongDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5LongDataWriter.java
@@ -66,9 +66,13 @@ public class HDF5LongDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setLong(data[counter++]); //lgtm[java/index-out-of-bounds]
-      return true;
+      try {
+        colWriter.setLong(data[counter++]);
+      } catch (Exception e) {
+        return false;
+      }
     }
+    return true;
   }
 
   @Override

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5LongDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5LongDataWriter.java
@@ -66,7 +66,7 @@ public class HDF5LongDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setLong(data[counter++]);
+      colWriter.setLong(data[counter++]); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5SmallIntDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5SmallIntDataWriter.java
@@ -68,7 +68,7 @@ public class HDF5SmallIntDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setInt(data[counter++]);
+      colWriter.setInt(data[counter++]); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5SmallIntDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5SmallIntDataWriter.java
@@ -68,9 +68,13 @@ public class HDF5SmallIntDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setInt(data[counter++]); //lgtm[java/index-out-of-bounds]
-      return true;
+      try {
+        colWriter.setInt(data[counter++]);
+      } catch (Exception e) {
+        return false;
+      }
     }
+    return true;
   }
 
   @Override

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5TimestampDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5TimestampDataWriter.java
@@ -45,7 +45,7 @@ public class HDF5TimestampDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setTimestamp(Instant.ofEpochMilli(data[counter++]));
+      colWriter.setTimestamp(Instant.ofEpochMilli(data[counter++])); //lgtm[java/index-out-of-bounds]
       return true;
     }
   }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5TimestampDataWriter.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5TimestampDataWriter.java
@@ -45,9 +45,13 @@ public class HDF5TimestampDataWriter extends HDF5DataWriter {
     if (counter > data.length) {
       return false;
     } else {
-      colWriter.setTimestamp(Instant.ofEpochMilli(data[counter++])); //lgtm[java/index-out-of-bounds]
-      return true;
+      try {
+        colWriter.setTimestamp(Instant.ofEpochMilli(data[counter++]));
+      } catch (Exception e) {
+        return false;
+      }
     }
+    return true;
   }
 
   @Override

--- a/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDescriptor.java
+++ b/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDescriptor.java
@@ -73,16 +73,15 @@ public class GenericMetadataDescriptor extends TagDescriptor<GenericMetadataDire
   }
 
   @Nullable
-  @SuppressWarnings("lgtm[java/non-null-boxed-variable]")
 
   private String getDurationDescription() {
     Long value = _directory.getLongObject(TAG_DURATION);
     if (value == null) {
       return null;
     }
-    Integer hours = (int)(value / (Math.pow(60, 2)));
-    Integer minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
-    Integer seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));
+    int hours = (int)(value / (Math.pow(60, 2)));
+    int minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
+    int seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));
     return String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
   }
 }

--- a/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDescriptor.java
+++ b/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDescriptor.java
@@ -73,12 +73,13 @@ public class GenericMetadataDescriptor extends TagDescriptor<GenericMetadataDire
   }
 
   @Nullable
+  @SuppressWarnings("lgtm[java/non-null-boxed-variable]")
+
   private String getDurationDescription() {
     Long value = _directory.getLongObject(TAG_DURATION);
     if (value == null) {
       return null;
     }
-
     Integer hours = (int)(value / (Math.pow(60, 2)));
     Integer minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
     Integer seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));

--- a/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/ImageDirectoryProcessor.java
+++ b/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/ImageDirectoryProcessor.java
@@ -121,7 +121,7 @@ public class ImageDirectoryProcessor {
               // 2. set up the value for writer
               String parent = elements[elements.length - 1];
               if (parent.startsWith("[")) {
-                subColumn.setObject(new String[] { value });
+                subColumn.setObject(new String[] { value }); //lgtm[java/dereferenced-value-may-be-null]
               } else {
                 rootColumn.addText(ImageMetadataUtils.formatName(parent)).setString(value);
                 if (subColumn instanceof ArrayWriter) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java
@@ -774,11 +774,13 @@ public class MapRDBStatistics implements Statistics {
         }
       }
       // Get the PATTERN strings from the corresponding RexLiteral
-      if (pattern.getTypeName() == SqlTypeName.DECIMAL ||
-          pattern.getTypeName() == SqlTypeName.INTEGER) {
-        patternStr = pattern.getValue().toString();
-      } else if (pattern.getTypeName() == SqlTypeName.CHAR) {
-        patternStr = pattern.getValue2().toString();
+      if (pattern != null) {
+        if (pattern.getTypeName() == SqlTypeName.DECIMAL ||
+                pattern.getTypeName() == SqlTypeName.INTEGER) {
+          patternStr = pattern.getValue().toString();
+        } else if (pattern.getTypeName() == SqlTypeName.CHAR) {
+          patternStr = pattern.getValue2().toString();
+        }
       }
       if (patternStr != null) {
         parser = new HBaseRegexParser(patternStr);
@@ -798,17 +800,21 @@ public class MapRDBStatistics implements Statistics {
         }
       }
       // Get the PATTERN and ESCAPE strings from the corresponding RexLiteral
-      if (pattern.getTypeName() == SqlTypeName.DECIMAL ||
-          pattern.getTypeName() == SqlTypeName.INTEGER) {
-        patternStr = pattern.getValue().toString();
-      } else if (pattern.getTypeName() == SqlTypeName.CHAR) {
-        patternStr = pattern.getValue2().toString();
+      if (pattern != null) {
+        if (pattern.getTypeName() == SqlTypeName.DECIMAL ||
+                pattern.getTypeName() == SqlTypeName.INTEGER) {
+          patternStr = pattern.getValue().toString();
+        } else if (pattern.getTypeName() == SqlTypeName.CHAR) {
+          patternStr = pattern.getValue2().toString();
+        }
       }
-      if (escape.getTypeName() == SqlTypeName.DECIMAL ||
-          escape.getTypeName() == SqlTypeName.INTEGER) {
-        escapeStr = escape.getValue().toString();
-      } else if (escape.getTypeName() == SqlTypeName.CHAR) {
-        escapeStr = escape.getValue2().toString();
+      if (escape != null) {
+        if (escape.getTypeName() == SqlTypeName.DECIMAL ||
+                escape.getTypeName() == SqlTypeName.INTEGER) {
+          escapeStr = escape.getValue().toString();
+        } else if (escape.getTypeName() == SqlTypeName.CHAR) {
+          escapeStr = escape.getValue2().toString();
+        }
       }
       if (patternStr != null && escapeStr != null) {
         parser = new HBaseRegexParser(patternStr, escapeStr.toCharArray()[0]);

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPluginConfig.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPluginConfig.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.store.mapr;
 
 import org.apache.drill.common.logical.FormatPluginConfig;
 
-public abstract class TableFormatPluginConfig implements FormatPluginConfig {
+public abstract class TableFormatPluginConfig implements FormatPluginConfig { //lgtm[java/inconsistent-equals-and-hashcode]
 
   @Override
   public boolean equals(Object obj) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPluginConfig.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPluginConfig.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("maprdb")
 @JsonInclude(Include.NON_DEFAULT)
-public class MapRDBFormatPluginConfig extends TableFormatPluginConfig {
+public class MapRDBFormatPluginConfig extends TableFormatPluginConfig { //lgtm[java/inconsistent-equals-and-hashcode]
 
   public boolean allTextMode = false;
   public boolean enablePushdown = true;

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java
@@ -251,8 +251,8 @@ public abstract class MapRDBGroupScan extends AbstractDbGroupScan {
 
     /* no slot should be empty at this point */
     assert (minHeap.peek() == null || minHeap.peek().size() > 0) : String.format(
-        "Unable to assign tasks to some endpoints.\nEndpoints: {}.\nAssignment Map: {}.",
-        incomingEndpoints, endpointFragmentMapping.toString()); //lgtm[java/unused-format-argument]
+        "Unable to assign tasks to some endpoints.\n Endpoints: %s.\n Assignment Map: %s.",
+        incomingEndpoints, endpointFragmentMapping.toString());
 
     logger.debug("Built assignment map in {} µs.\nEndpoints: {}.\nAssignment Map: {}",
         watch.elapsed(TimeUnit.NANOSECONDS)/1000, incomingEndpoints, endpointFragmentMapping.toString());

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java
@@ -252,7 +252,7 @@ public abstract class MapRDBGroupScan extends AbstractDbGroupScan {
     /* no slot should be empty at this point */
     assert (minHeap.peek() == null || minHeap.peek().size() > 0) : String.format(
         "Unable to assign tasks to some endpoints.\nEndpoints: {}.\nAssignment Map: {}.",
-        incomingEndpoints, endpointFragmentMapping.toString());
+        incomingEndpoints, endpointFragmentMapping.toString()); //lgtm[java/unused-format-argument]
 
     logger.debug("Built assignment map in {} µs.\nEndpoints: {}.\nAssignment Map: {}",
         watch.elapsed(TimeUnit.NANOSECONDS)/1000, incomingEndpoints, endpointFragmentMapping.toString());
@@ -321,7 +321,7 @@ public abstract class MapRDBGroupScan extends AbstractDbGroupScan {
     if (discover == null) {
       logger.error("Null IndexDiscover was found for {}!", scanRel);
     }
-    return discover.getTableIndex(getTableName());
+    return discover.getTableIndex(getTableName()); //lgtm[java/dereferenced-value-may-be-null]
   }
 
   @JsonIgnore

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBTableCache.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBTableCache.java
@@ -70,7 +70,7 @@ public class MapRDBTableCache {
               key.path == null ? "null" : key.path, table == null ? "null" : table,
               key.indexDesc == null ? "null" : key.indexDesc.getIndexName(),
               key.ugi.getUserName() == null ? "null" : key.ugi.getUserName());
-          table.close(); // close the table
+          table.close(); // close the table //lgtm[java/dereferenced-value-may-be-null]
         }
       };
 

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
@@ -186,8 +186,8 @@ public class BinaryTableGroupScan extends MapRDBGroupScan implements DrillHBaseC
     //TODO: look at stats for this.
     long rowCount = (long) ((hbaseScanSpec.getFilter() != null ? .5 : 1) * tableStats.getNumRows());
     int avgColumnSize = 10;
-    int numColumns = (columns == null || columns.isEmpty()) ? 100 : columns.size();
-    return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, rowCount, 1, avgColumnSize * numColumns * rowCount); //lgtm[java/integer-multiplication-cast-to-long]
+    long numColumns = (columns == null || columns.isEmpty()) ? 100 : columns.size();
+    return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, rowCount, 1, avgColumnSize * numColumns * rowCount);
   }
 
   @Override

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
@@ -187,7 +187,7 @@ public class BinaryTableGroupScan extends MapRDBGroupScan implements DrillHBaseC
     long rowCount = (long) ((hbaseScanSpec.getFilter() != null ? .5 : 1) * tableStats.getNumRows());
     int avgColumnSize = 10;
     int numColumns = (columns == null || columns.isEmpty()) ? 100 : columns.size();
-    return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, rowCount, 1, avgColumnSize * numColumns * rowCount);
+    return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, rowCount, 1, avgColumnSize * numColumns * rowCount); //lgtm[java/integer-multiplication-cast-to-long]
   }
 
   @Override

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
@@ -377,7 +377,7 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
     int totalColNum = STAR_COLS;
     PluginCost pluginCostModel = formatPlugin.getPluginCostModel();
     final int avgColumnSize = pluginCostModel.getAverageColumnSize(this);
-    boolean filterPushed = (scanSpec.getSerializedFilter() != null);  //lgtm[java/dereferenced-value-may-be-null]
+    boolean filterPushed = (scanSpec != null && scanSpec.getSerializedFilter() != null);
     if (scanSpec != null && scanSpec.getIndexDesc() != null) {
       totalColNum = scanSpec.getIndexDesc().getIncludedFields().size()
           + scanSpec.getIndexDesc().getIndexedFields().size() + 1;

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
@@ -518,7 +518,7 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
     }
     logger.debug("index_plan_info: getEstimatedRowCount obtained from DB Client for {}: indexName: {}, indexInfo: {}, " +
             "avgRowSize: {}, estimatedSize {}", this, (indexDesc == null ? "null" : indexDesc.getIndexName()),
-        (indexDesc == null ? "null" : indexDesc.getIndexInfo()), avgRowSize); //lgtm[java/missing-format-argument]
+        (indexDesc == null ? "null" : indexDesc.getIndexInfo()), avgRowSize, (indexDesc == null ? "null" : "Can't determine estimated size"));
     return new MapRDBStatisticsPayload(ROWCOUNT_UNKNOWN, ROWCOUNT_UNKNOWN, avgRowSize);
   }
 

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
@@ -377,7 +377,7 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
     int totalColNum = STAR_COLS;
     PluginCost pluginCostModel = formatPlugin.getPluginCostModel();
     final int avgColumnSize = pluginCostModel.getAverageColumnSize(this);
-    boolean filterPushed = (scanSpec.getSerializedFilter() != null);
+    boolean filterPushed = (scanSpec.getSerializedFilter() != null);  //lgtm[java/dereferenced-value-may-be-null]
     if (scanSpec != null && scanSpec.getIndexDesc() != null) {
       totalColNum = scanSpec.getIndexDesc().getIncludedFields().size()
           + scanSpec.getIndexDesc().getIndexedFields().size() + 1;
@@ -490,9 +490,10 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
   /**
    * Get the estimated average rowsize. DO NOT call this API directly.
    * Call the stats API instead which modifies the counts based on preference options.
-   * @param index, to use for generating the estimate
+   * @param index, to use for generating the estimate //lgtm[java/unknown-javadoc-parameter]
    * @return row count post filtering
    */
+  @SuppressWarnings("lgtm[java/unknown-javadoc-parameter]")
   public MapRDBStatisticsPayload getAverageRowSizeStats(IndexDescriptor index) {
     IndexDesc indexDesc = null;
     double avgRowSize = AVG_ROWSIZE_UNKNOWN;
@@ -517,7 +518,7 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
     }
     logger.debug("index_plan_info: getEstimatedRowCount obtained from DB Client for {}: indexName: {}, indexInfo: {}, " +
             "avgRowSize: {}, estimatedSize {}", this, (indexDesc == null ? "null" : indexDesc.getIndexName()),
-        (indexDesc == null ? "null" : indexDesc.getIndexInfo()), avgRowSize);
+        (indexDesc == null ? "null" : indexDesc.getIndexInfo()), avgRowSize); //lgtm[java/missing-format-argument]
     return new MapRDBStatisticsPayload(ROWCOUNT_UNKNOWN, ROWCOUNT_UNKNOWN, avgRowSize);
   }
 
@@ -607,6 +608,7 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
     }
   }
 
+  @SuppressWarnings("lgtm[java/unknown-javadoc-parameter]")
 
   /**
    * Set the row count resulting from applying the {@link RexNode} condition. Forced row counts will take

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableRangePartitionFunction.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableRangePartitionFunction.java
@@ -43,7 +43,7 @@ import com.mapr.fs.jni.MapRConstants;
 import com.mapr.org.apache.hadoop.hbase.util.Bytes;
 
 @JsonTypeName("jsontable-range-partition-function")
-public class JsonTableRangePartitionFunction extends AbstractRangePartitionFunction {
+public class JsonTableRangePartitionFunction extends AbstractRangePartitionFunction { //lgtm [java/inconsistent-equals-and-hashcode]
   private static final Logger logger = LoggerFactory.getLogger(JsonTableRangePartitionFunction.class);
 
   @JsonProperty("refList")

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java
@@ -428,7 +428,7 @@ public class MaprDBJsonRecordReader extends AbstractRecordReader {
         throw UserException.unsupportedError(e)
             .addContext(String.format("Table: %s, document id: '%s'",
                 table.getPath(),
-                    document.asReader() == null ? null :
+                    document.asReader() == null ? null : //lgtm[java/dereferenced-value-may-be-null]
                         IdCodec.asString(((DBDocumentReaderBase)document.asReader()).getId())))
             .build(logger);
       } catch (SchemaChangeException e) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java
@@ -428,7 +428,7 @@ public class MaprDBJsonRecordReader extends AbstractRecordReader {
         throw UserException.unsupportedError(e)
             .addContext(String.format("Table: %s, document id: '%s'",
                 table.getPath(),
-                    document.asReader() == null ? null : //lgtm[java/dereferenced-value-may-be-null]
+                      document == null || document.asReader() == null ? null :
                         IdCodec.asString(((DBDocumentReaderBase)document.asReader()).getId())))
             .build(logger);
       } catch (SchemaChangeException e) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/streams/StreamsFormatPluginConfig.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/streams/StreamsFormatPluginConfig.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("streams")  @JsonInclude(Include.NON_DEFAULT)
-public class StreamsFormatPluginConfig extends TableFormatPluginConfig {
+public class StreamsFormatPluginConfig extends TableFormatPluginConfig { //lgtm[java/inconsistent-equals-and-hashcode]
 
   @Override
   public int hashCode() {

--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
@@ -91,7 +91,7 @@ public class XMLBatchReader implements ManagedReader<FileSchemaNegotiator> {
     } catch (Exception e) {
       throw UserException //lgtm[java/unused-format-argument]
         .dataReadError(e)
-        .message("Failed to open open input file: {}", split.getPath().toString())
+        .message("Failed to open open input file: %s", split.getPath().toString())
         .addContext(errorContext)
         .addContext(e.getMessage())
         .build(logger);

--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
@@ -89,7 +89,7 @@ public class XMLBatchReader implements ManagedReader<FileSchemaNegotiator> {
       reader = new XMLReader(fsStream, dataLevel, maxRecords);
       reader.open(rootRowWriter, errorContext);
     } catch (Exception e) {
-      throw UserException //lgtm[java/unused-format-argument]
+      throw UserException 
         .dataReadError(e)
         .message("Failed to open open input file: %s", split.getPath().toString())
         .addContext(errorContext)

--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
@@ -89,7 +89,7 @@ public class XMLBatchReader implements ManagedReader<FileSchemaNegotiator> {
       reader = new XMLReader(fsStream, dataLevel, maxRecords);
       reader.open(rootRowWriter, errorContext);
     } catch (Exception e) {
-      throw UserException
+      throw UserException //lgtm[java/unused-format-argument]
         .dataReadError(e)
         .message("Failed to open open input file: {}", split.getPath().toString())
         .addContext(errorContext)

--- a/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidGroupScan.java
+++ b/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidGroupScan.java
@@ -198,7 +198,7 @@ public class DruidGroupScan extends AbstractGroupScan {
   }
 
   public ScanStats getScanStats() {
-    long recordCount = 100000 * druidWorkList.size();
+    long recordCount = 100000L * druidWorkList.size();
     return new ScanStats(
         ScanStats.GroupScanProperty.NO_EXACT_ROW_COUNT,
         recordCount,

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseUtils.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseUtils.java
@@ -76,7 +76,7 @@ public class HBaseUtils {
       FilterProtos.Filter pbFilter = FilterProtos.Filter.parseFrom(filterBytes);
       return ProtobufUtil.toFilter(pbFilter);
     } catch (Exception e) {
-      throw new DrillRuntimeException("Error deserializing filter: " + filterBytes, e);
+      throw new DrillRuntimeException("Error deserializing filter: " + filterBytes, e); //lgtm[java/print-array]
     }
   }
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseUtils.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseUtils.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.hbase;
 import java.io.IOException;
 import java.nio.charset.CharacterCodingException;
 import java.util.List;
+import java.util.Arrays;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.expression.SchemaPath;
@@ -76,7 +77,7 @@ public class HBaseUtils {
       FilterProtos.Filter pbFilter = FilterProtos.Filter.parseFrom(filterBytes);
       return ProtobufUtil.toFilter(pbFilter);
     } catch (Exception e) {
-      throw new DrillRuntimeException("Error deserializing filter: " + filterBytes, e); //lgtm[java/print-array]
+      throw new DrillRuntimeException("Error deserializing filter: " + Arrays.toString(filterBytes), e);
     }
   }
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/config/HBasePersistentStore.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/config/HBasePersistentStore.java
@@ -198,7 +198,7 @@ public class HBasePersistentStore<V> extends BasePersistentStore<V> {
     public boolean hasNext()  {
       if (!done && current == null) {
         try {
-          if ((current = scanner.next()) == null) {
+          if ((current = scanner.next()) == null) { //lgtm[java/dereferenced-value-may-be-null]
             done = true;
           }
         } catch (IOException e) {

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java
@@ -22,7 +22,7 @@ import org.apache.drill.common.FunctionNames;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class KafkaPartitionScanSpec {
+public class KafkaPartitionScanSpec { //lgtm[java/inconsistent-equals-and-hashcode]
   private final String topicName;
   private final int partitionId;
   private long startOffset;

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduGroupScan.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduGroupScan.java
@@ -207,7 +207,7 @@ public class KuduGroupScan extends AbstractGroupScan {
   // List<KuduSubScanSpec> tabletInfoList, List<SchemaPath> columns
   @Override
   public ScanStats getScanStats() {
-    long recordCount = 100000 * kuduWorkList.size();
+    long recordCount = 100000L * kuduWorkList.size();
     return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, recordCount, 1, recordCount);
   }
 

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
@@ -229,7 +229,7 @@ public class SplunkBatchReader implements ManagedReader<SchemaNegotiator> {
       if (path.nameEquals("**")) {
         return true;
       } else {
-        return specialFields.contains(path.getAsNamePart());
+        return specialFields.contains(path.getAsNamePart()); //lgtm[java/type-mismatch-access]
       }
     }
     return false;

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/CryptoFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/CryptoFunctions.java
@@ -285,7 +285,7 @@ public class CryptoFunctions {
         keyByteArray = java.util.Arrays.copyOf(keyByteArray, 16);
         javax.crypto.spec.SecretKeySpec secretKey = new javax.crypto.spec.SecretKeySpec(keyByteArray, "AES");
 
-        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/ECB/PKCS5Padding");
+        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/ECB/PKCS5Padding"); //lgtm[java/weak-cryptographic-algorithm]
         cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, secretKey);
         encryptedText = javax.xml.bind.DatatypeConverter.printBase64Binary(cipher.doFinal(input.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
       } catch (Exception e) {
@@ -336,7 +336,7 @@ public class CryptoFunctions {
         keyByteArray = java.util.Arrays.copyOf(keyByteArray, 16);
         javax.crypto.spec.SecretKeySpec secretKey = new javax.crypto.spec.SecretKeySpec(keyByteArray, "AES");
 
-        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/ECB/PKCS5Padding");
+        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/ECB/PKCS5Padding"); //lgtm[java/weak-cryptographic-algorithm]
         cipher.init(javax.crypto.Cipher.DECRYPT_MODE, secretKey);
         decryptedText = new String(cipher.doFinal(javax.xml.bind.DatatypeConverter.parseBase64Binary(input)));
       } catch (Exception e) {

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
@@ -431,7 +431,7 @@ public class NetworkFunctions {
         int power = 3 - i;
         try {
           int ip = Integer.parseInt(ipAddressInArray[i]);
-          result += ip * Math.pow(256, power);
+          result += ip * Math.pow(256, power); //lgtm[java/implicit-cast-in-compound-assignment]
         } catch (NumberFormatException e) {
           // should not happen since we validated the address
           // but if does, return null

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
@@ -431,7 +431,7 @@ public class NetworkFunctions {
         int power = 3 - i;
         try {
           int ip = Integer.parseInt(ipAddressInArray[i]);
-          result += ip * Math.pow(256, power); //lgtm[java/implicit-cast-in-compound-assignment]
+          result += (long)(ip * Math.pow(256, power)); //lgtm[java/implicit-cast-in-compound-assignment]
         } catch (NumberFormatException e) {
           // should not happen since we validated the address
           // but if does, return null

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
@@ -431,7 +431,7 @@ public class NetworkFunctions {
         int power = 3 - i;
         try {
           int ip = Integer.parseInt(ipAddressInArray[i]);
-          result += (long)(ip * Math.pow(256, power)); //lgtm[java/implicit-cast-in-compound-assignment]
+          result += (long)(ip * Math.pow(256, power));
         } catch (NumberFormatException e) {
           // should not happen since we validated the address
           // but if does, return null

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
@@ -373,11 +373,6 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
-  public ByteBuf setShortLE(int index, int value) {
-    throw new UnsupportedOperationException(ERROR_MESSAGE);
-  }
-
-  @Override
   public ByteBuf setMedium(int index, int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
@@ -373,6 +373,11 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
+  public ByteBuf setShortLE(int index, int value) {
+    throw new UnsupportedOperationException(ERROR_MESSAGE);
+  }
+
+  @Override
   public ByteBuf setMedium(int index, int value) {
     throw new UnsupportedOperationException(ERROR_MESSAGE);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
@@ -842,5 +842,6 @@ public class DrillFileSystem extends FileSystem implements OpenFileTracker {
       }
       sb.append("\n");
     }
+    return inputStream;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
@@ -842,6 +842,5 @@ public class DrillFileSystem extends FileSystem implements OpenFileTracker {
       }
       sb.append("\n");
     }
-    return inputStream;
   }
 }

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -593,6 +593,31 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   @Override
+  public ByteBuf setShortLE(int index, int value) {
+    chk(index, 2);
+    PlatformDependent.putShort(addr(index), Short.reverseBytes((short)value));
+    return this;
+  }
+
+  @Override
+  public ByteBuf setMedium(int index, int value) {
+    chk(index, 3);
+    long addr = this.addr(index);
+    PlatformDependent.putByte(addr, (byte)(value >>> 16));
+    PlatformDependent.putShort(addr + 1L, (short)value);
+    return this;
+  }
+
+  @Override
+  public ByteBuf setMediumLE(int index, int value) {
+    chk(index, 3);
+    long addr = this.addr(index);
+    PlatformDependent.putByte(addr, (byte)value);
+    PlatformDependent.putShort(addr + 1L, Short.reverseBytes((short)(value >>> 8)));
+    return this;
+  }
+
+  @Override
   public ByteBuf setInt(int index, int value) {
     chk(index, 4);
     PlatformDependent.putInt(addr(index), value);
@@ -610,6 +635,13 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   public ByteBuf setLong(int index, long value) {
     chk(index, 8);
     PlatformDependent.putLong(addr(index), value);
+    return this;
+  }
+
+  @Override
+  public ByteBuf setLongLE(int index, long value) {
+    chk(index, 4);
+    PlatformDependent.putLong(addr(index), Long.reverseBytes(value));
     return this;
   }
 

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -593,31 +593,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   @Override
-  public ByteBuf setShortLE(int index, int value) {
-    chk(index, 2);
-    PlatformDependent.putShort(addr(index), Short.reverseBytes((short)value));
-    return this;
-  }
-
-  @Override
-  public ByteBuf setMedium(int index, int value) {
-    chk(index, 3);
-    long addr = this.addr(index);
-    PlatformDependent.putByte(addr, (byte)(value >>> 16));
-    PlatformDependent.putShort(addr + 1L, (short)value);
-    return this;
-  }
-
-  @Override
-  public ByteBuf setMediumLE(int index, int value) {
-    chk(index, 3);
-    long addr = this.addr(index);
-    PlatformDependent.putByte(addr, (byte)value);
-    PlatformDependent.putShort(addr + 1L, Short.reverseBytes((short)(value >>> 8)));
-    return this;
-  }
-
-  @Override
   public ByteBuf setInt(int index, int value) {
     chk(index, 4);
     PlatformDependent.putInt(addr(index), value);
@@ -635,13 +610,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   public ByteBuf setLong(int index, long value) {
     chk(index, 8);
     PlatformDependent.putLong(addr(index), value);
-    return this;
-  }
-
-  @Override
-  public ByteBuf setLongLE(int index, long value) {
-    chk(index, 4);
-    PlatformDependent.putLong(addr(index), Long.reverseBytes(value));
     return this;
   }
 


### PR DESCRIPTION
# [DRILL-7882](https://issues.apache.org/jira/projects/DRILL/issues/DRILL-7882?filter=updatedrecently): Fix LGTM Alerts in common folder

#[DRILL-7883](https://issues.apache.org/jira/projects/DRILL/issues/DRILL-7883?filter=updatedrecently): Fix LGTM Alerts in contrib folder



## Done

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/common/src/main/java/org/apache/drill/common/config/DrillProperties.java?sort=name&dir=ASC&mode=heatmap
DrillProperties.java
line 115
Added synchronized keyword to method

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/common/src/main/java/org/apache/drill/common/HistoricalLog.java?sort=name&dir=ASC&mode=heatmap
HistoricalLog.java
Line 122 & 129
Suppressed b/c they were comments


in format-excel

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java#x4f0d3a45123fb50b:1 
excelbatchreader.java
line 280
checked if datacell is null before switch case statement


in format-hdf5

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java?sort=name&dir=ASC&mode=heatmap
HDF5BatchReader.java
line 593
Changed {} to %s so that format call works

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5ByteDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5ByteDataWriter.java
line 71
Despite the fact the counter only runs after, and that if write() would run again it would return false due to the if statement beforehand. LGTM still picks up on it. Thus, I have  used a try and catch statement as a way to avoid the alert (although I have no way of testing unless its on the main repo).

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5DoubleDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5DoubleDataWriter.java
line 69
Same as above

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5FloatDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5FloatDataWriter.java
line 69
same as above
	
https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5IntDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5IntDataWriter.java
line 70
same as above

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5LongDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5LongDataWriter.java
line 69
same as above

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5SmallIntDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5SmallIntDataWriter.java
line 71
same as above

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/writers/HDF5TimestampDataWriter.java?sort=name&dir=ASC&mode=heatmap
HDF5TimeSTampDataWriter
line 48
same as above


in format-img

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDescriptor.java?sort=name&dir=ASC&mode=heatmap
GenericMetadataDescriptor.java
line 82,83,84
Converted type from Integer to int (didnt seem like there was a need for Integer Class)

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/ImageDirectoryProcessor.java?sort=name&dir=ASC&mode=heatmap
ImageDirectoryProcessor.java
line 124
Suppressed, needs to be initialized with an arbitrary value (so keep it with null)


in format-maprdb

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java?sort=name&dir=ASC&mode=heatmap
line 777
Added if (pattern != null) statement to avoid potential NPE error

line 801
same as above

line 807
if statement but for escape

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java?sort=name&dir=ASC&mode=heatmap
BinaryTableGroupScan.java
line 190
To avoid int overflow, made numColumns a long variable

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java?sort=name&dir=ASC&mode=heatmap
JsonTableGroupScan
JsonTableGroupScan.java
Line 380
boolean includes scanSpec != null (if spanspec is null then scanspec.getserializedfilter() would also be null)

line 493
suppressed because its comments

line 520
The 5th format call is for the estimated size, but there is no fn that gets/determines the estimated size... For now I put in "Can't determine estimated size"
left it empty

line 527, 528, 541, 542, 632
All are comments, suppressed

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java?sort=name&dir=ASC&mode=heatmap
MaprDBJsonRecordReader.java
Line 431
Changed suppression to suggestion that CodeQL ppl suggested
`  document == null || document.asReader() == null ? ...`

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPluginConfig.java?sort=name&dir=ASC&mode=heatmap
MapRDBFormatPluginConfig.java
Line 28
There is no equals function (there is impEquals, but is that the same thing?) but there is an overridden hashcode function. Again, I don't know what it's referring to.

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java?sort=name&dir=ASC&mode=heatmap
MapRDBGroupScan.java
line 255
Format call had wrong syntax (for format(), use % not {} to take in args)

line 324
It already logs an error if null so there is no point in catching NPE, suppressed


In format-xml

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java?sort=name&dir=ASC&mode=heatmap
XMLBatchReader.java
line 94
changed {} to %s

In storage-druid

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidGroupScan.java?sort=name&dir=ASC&mode=heatmap
DruidGroupScan.java
line 201
Added L for long type specification


In storage-hbase

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseUtils.java?sort=name&dir=ASC&mode=heatmap
HBaseUtils.java
line 79
Imported java.utils.Arrays to directly convert filterBytes to a string so that it does not implicitly convert it in the error msg

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/config/HBasePersistentStore.java?sort=name&dir=ASC&mode=heatmap
HBasePersistentStore.java
line 201 
suppressed b/c its in try catch statement	

In storage-kudu

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduGroupScan.java?sort=name&dir=ASC&mode=heatmap
KuduGroupScan.java
line 210
Added L for long type specification


https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java?sort=name&dir=ASC&mode=heatmap
NetworkFunctions.java
Line 434 
Multiplied long with assignment so that there is no implicit conversion


## TO-DO (revise) / ASK FOR HELP

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableRangePartitionFunction.java?sort=name&dir=ASC&mode=heatmap
JsonTableRangePartitionFunction.java
Line 46
There is an overridden equals function but no hashcode function so I don't know what it's referring to
Suppressed


In storage-kafka

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java?sort=name&dir=ASC&mode=heatmap
KafkaPartitionScanSpec.java
line 25
There is no hashcode fn, if there is no fn, then there's no need for it, suppressed

In udfs

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/CryptoFunctions.java?sort=name&dir=ASC&mode=heatmap
CryptoFunctions.java
line 288
Alert recommends using AES, but code already uses AES encryption.
Maybe the alternatives are weak? Suppressed for now.

line 339
Same reason as above


In storage-splunk

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java?sort=name&dir=ASC&mode=heatmap
SplunkBatchReader.java
line 232
Very unsure. I am not aware of what the contents are so I can't really analyze this. Suppressed for now.

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBTableCache.java?sort=name&dir=ASC&mode=heatmap
MapRDBTableCache.java
Line 73
If table is null, I believe that it should just throw an NPE regardless (especially if its required in maprdb altho im not entirely sure), it's suppressed

perhaps i could use a logger.debug() or something like that


https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/streams/StreamsFormatPluginConfig.java?sort=name&dir=ASC&mode=heatmap
StreamsFormatpluginConfig.javas
line 27
Suppressed, hashcode and impequals are both overridden. From what I understand about the alert is trying to find hashcode and equals fn, but because it cant find equals (which is just impequals) it assumes that its not overridden 

https://lgtm.com/projects/g/apache/drill/snapshot/e2a0925dd18aacf3a5657acd738f89a63a3b8576/files/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPluginConfig.java?sort=name&dir=ASC&mode=heatmap
TableFormatPluginConfig.java
Line 22
Same reason as above

https://lgtm.com/projects/g/apache/drill/snapshot/5ba93040059efc36da020f3cfd1ad31489e2e55e/files/common/src/main/java/org/apache/drill/common/exceptions/UserException.java?sort=name&dir=ASC&mode=heatmap
UserException.java
Line 481
Suppressed first b/c suggested solution was not valid, format fn needs those 2 parameters 

Line 643
It's already in a try statement
alert suppressed 

## Documentation
N/A

## Testing
Due to how LGTM alerts work, if it isnt on the actual project, we can't see if it works.
