### PR TITLE
DRILL-7910: Bumps commons-io from 2.4 to 2.7

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
@@ -642,8 +642,8 @@ public abstract class DrillRelOptUtil {
   /**
    * Returns whether the join condition is a simple equi-join or not. A simple equi-join is
    * defined as an two-table equality join (no self-join)
-   * @param join : input join
-   * @param joinFieldOrdinals: join field ordinal w.r.t. the underlying inputs to the join
+   * @param join input join
+   * @param joinFieldOrdinals join field ordinal w.r.t. the underlying inputs to the join
    * @return TRUE if the join is a simple equi-join (not a self-join), FALSE otherwise
    * */
   public static boolean analyzeSimpleEquiJoin(Join join, int[] joinFieldOrdinals) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/UserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/UserClientConnection.java
@@ -46,16 +46,16 @@ public interface UserClientConnection {
   /**
    * Send query result outcome to client. Outcome is returned through {@code listener}.
    *
-   * @param listener
-   * @param result
+   * @param listener The listener
+   * @param result The query result to be sent
    */
   void sendResult(RpcOutcomeListener<Ack> listener, QueryResult result);
 
   /**
    * Send query data to client. Outcome is returned through {@code listener}.
    *
-   * @param listener
-   * @param result
+   * @param listener The listener
+   * @param data The data to be sent
    */
   void sendData(RpcOutcomeListener<Ack> listener, QueryDataPackage data);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
@@ -246,10 +246,7 @@ public class FilterPushDownStrategy {
      * Rebuilds the query plan subtree to include any substitutions and removals requested
      * by the listener.
      *
-     * @param oldScan the original scan node
      * @param newGroupScan the optional replacement scan node given by the listener
-     * @param filter the original filter
-     * @param project the original optional project node
      * @param remainingPreds the Calcite predicates which the listener *does not* handle
      * and which should remain in the plan tree
      * @return a rebuilt query subtree

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <kerby.version>1.0.0</kerby.version>
     <findbugs.version>3.0.0</findbugs.version>
     <netty.tcnative.classifier />
-    <commons.io.version>2.4</commons.io.version>
+    <commons.io.version>2.7</commons.io.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
     <curator.version>5.1.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>

--- a/tools/drill-patch-review.py
+++ b/tools/drill-patch-review.py
@@ -33,9 +33,9 @@ def get_jira():
     'server': 'https://issues.apache.org/jira'
   }
   # read the config file
-  home=jira_home=os.getenv('HOME')
-  home=home.rstrip('/')
-  jira_config = dict(line.strip().split('=') for line in open(home + '/jira.ini'))
+  jira_home=os.getenv('HOME')
+  jira_home=jira_home.rstrip('/')
+  jira_config = dict(line.strip().split('=') for line in open(jira_home + '/jira.ini'))
   jira = JIRA(options,basic_auth=(jira_config['user'], jira_config['password']))
   return jira 
 

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
# [DRILL-7910](https://issues.apache.org/jira/browse/DRILL-7910): Bumps commons-io from 2.4 to 2.7

## Description
This fix addresses CVE-2021-29425.

In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like `"//../foo"`, or `"\..\foo"`, the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.
Simple solution is to update the library.

## Documentation
N/A

## Testing