### PR TITLE
DRILL-7925 Use .asf.yaml for the website

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+publish:
+   whoami: asf-site
+

--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,6 @@ sass:
 
 plugins:
   - jekyll-redirect-from
+
+include:
+  - .asf.yaml


### PR DESCRIPTION
# [DRILL-7925](https://issues.apache.org/jira/browse/DRILL-7925): Use .asf.yaml

## Description

As requested by Apache Infra team with https://lists.apache.org/thread.html/r8d023c0f5afefca7f6ce4e26d02404762bd6234fbe328011e1564249%40%3Cusers.infra.apache.org%3E

## Documentation
N/A

## Testing
N/A
