### PR TITLE
DRILL-7893: Column alias is not working for a parquet file

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/ComplexToJsonPrelVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/ComplexToJsonPrelVisitor.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import org.apache.drill.exec.planner.physical.ComplexToJsonPrel;
 import org.apache.drill.exec.planner.physical.Prel;
 import org.apache.drill.exec.planner.physical.ScreenPrel;
-import org.apache.calcite.rel.RelNode;
 
 public class ComplexToJsonPrelVisitor extends BasePrelVisitor<Prel, Void, RuntimeException> {
 
@@ -34,7 +33,7 @@ public class ComplexToJsonPrelVisitor extends BasePrelVisitor<Prel, Void, Runtim
 
   @Override
   public Prel visitScreen(ScreenPrel prel, Void value) throws RuntimeException {
-    return prel.copy(prel.getTraitSet(), Collections.singletonList((RelNode)new ComplexToJsonPrel((Prel)prel.getInput())));
+    return prel.copy(prel.getTraitSet(), Collections.singletonList(new ComplexToJsonPrel((Prel) prel.getInput())));
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/InsertLocalExchangeVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/InsertLocalExchangeVisitor.java
@@ -60,6 +60,9 @@ public class InsertLocalExchangeVisitor extends BasePrelVisitor<Prel, Void, Runt
     for(Prel child : prel){
       children.add(child.accept(this, null));
     }
+    if (children.equals(prel.getInputs())) {
+      return prel;
+    }
     return (Prel) prel.copy(prel.getTraitSet(), children);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/LateralUnnestRowIDVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/LateralUnnestRowIDVisitor.java
@@ -40,7 +40,7 @@ import java.util.Map;
  */
 public class LateralUnnestRowIDVisitor extends BasePrelVisitor<Prel, Boolean, RuntimeException> {
 
-  private static LateralUnnestRowIDVisitor INSTANCE = new LateralUnnestRowIDVisitor();
+  private static final LateralUnnestRowIDVisitor INSTANCE = new LateralUnnestRowIDVisitor();
 
   public static Prel insertRowID(Prel prel){
     return prel.accept(INSTANCE, false);
@@ -51,6 +51,8 @@ public class LateralUnnestRowIDVisitor extends BasePrelVisitor<Prel, Boolean, Ru
     List<RelNode> children = getChildren(prel, isRightOfLateral);
     if (isRightOfLateral) {
       return prel.prepareForLateralUnnestPipeline(children);
+    } else if (children.equals(prel.getInputs())) {
+      return prel;
     } else {
       return (Prel) prel.copy(prel.getTraitSet(), children);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RuntimeFilterVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RuntimeFilterVisitor.java
@@ -57,13 +57,13 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RuntimeFilterVisitor extends BasePrelVisitor<Prel, Void, RuntimeException> {
 
-  private Set<ScanPrel> toAddRuntimeFilter = new HashSet<>();
+  private final Set<ScanPrel> toAddRuntimeFilter = new HashSet<>();
 
-  private Multimap<ScanPrel, HashJoinPrel> probeSideScan2hj = HashMultimap.create();
+  private final Multimap<ScanPrel, HashJoinPrel> probeSideScan2hj = HashMultimap.create();
 
-  private double fpp;
+  private final double fpp;
 
-  private int bloomFilterMaxSizeInBytesDef;
+  private final int bloomFilterMaxSizeInBytesDef;
 
   private static final AtomicLong rfIdCounter = new AtomicLong();
 
@@ -86,6 +86,9 @@ public class RuntimeFilterVisitor extends BasePrelVisitor<Prel, Void, RuntimeExc
     for (Prel child : prel) {
       child = child.accept(this, value);
       children.add(child);
+    }
+    if (children.equals(prel.getInputs())) {
+      return prel;
     }
     return (Prel) prel.copy(prel.getTraitSet(), children);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SelectionVectorPrelVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SelectionVectorPrelVisitor.java
@@ -29,7 +29,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class SelectionVectorPrelVisitor extends BasePrelVisitor<Prel, Void, RuntimeException>{
 
-  private static SelectionVectorPrelVisitor INSTANCE = new SelectionVectorPrelVisitor();
+  private static final SelectionVectorPrelVisitor INSTANCE = new SelectionVectorPrelVisitor();
 
   public static Prel addSelectionRemoversWhereNecessary(Prel prel) {
     return prel.accept(INSTANCE, null);
@@ -44,6 +44,9 @@ public class SelectionVectorPrelVisitor extends BasePrelVisitor<Prel, Void, Runt
       children.add(convert(encodings, child));
     }
 
+    if (children.equals(prel.getInputs())) {
+      return prel;
+    }
     return (Prel) prel.copy(prel.getTraitSet(), children);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
@@ -62,6 +62,9 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
       child = child.accept(this, unused);
       children.add(child);
     }
+    if (children.equals(prel.getInputs())) {
+      return prel;
+    }
     return (Prel) prel.copy(prel.getTraitSet(), children);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -544,7 +544,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
      * If two fragments are both estimated to be parallelization one, remove the exchange
      * separating them.
      */
-    phyRelNode = ExcessiveExchangeIdentifier.removeExcessiveEchanges(phyRelNode, targetSliceSize);
+    phyRelNode = ExcessiveExchangeIdentifier.removeExcessiveExchanges(phyRelNode, targetSliceSize);
 
     /* Insert the IMPLICIT_COLUMN in the lateral unnest pipeline */
     phyRelNode = LateralUnnestRowIDVisitor.insertRowID(phyRelNode);
@@ -589,7 +589,13 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
      */
     phyRelNode = SelectionVectorPrelVisitor.addSelectionRemoversWhereNecessary(phyRelNode);
 
-    /* 10.)
+    /*
+     * 10.)
+     * Insert project above the screen operator or writer to ensure that final output column names are preserved after all optimizations.
+     */
+    phyRelNode = TopProjectVisitor.insertTopProject(phyRelNode, validatedRowType);
+
+    /* 11.)
      * Finally, Make sure that the no rels are repeats.
      * This could happen in the case of querying the same table twice as Optiq may canonicalize these.
      */

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -704,6 +704,19 @@ public class TestParquetFilterPushDown extends PlanTestBase {
     testParquetFilterPruning(query, 25, 1, new String[]{"Filter\\("});
   }
 
+  @Test
+  public void testPreservingColumnAliasAfterRemovingFilter() throws Exception {
+    test("create table dfs.tmp.`testAliasTable` as select * from cp.`tpch/nation.parquet` limit 1");
+    String query = "select n_regionkey as x from dfs.tmp.`testAliasTable` where n_nationkey > -100500";
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("x")
+        .baselineValues(0)
+        .go();
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Some test helper functions.
   //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# [DRILL-7893](https://issues.apache.org/jira/browse/DRILL-7893): Column alias is not working for a parquet file

## Description
Updated visitors applied after optimizations to prevent creating unnecessary copies that will lose actual row type.
Added a call to create a top project after all optimizations to ensure that column names will match the name from row type.

## Documentation
NA

## Testing
Added unit test.
