### PR TITLE
DRILL-7888: query.json returns an incorrect error message when the query fails

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -1216,6 +1216,10 @@ public final class ExecConstants {
           "the sender to send out its data more rapidly, but you should know that it has a risk to OOM when the system is solving parallel " +
           "large queries until we have a more accurate resource manager."));
 
+  public static final String ENABLE_REST_VERBOSE_ERRORS_KEY = "drill.exec.http.rest.errors.verbose";
+  public static final OptionValidator ENABLE_REST_VERBOSE_ERRORS = new BooleanValidator(ENABLE_REST_VERBOSE_ERRORS_KEY,
+      new OptionDescription("Toggles verbose output of executable error messages in rest response"));
+
   // HTTP proxy configuration (Drill config)
   public static final String NET_PROXY_BASE = "drill.exec.net_proxy";
   // HTTP proxy config

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -257,6 +257,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ClassCompilerSelector.JAVA_COMPILER_JANINO_MAXSIZE),
       new OptionDefinition(ClassCompilerSelector.JAVA_COMPILER_DEBUG),
       new OptionDefinition(ExecConstants.ENABLE_VERBOSE_ERRORS),
+      new OptionDefinition(ExecConstants.ENABLE_REST_VERBOSE_ERRORS),
       new OptionDefinition(ExecConstants.ENABLE_WINDOW_FUNCTIONS_VALIDATOR),
       new OptionDefinition(ExecConstants.SCALAR_REPLACEMENT_VALIDATOR),
       new OptionDefinition(ExecConstants.ENABLE_NEW_TEXT_READER),

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -555,6 +555,7 @@ drill.exec.options: {
     exec.enable_bulk_load_table_list: false,
     exec.enable_union_type: false,
     exec.errors.verbose: false,
+    drill.exec.http.rest.errors.verbose: false,
     exec.hashjoin.mem_limit: 0,
     exec.hashjoin.hash_table_calc_type: "LEAN",
     exec.hashjoin.safety_factor: 1.0,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestRestJson.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestRestJson.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.store.easy.text.TextFormatPlugin.TextFormatConfig;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
@@ -145,6 +146,26 @@ public class TestRestJson extends ClusterTest {
         null, "bogusUser", null, null);
     runQuery(query, outFile);
     verifier.verifyFileWithResource(outFile, "failed.json");
+  }
+
+  @Test
+  public void testQueryWithException() throws IOException {
+    File outFile = new File(dirTestWatcher.getTmpDir(), "exception.json");
+    String sql = "SELECT * FROM cp.`employee123321123321.json` LIMIT 20";
+    QueryWrapper query = new QueryWrapper(sql, QueryType.SQL.name(),
+        null, null, null, null);
+    runQuery(query, outFile);
+    verifier.verifyFileWithResource(outFile, "exception.json");
+  }
+
+  @Test
+  public void testQueryWithVerboseException() throws IOException {
+    File outFile = new File(dirTestWatcher.getTmpDir(), "verboseExc.json");
+    String sql = "SELECT * FROM cp.`employee123321123321.json` LIMIT 20";
+    QueryWrapper query = new QueryWrapper(sql, QueryType.SQL.name(),
+        null, null, null, ImmutableMap.of(ExecConstants.ENABLE_REST_VERBOSE_ERRORS_KEY, "true"));
+    runQuery(query, outFile);
+    verifier.verifyFileWithResource(outFile, "verboseExc.json");
   }
 
   @SuppressWarnings("unused")

--- a/exec/java-exec/src/test/resources/rest/exception.json
+++ b/exec/java-exec/src/test/resources/rest/exception.json
@@ -1,0 +1,3 @@
+!\{"queryId":"[^"]+"
+,"queryState":"FAILED"
+}

--- a/exec/java-exec/src/test/resources/rest/verboseExc.json
+++ b/exec/java-exec/src/test/resources/rest/verboseExc.json
@@ -1,0 +1,6 @@
+!\{"queryId":"[^"]+"
+,"exception":"org.apache.calcite.runtime.CalciteContextException"
+,"errorMessage":"From line 1, column 15 to line 1, column 16: Object 'employee123321123321.json' not found within 'cp': Object 'employee123321123321.json' not found within 'cp'"
+!,"stackTrace":\[.*\]
+,"queryState":"FAILED"
+}


### PR DESCRIPTION
# [DRILL-7888](https://issues.apache.org/jira/browse/DRILL-7888): query.json returns an incorrect error message when the query fails

## Description
Updated StreamingHttpConnection.java to return query id and failed state instead of the incorrect message as stated in the Jira ticket.

Examples of the requests and responses:
Request:
```
{
    "query": "SELECT * FROM cp.`employee123321123321.json` LIMIT 20",
    "queryType": "SQL"
}
```
Response:
```
{
    "queryId": "1fa0acc2-e507-6688-69fe-02fc627c8c47",
    "queryState": "FAILED"
}
```
Please note, to preserve backward compatibility, default response has such a form, so now it is possible to obtain additional error info from the query profile.

