### PR TITLE
DRILL-7900: Bump libthrift from 0.13.0 to 0.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <hikari.version>3.4.2</hikari.version>
     <netty.version>4.1.59.Final</netty.version>
     <httpclient.version>4.5.12</httpclient.version>
-    <libthrift.version>0.13.0</libthrift.version>
+    <libthrift.version>0.14.0</libthrift.version>
     <derby.version>10.14.2.0</derby.version>
     <commons.cli.version>1.4</commons.cli.version>
     <snakeyaml.version>1.26</snakeyaml.version>


### PR DESCRIPTION
# [DRILL-7900](https://issues.apache.org/jira/browse/DRILL-7900): Bump libthrift from 0.13.0 to 0.14.0

## Description

Bumps [libthrift](https://github.com/apache/thrift) from 0.13.0 to 0.14.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/apache/thrift/releases">libthrift's releases</a>.</em></p>
<blockquote>
<h2>Version 0.14.0</h2>
<p>For release 0.14.0 head over to the official release download source:
<a href="http://thrift.apache.org/download">http://thrift.apache.org/download</a></p>
<p>The assets below are added by Github based on the release tag and they may therefore not match the checkums.</p>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/apache/thrift/blob/master/CHANGES.md">libthrift's changelog</a>.</em></p>
<blockquote>
<h2>0.14.0</h2>
<h3>Deprecated Languages</h3>
<ul>
<li><a href="https://issues.apache.org/jira/browse/THRIFT-5229">THRIFT-5229</a> - Deprecate ActionScript 3 support</li>
</ul>
<h3>Removed Languages</h3>
<ul>
<li><a href="https://issues.apache.org/jira/browse/THRIFT-4980">THRIFT-4980</a> - Remove deprecated C# and netcore bindings from the code base</li>
<li><a href="https://issues.apache.org/jira/browse/THRIFT-4981">THRIFT-4981</a> - Remove deprecated netcore bindings from the code base</li>
<li><a href="https://issues.apache.org/jira/browse/THRIFT-4982">THRIFT

## Documentation
N/A

## Testing
All unit tests pass.