### PR TITLE
DRILL-7904: Update to 30-jre Guava version

### DIFF
--- a/docs/dev/UpgradeGuava.md
+++ b/docs/dev/UpgradeGuava.md
@@ -55,7 +55,7 @@ Verify that all checks are passed and staging repository was closed. Otherwise, 
 
 Select uploaded staging repository and press `Release` button.
 
-## Check that artifacts were deployed
+## Check artifacts were deployed
 
 Find deployed artifacts at [repository.apache.org](https://repository.apache.org/content/groups/public/org/apache/drill/)
 

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -535,7 +535,7 @@
                   This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                   </message>
-                  <maxsize>46600000</maxsize>
+                  <maxsize>46900000</maxsize>
                   <minsize>15000000</minsize>
                   <files>
                    <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.26</slf4j.version>
     <shaded.guava.version>28.2-jre</shaded.guava.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.12.0</parquet.version>
     <parquet.format.version>2.8.0</parquet.format.version>


### PR DESCRIPTION
# [DRILL-7904](https://issues.apache.org/jira/browse/DRILL-7904): Update to 30-jre Guava version

## Description

* Update guava version to the newest one (30.1.1-jre)
* Drop <shaded.guava.version> at all

## Documentation
NA

## Testing
@vvysotskyi Since the original Guava shade was performed by you please advice what is needed to be tested before merging?
