### PR TITLE
DRILL-7923 Use TravisCI for building and testing on Linux ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: TravisCI is used only for testing on Linux ARM64
+# The testing on x86_64 is done on Github Actions
+
+dist: focal
+language: generic
+sudo: required
+arch: arm64-graviton2
+virt: vm
+group: edge
+
+# install JDK and Maven from Ubuntu repos because TravisCI has no JDK 1.8 for ARM64 images
+addons:
+  apt:
+    update: true
+    packages:
+      - openjdk-8-jdk
+      - maven
+      - unzip
+
+matrix:
+  fast_finish: true
+  include:
+    - env: PHASE=tests
+    - env: PHASE=build_checkstyle_protobuf
+
+cache:
+  directories:
+    - "$HOME/.m2"
+    - "$HOME/protobuf"
+before_install:
+  - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64"
+  - export PATH="$JAVA_HOME/bin:$PATH"
+  - java -version
+  - mvn -version
+  - git fetch --unshallow
+  # Install libraries required for protobuf generation
+  - |
+    if [ $PHASE = "build_checkstyle_protobuf" ]; then \
+      sudo apt-get install -y libboost-all-dev libzookeeper-mt-dev libsasl2-dev cmake libcppunit-dev checkinstall && \
+      pushd .. && \
+      if [ -f $HOME/protobuf/protobuf_3.11.1* ]; then \
+        sudo dpkg -i $HOME/protobuf/protobuf_3.11.1*; \
+      else \
+        wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.1/protobuf-java-3.11.1.zip && \
+        unzip protobuf-java-3.11.1.zip && pushd protobuf-3.11.1 && \
+        ./configure && sudo make && sudo checkinstall -y && \
+        if [ ! -d $HOME/protobuf ]; then \
+          mkdir -p $HOME/protobuf; \
+        fi && \
+        mv protobuf_3.11.1* $HOME/protobuf/ && popd; \
+      fi && \
+      sudo ldconfig && popd; \
+    fi
+install:
+  # For tests phase runs unit tests
+  # For protobuf phase: builds Drill project, performs license checkstyle goal and regenerates Java and C++ Protobuf files
+  - |
+    if [ $PHASE = "tests" ]; then \
+      mvn install --batch-mode --no-transfer-progress \
+        -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" \
+        -DmemoryMb=1300 -DdirectMemoryMb=3000; \
+    elif [ $PHASE = "build_checkstyle_protobuf" ]; then \
+      MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --no-transfer-progress -Drat.skip=false -Dlicense.skip=false --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true && \
+      pushd protocol && mvn process-sources -P proto-compile && popd && \
+      mkdir contrib/native/client/build && pushd contrib/native/client/build && /usr/bin/cmake -G "Unix Makefiles" .. && make cpProtobufs && popd; \
+    fi
+script:
+  # Checks whether project files weren't changed after regenerating protobufs
+  - |
+    if [ "$(git status -s | grep -c "")" -gt 0 ]; then \
+      echo "The following changes are found in files after regenerating protobufs (output may be used as a patch to apply):" >&2 &&
+      echo "$(git diff --color)" && \
+      exit 1; \
+    else
+      echo "All checks are passed!";
+    fi

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <codemodel.version>2.6</codemodel.version>
     <joda.version>2.10.5</joda.version>
     <javax.el.version>3.0.0</javax.el.version>
-    <surefire.version>3.0.0-M4</surefire.version>
+    <surefire.version>3.0.0-M5</surefire.version>
     <commons.compress.version>1.20</commons.compress.version>
     <hikari.version>3.4.2</hikari.version>
     <netty.version>4.1.59.Final</netty.version>


### PR DESCRIPTION
# [DRILL-7923](https://issues.apache.org/jira/browse/DRILL-7923): Use TravisCI for building and testing on Linux ARM64

## Description

As discussed at https://lists.apache.org/thread.html/r6af8d66c10e36c9610fb28db2f29aba650e66b9bae5eafc7d7183000%40%3Cdev.drill.apache.org%3E TravisCI could be re-introduced for building and testing Drill on Linux ARM64.

The content of .travis.yml is copied from tag drill-1.17.0 and modified slightly to build on Linux ARM64 at AWS Graviton2 build nodes.

This PR depends on https://github.com/apache/drill/pull/2217, https://github.com/apache/drill/pull/2218 and https://github.com/apache/drill/pull/2219. The build will fail before those are merged. 

## Documentation

The documentation at the website could be updated to mention that all PRs are automatically tested on Linux ARM64 at TravisCI.

## Testing

This PR introduces additional testing on Linux ARM64 hardware at TravisCI.