### PR TITLE
DRILL-7911 Increase the max direct memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <asm.version>7.3.1</asm.version>
     <excludedGroups />
     <memoryMb>4000</memoryMb>
-    <directMemoryMb>2500</directMemoryMb>
+    <directMemoryMb>3000</directMemoryMb>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>
     <docker.repository>apache/drill</docker.repository>


### PR DESCRIPTION
# [DRILL-7911](https://issues.apache.org/jira/browse/DRILL-7911): Increase the max direct memory

## Description

It seems 2500Mb is not enough on Linux ARM64

Fixes errors like:
```
[ERROR] Tests run: 19, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 5.039 s <<< FAILURE! - in org.apache.drill.exec.record.vector.TestValueVector
[ERROR] org.apache.drill.exec.record.vector.TestValueVector.testFixedVectorReallocation  Time elapsed: 0.037 s  <<< ERROR!
java.lang.Exception: Unexpected exception, expected<org.apache.drill.exec.exception.OversizedAllocationException> but was<org.apache.drill.exec.exception.OutOfMemoryException>
	at org.apache.drill.exec.record.vector.TestValueVector.testFixedVectorReallocation(TestValueVector.java:107)
Caused by: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 2147483644 byte(s) of direct memory (used: 872415232, max: 2621440000)
	at org.apache.drill.exec.record.vector.TestValueVector.testFixedVectorReallocation(TestValueVector.java:107)
```

## Documentation

Another way to "fix" this issue is to pass `-DdirectMemoryMb=3000` only for builds on Linux ARM64. In this case this will have to be documented in the README and https://drill.apache.org/docs/apache-drill-contribution-guidelines/

## Testing

There are no code changes.