### PR TITLE
Create .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,7 +1,7 @@
 # https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
 
 github:
-description: "Apache Drill: An open source distributed query engine for self describing data."
+  description: "Apache Drill: An open source distributed query engine for self describing data."
   homepage: https://drill.apache.org/
   labels:
     - drill

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,8 +12,8 @@ github:
     - hadoop
     - jdbc
     - parquet
-
-features:
+  
+  features:
     # Enable wiki for documentation
     wiki: true
     # Enable issue management

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,7 +1,7 @@
 # https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
 
 github:
-  description: "Apache Drill: An open source distributed query engine for self describing data."
+  description: "Apache Drill is a distributed MPP query layer for self describing data"
   homepage: https://drill.apache.org/
   labels:
     - drill

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,22 @@
+# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+
+github:
+description: "Apache Drill: An open source distributed query engine for self describing data."
+  homepage: https://drill.apache.org/
+  labels:
+    - drill
+    - sql
+    - big-data
+    - java
+    - hive
+    - hadoop
+    - jdbc
+    - parquet
+
+features:
+    # Enable wiki for documentation
+    wiki: true
+    # Enable issue management
+    issues: true
+    # Enable projects for project management boards
+    projects: true

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
             <exclude>**/clientlib/y2038/*.c</exclude> <!-- All the files here should have MIT License -->
             <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->
             <exclude>**/resources/parquet/**/*</exclude>
+            <exclude>**/.asf.yaml</exclude>
             <exclude>**/*.woff2</exclude>
             <exclude>**/*.ks</exclude>
             <exclude>**/*.pcap</exclude>
@@ -677,6 +678,7 @@
               <exclude>**/clientlib/y2038/*.c</exclude> <!-- All the files here should have MIT License -->
               <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->
               <exclude>**/resources/parquet/**/*</exclude>
+              <exclude>**/.asf.yaml</exclude>
               <exclude>**/*.woff2</exclude>
               <exclude>**/*.ks</exclude>
               <exclude>**/*.pcap</exclude>


### PR DESCRIPTION
# Add `.asf.yaml` to `master` branch.

## Description
See: https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories.
This PR turns on wikis and issues in github.   Per conversations in slack, we decided that it would be useful to migrate developer docs to github wikis rather than random `README` files.  


## Documentation
N/A

## Testing
N/A
