### PR TITLE
DRILL-7922: Add feature of viewing external profile in web UI

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/list.ftl
@@ -84,6 +84,14 @@
         $("#queryCancelModal").modal("show");
     }
 
+    //Trigger the click event of file input and submit the file selected to the server
+    function viewProfile() {
+        $("#view-profile-file").change(function() {
+            $("#view-profile").submit();
+            this.value = null;
+        });
+        $("#view-profile-file").trigger("click");
+    }
 </script>
 
 <!-- CSS to control DataTable Elements -->
@@ -172,6 +180,11 @@
         <form name="profileFetch" action="/profiles" onsubmit="return checkMaxFetch();" method="get"><span title="Max number of profiles to load">Loaded <b>${model.getFinishedQueries()?size}</b> profiles </span>
         <input id="fetchMax" type="text" size="5" name="max" value="" style="text-align: right" />
         <input type="submit" value="Reload"/>
+      </form></td>
+      <td align="right" width="1px">
+        <form id="view-profile" action="/profiles/view" enctype='multipart/form-data' method="post">
+        <input type="file" id="view-profile-file" name="profileData" style="display: none"/>
+        <input type="button" value="View" onclick = "viewProfile()"/>
       </form></td>
     </tr></table>
     <!-- Placed after textbox to allow for DOM to contain "fetchMax" element -->


### PR DESCRIPTION
# [DRILL-7922](https://issues.apache.org/jira/browse/DRILL-7922): Add import profile function

## Description
Usage scenario:
Analysis the profile json exported from other clusters(ex. user's cluster). The original profile json is not readable (time type is epoch time), so it will be better to view it in the detailed profile web console.

## Documentation
To upload the profile json file(need to be the same format as the json profile exported from the detailed profile web console) and view it on the web console:
- click import button on the Profiles tab of Web-UI
![image](https://user-images.githubusercontent.com/25920008/118363081-46721b00-b5c5-11eb-99a0-ec48c460b2e7.png)
- select the profile file you want to view
![image](https://user-images.githubusercontent.com/25920008/118351326-f4fa6980-b58d-11eb-8aff-eb1ea346fd7f.png)
- the profile will be displayed as nomal query profile
![image](https://user-images.githubusercontent.com/25920008/118351355-1b200980-b58e-11eb-9ebd-934c619b1222.png)

## Testing
NA