### PR TITLE
[Minor Update] Add reset button and reduce the dialog text

### DIFF
--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -85,6 +85,10 @@
       Submit
     </button>
     &nbsp;&nbsp;&nbsp;
+    <button class="btn btn-secondary" type="button" onclick="resetQuery()">
+      Reset
+    </button>
+    &nbsp;&nbsp;&nbsp;
     <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>>
       Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*">
       rows <span class="material-icons" title="Limits the number of records retrieved in the query.

--- a/exec/java-exec/src/main/resources/rest/runningQuery.ftl
+++ b/exec/java-exec/src/main/resources/rest/runningQuery.ftl
@@ -27,7 +27,7 @@
         </div>
         <div class="modal-body" style="line-height:3">
             <table border="0px" width="100%"><tr>
-                <td align="center" style="font-size:125%">Waiting for results... (This may take some time) <br>Please don't close this window</td>
+                <td align="center" style="font-size:125%">Waiting for results...<br>Please don't close this window</td>
                 <td align="right"><img src="/static/img/loader.gif"></td>
             </tr></table>
         </div>

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -86,3 +86,10 @@ function submitQuery() {
     $("#queryForm").submit();
     $(window).bind("pageshow", function(event) { closePopup();});
 }
+
+//Reset Query
+function resetQuery() {
+	var editor = ace.edit("query-editor-format");
+	editor.getSession().setValue("");
+	editor.focus();
+}


### PR DESCRIPTION
# [Minor Update] Add reset button and reduce the dialog text

## Description

1. Reduce the text of `Loading dialog` (optimize the layout).
2. Add `Reset` button for quickly reset the Long-SQL-Text.

## Documentation
N/A

## Testing
![image](https://user-images.githubusercontent.com/50079619/116801893-b782ee80-ab40-11eb-915d-12707c956725.png)