To provide error details right in the response, the `exec.errors.verbose` option should be set in the following way:
```
{
    "query": "SELECT * FROM cp.`employee123321123321.json` LIMIT 20",
    "queryType": "SQL",
    "options": {
        "drill.exec.http.rest.errors.verbose": "true"
    }
}
```

The result will be the following and includes a detailed error message and exception stack trace:
```
{
    "queryId": "1f9c72aa-bafb-2d58-ebfa-5cd3f21f4ddd",
    "exception": "org.apache.calcite.runtime.CalciteContextException",
    "errorMessage": "From line 1, column 15 to line 1, column 16: Object 'employee123321123321.json' not found within 'cp': Object 'employee123321123321.json' not found within 'cp'",
    "stackTrace": [
        "org.apache.calcite.runtime.CalciteContextException: From line 1, column 15 to line 1, column 16: Object 'employee123321123321.json' not found within 'cp': Object 'employee123321123321.json' not found within 'cp'",
        "\tat .......(:0)",
        "\tat org.apache.calcite.runtime.Resources$ExInstWithCause.ex(Resources.java:463)",
        "\tat org.apache.calcite.sql.SqlUtil.newContextException(SqlUtil.java:835)",
        "\tat org.apache.calcite.sql.SqlUtil.newContextException(SqlUtil.java:820)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.newValidationError(SqlValidatorImpl.java:4881)",
        "\tat org.apache.calcite.sql.validate.IdentifierNamespace.resolveImpl(IdentifierNamespace.java:127)",
        "\tat org.apache.calcite.sql.validate.IdentifierNamespace.validateImpl(IdentifierNamespace.java:177)",
        "\tat org.apache.calcite.sql.validate.AbstractNamespace.validate(AbstractNamespace.java:84)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateNamespace(SqlValidatorImpl.java:1009)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateQuery(SqlValidatorImpl.java:969)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateFrom(SqlValidatorImpl.java:3129)",
        "\tat org.apache.drill.exec.planner.sql.conversion.DrillValidator.validateFrom(DrillValidator.java:63)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateFrom(SqlValidatorImpl.java:3111)",
        "\tat org.apache.drill.exec.planner.sql.conversion.DrillValidator.validateFrom(DrillValidator.java:63)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateSelect(SqlValidatorImpl.java:3383)",
        "\tat org.apache.calcite.sql.validate.SelectNamespace.validateImpl(SelectNamespace.java:60)",
        "\tat org.apache.calcite.sql.validate.AbstractNamespace.validate(AbstractNamespace.java:84)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateNamespace(SqlValidatorImpl.java:1009)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateQuery(SqlValidatorImpl.java:969)",
        "\tat org.apache.calcite.sql.SqlSelect.validate(SqlSelect.java:216)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validateScopedExpression(SqlValidatorImpl.java:944)",
        "\tat org.apache.calcite.sql.validate.SqlValidatorImpl.validate(SqlValidatorImpl.java:651)",
        "\tat org.apache.drill.exec.planner.sql.conversion.SqlConverter.validate(SqlConverter.java:189)",
        "\tat org.apache.drill.exec.planner.sql.handlers.DefaultSqlHandler.validateNode(DefaultSqlHandler.java:641)",
        "\tat org.apache.drill.exec.planner.sql.handlers.DefaultSqlHandler.validateAndConvert(DefaultSqlHandler.java:195)",
        "\tat org.apache.drill.exec.planner.sql.handlers.DefaultSqlHandler.getPlan(DefaultSqlHandler.java:169)",
        "\tat org.apache.drill.exec.planner.sql.DrillSqlWorker.getQueryPlan(DrillSqlWorker.java:283)",
        "\tat org.apache.drill.exec.planner.sql.DrillSqlWorker.getPhysicalPlan(DrillSqlWorker.java:163)",
        "\tat org.apache.drill.exec.planner.sql.DrillSqlWorker.convertPlan(DrillSqlWorker.java:128)",
        "\tat org.apache.drill.exec.planner.sql.DrillSqlWorker.getPlan(DrillSqlWorker.java:93)",
        "\tat org.apache.drill.exec.work.foreman.Foreman.runSQL(Foreman.java:592)",
        "\tat org.apache.drill.exec.work.foreman.Foreman.run(Foreman.java:273)",
        "\tat .......(:0)",
        "Caused by: org.apache.calcite.sql.validate.SqlValidatorException: Object 'employee123321123321.json' not found within 'cp'",
        "\tat .......(:0)",
        "\tat org.apache.calcite.runtime.Resources$ExInstWithCause.ex(Resources.java:463)",
        "\tat org.apache.calcite.runtime.Resources$ExInst.ex(Resources.java:572)",
        "\t... 31 more"
    ],
    "queryState": "FAILED"
}
```

## Documentation
NA

## Testing
Added unit tests and checked manually.
