### PR TITLE
DRILL-7918: Dependency Updates for CVE

### DIFF
--- a/contrib/storage-kudu/pom.xml
+++ b/contrib/storage-kudu/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.kudu</groupId>
       <artifactId>kudu-client</artifactId>
-      <version>1.3.0</version>
+      <version>1.14.0</version>
     </dependency>
 
   </dependencies>

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduRecordReader.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduRecordReader.java
@@ -60,10 +60,10 @@ import org.apache.kudu.client.KuduScanner.KuduScannerBuilder;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.RowResult;
 import org.apache.kudu.client.RowResultIterator;
-import org.apache.kudu.client.shaded.com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class KuduRecordReader extends AbstractRecordReader {

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     -->
     <calcite.groupId>com.github.vvysotskyi.drill-calcite</calcite.groupId>
     <calcite.version>1.21.0-drill-r2</calcite.version>
-    <avatica.version>1.15.0</avatica.version>
+    <avatica.version>1.17.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.9.0</sqlline.version>
     <jackson.version>2.12.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     -->
     <hive.version>3.1.2</hive.version>
     <hadoop.version>3.2.1</hadoop.version>
-    <hbase.version>2.2.2</hbase.version>
+    <hbase.version>2.4.2</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>
     <javassist.version>3.27.0-GA</javassist.version>


### PR DESCRIPTION
# [DRILL-7918](https://issues.apache.org/jira/browse/DRILL-7918): Dependency Updates for CVE

## Description
This PR updates several dependencies to address outstanding CVEs.

The updates are:

* Kudu from version 1.3 to 1.7
* Avatica from version 1.15 to 1.17
* HBase from 2.2.2 to 2.4.2


## Documentation
N/A

## Testing
(Please describe how this PR has been tested.)
