### PR TITLE
DRILL-7894: Large Attributes Crash HDF5 Reader

### DIFF
--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
@@ -24,6 +24,7 @@ import io.jhdf.api.Dataset;
 import io.jhdf.api.Group;
 import io.jhdf.api.Node;
 import io.jhdf.exceptions.HdfException;
+import io.jhdf.exceptions.UnsupportedHdfException;
 import io.jhdf.links.SoftLink;
 import io.jhdf.object.datatype.CompoundDataType;
 import io.jhdf.object.datatype.CompoundDataType.CompoundDataMember;
@@ -498,7 +499,7 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
    * @return Map The attributes for the given path.  Empty Map if no attributes present
    */
   private Map<String, HDF5Attribute> getAttributes(String path) {
-
+    Map<String, Attribute> attributeList;
     // Remove trailing slashes
     if (path.endsWith("/")) {
       path = path.substring(0, path.length() - 1);
@@ -516,7 +517,12 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
       return attributes;
     }
 
-    Map<String, Attribute> attributeList = theNode.getAttributes();
+    try {
+      attributeList = theNode.getAttributes();
+    } catch (HdfException e) {
+      logger.warn("Unable to get attributes for {}: Only Huge objects BTrees with 1 record are currently supported.", path);
+      return attributes;
+    }
 
     logger.debug("Found {} attribtutes for {}", attributeList.size(), path);
     for (Map.Entry<String, Attribute> attributeEntry : attributeList.entrySet()) {

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
@@ -24,7 +24,6 @@ import io.jhdf.api.Dataset;
 import io.jhdf.api.Group;
 import io.jhdf.api.Node;
 import io.jhdf.exceptions.HdfException;
-import io.jhdf.exceptions.UnsupportedHdfException;
 import io.jhdf.links.SoftLink;
 import io.jhdf.object.datatype.CompoundDataType;
 import io.jhdf.object.datatype.CompoundDataType.CompoundDataMember;


### PR DESCRIPTION
# [DRILL-7894](https://issues.apache.org/jira/browse/DRILL-7894):  Large Attributes Crash HDF5 Reader

## Description
This PR fixes a minor issue with Drill's HDF5 reader.  The jhdf5 reader does not support large b-trees in attributes.  This PR adds a try/catch block around the `getAttributes()` function.

## Documentation
No user facing changes.

## Testing
Tested with client supplied file.  
