### PR TITLE
DRILL-7911 Disable maven-surefire-plugin for Splunk for ARM Build

### DIFF
--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -96,4 +96,30 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>linux-aarch64</id>
+      <activation>
+        <os>
+          <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <!-- DRILL-7911: There is no Docker image for Linux ARM64 -->
+                <skip>true</skip>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -99,11 +99,10 @@
 
   <profiles>
     <profile>
-      <id>linux-aarch64</id>
+      <id>non-x86_64</id>
       <activation>
         <os>
-          <family>linux</family>
-          <arch>aarch64</arch>
+          <arch>!amd64</arch>
         </os>
       </activation>
       <build>
@@ -113,7 +112,7 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
-                <!-- DRILL-7911: There is no Docker image for Linux ARM64 -->
+                <!-- DRILL-7911: There is no Docker image for non-Linux/AMD64 -->
                 <skip>true</skip>
               </configuration>
             </plugin>


### PR DESCRIPTION
# [DRILL-7911](https://issues.apache.org/jira/browse/DRILL-7911): Disable maven-surefire-plugin for Splunk on ARM Build

## Description

Disable running the unit tests for Contrib Storage Splunk for Linux ARM64 because there is no Docker image for splunk/splunk

## Documentation
No user visible changes. Only the unit tests are disabled for Contrib Storage Splunk module because there is no Docker image for `splunk/splunk` for Linux/arm64

## Testing
`mvn test` now passes for Contrib Storage Splunk module because the tests are skipped.