### PR TITLE
 DRILL-7912: Add Sheet Names to Excel Reader

### DIFF
--- a/contrib/format-excel/README.md
+++ b/contrib/format-excel/README.md
@@ -67,6 +67,7 @@ The fields are:
     _created
     _last_printed
     _modified
+    _sheets
 
 
 ### Known Limitations:

--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>3.0.3</version>
+      <version>3.0.4</version>
     </dependency>
   </dependencies>
   <build>

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -237,9 +237,6 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void getColumnHeaders(SchemaBuilder builder) {
-    //Get the field names
-    int columnCount;
-
     // Case for empty sheet
     if (sheet.getLastRowNum() == 0) {
       builder.buildSchema();
@@ -253,7 +250,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
 
     // Get the number of columns.
     // This menthod also advances the row reader to the location of the first row of data
-    columnCount = getColumnCount();
+    setFirstRow();
 
     excelFieldNames = new ArrayList<>();
     cellWriterArray = new ArrayList<>();
@@ -345,11 +342,10 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   /**
-   * Returns the column count.  There are a few gotchas here in that we have to know the header row and count the physical number of cells
+   * There are a few gotchas here in that we have to know the header row and count the physical number of cells
    * in that row.  This function also has to move the rowIterator object to the first row of data.
-   * @return The number of actual columns
    */
-  private int getColumnCount() {
+  private void setFirstRow() {
     // Initialize
     currentRow = rowIterator.next();
     int rowNumber = readerConfig.headerRow > 0 ? sheet.getFirstRowNum() : 0;
@@ -359,8 +355,6 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
     for (int i = 1; i < rowNumber; i++) {
       currentRow = rowIterator.next();
     }
-
-    return currentRow.getPhysicalNumberOfCells();
   }
 
   @Override

--- a/contrib/format-excel/src/test/java/org/apache/drill/exec/store/excel/TestExcelFormat.java
+++ b/contrib/format-excel/src/test/java/org/apache/drill/exec/store/excel/TestExcelFormat.java
@@ -38,6 +38,7 @@ import org.junit.experimental.categories.Category;
 import java.nio.file.Paths;
 
 import static org.apache.drill.test.QueryTestUtil.generateCompressedFile;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -509,6 +510,22 @@ public class TestExcelFormat extends ClusterTest {
     "America/Puerto_Rico")
       .addRow(606.0, 18.16724, -66.93828, "Maricao", "PR", "Puerto Rico", "TRUE", 0.0, 6437.0, 60.4, 72093.0, "Maricao", "{'72093':94.88,'72121':1.35,'72153':3.78}", "Maricao|Yauco" +
     "|Sabana Grande", "72093|72153|72121", "FALSE", "FALSE", "America/Puerto_Rico")
+      .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testGetSheetNames() throws RpcException {
+    String sql = "SELECT _sheets FROM dfs.`excel/test_data.xlsx` LIMIT 1";
+
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    TupleMetadata expectedSchema = new SchemaBuilder()
+      .addArray("_sheets", MinorType.VARCHAR)
+      .buildSchema();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+      .addRow((Object)strArray("data", "secondSheet", "thirdSheet", "fourthSheet", "emptySheet", "missingDataSheet", "inconsistentData", "comps"))
       .build();
 
     new RowSetComparison(expected).verifyAndClearAll(results);


### PR DESCRIPTION
# [DRILL-7912](https://issues.apache.org/jira/browse/DRILL-7912): Add Sheet Names to Excel Reader and Update Reader Version

## Description
Currently, there was no way to determine what sheets are available in a given Excel file.  This minor PR adds a new implicit metadata field called `_sheets` which a user can use to determine what sheets are available.  By definition, Excel files must have at least one sheet.

Additionally, I updated the streaming reader to the latest version.

## Documentation
Updated `README` to reflect the additional field, but to determine the available sheets, a user could execute the query below:

```sql
SELECT FLATTEN(_sheets) AS sheetNames 
FROM <Excel File>
```

## Testing
Added additional unit test. 
