### PR TITLE
DRILL-7899: Bump checkstyle from 8.16 to 8.29 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.16</version>
+            <version>8.29</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -1011,7 +1011,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# [DRILL-7899](https://issues.apache.org/jira/browse/DRILL-XXXX): Bump checkstyle from 8.16 to 8.29 

## Description
Resolves an issue here (https://github.com/advisories/GHSA-763g-fqq7-48wg). 


## Documentation
No user facing changes.

## Testing
Ran all unit tests locally.  Got random failure.  Re ran tests without changes, and all passed.