### PR TITLE
DRILL-7928: Add fourth parameter for split_part udf

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -70,24 +70,6 @@ public class TestStringFunctions extends BaseTestQuery {
         .baselineValues("rty")
         .go();
 
-    // invalid index
-    boolean expectedErrorEncountered;
-    try {
-      testBuilder()
-          .sqlQuery("select split_part('abc~@~def~@~ghi', '~@~', 0) res1 from (values(1))")
-          .ordered()
-          .baselineColumns("res1")
-          .baselineValues("abc")
-          .go();
-      expectedErrorEncountered = false;
-    } catch (Exception ex) {
-      assertTrue(ex.getMessage().contains("Index in split_part must be positive, value provided was 0"));
-      expectedErrorEncountered = true;
-    }
-    if (!expectedErrorEncountered) {
-      throw new RuntimeException("Missing expected error on invalid index for split_part function");
-    }
-
     // with a multi-byte splitter
     testBuilder()
         .sqlQuery("select split_part('abc\\u1111drill\\u1111ghi', '\\u1111', 2) res1 from (values(1))")
@@ -111,6 +93,102 @@ public class TestStringFunctions extends BaseTestQuery {
         .baselineColumns("res1")
         .baselineValues("a,b,c")
         .go();
+  }
+
+  @Test
+  public void testSplitPartStartEnd() throws Exception {
+    testBuilder()
+      .sqlQuery("select split_part(a, '~@~', 1, 2) res1 from (" +
+        "values('abc~@~def~@~ghi'), ('qwe~@~rty~@~uio')) as t(a)")
+      .ordered()
+      .baselineColumns("res1")
+      .baselineValues("abc~@~def")
+      .baselineValues("qwe~@~rty")
+      .go();
+
+    testBuilder()
+      .sqlQuery("select split_part(a, '~@~', 2, 3) res1 from (" +
+        "values('abc~@~def~@~ghi'), ('qwe~@~rty~@~uio')) as t(a)")
+      .ordered()
+      .baselineColumns("res1")
+      .baselineValues("def~@~ghi")
+      .baselineValues("rty~@~uio")
+      .go();
+
+    // with a multi-byte splitter
+    testBuilder()
+      .sqlQuery("select split_part('abc\\u1111drill\\u1111ghi', '\\u1111', 2, 2) " +
+        "res1 from (values(1))")
+      .ordered()
+      .baselineColumns("res1")
+      .baselineValues("drill")
+      .go();
+
+    // start index going beyond the last available index, returns empty string
+    testBuilder()
+      .sqlQuery("select split_part('a,b,c', ',', 4, 5) res1 from (values(1))")
+      .ordered()
+      .baselineColumns("res1")
+      .baselineValues("")
+      .go();
+
+    // end index going beyond the last available index, returns remaining string
+    testBuilder()
+      .sqlQuery("select split_part('a,b,c', ',', 1, 10) res1 from (values(1))")
+      .ordered()
+      .baselineColumns("res1")
+      .baselineValues("a,b,c")
+      .go();
+
+    // if the delimiter does not appear in the string, 1 returns the whole string
+    testBuilder()
+      .sqlQuery("select split_part('a,b,c', ' ', 1, 2) res1 from (values(1))")
+      .ordered()
+      .baselineColumns("res1")
+      .baselineValues("a,b,c")
+      .go();
+  }
+
+  @Test
+  public void testInvalidSplitPartParameters() {
+    boolean expectedErrorEncountered;
+    try {
+      testBuilder()
+        .sqlQuery("select split_part('abc~@~def~@~ghi', '~@~', 0) res1 from " +
+          "(values(1))")
+        .ordered()
+        .baselineColumns("res1")
+        .baselineValues("abc")
+        .go();
+      expectedErrorEncountered = false;
+    } catch (Exception ex) {
+      assertTrue(ex.getMessage().contains("Index in split_part must be positive, " +
+        "value provided was 0"));
+      expectedErrorEncountered = true;
+    }
+    if (!expectedErrorEncountered) {
+      throw new RuntimeException("Missing expected error on invalid index for " +
+        "split_part function");
+    }
+
+    try {
+      testBuilder()
+        .sqlQuery("select split_part('abc~@~def~@~ghi', '~@~', 2, 1) res1 from " +
+          "(values(1))")
+        .ordered()
+        .baselineColumns("res1")
+        .baselineValues("abc")
+        .go();
+      expectedErrorEncountered = false;
+    } catch (Exception ex) {
+      assertTrue(ex.getMessage().contains("End in split_part must be greater " +
+        "than or equal to start"));
+      expectedErrorEncountered = true;
+    }
+    if (!expectedErrorEncountered) {
+      throw new RuntimeException("Missing expected error on invalid index for " +
+        "split_part function");
+    }
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-7928](https://issues.apache.org/jira/browse/DRILL-7928): Add fourth parameter for split_part udf

## Description
Add the fourth parameter in split_part udf as end index: suport split_part('a,b,c,d', ',' , 1, 2) = 'a,b'
Return all remaining string if end indx is greater then splitted string length

## Documentation
string split_part(string input, string delimiter, bigint start, bigint end)
user doc updated in [PR](https://github.com/apache/drill/pull/2229)

## Testing
New test added in org.apache.drill.exec.expr.fn.impl.TestStringFunctions.testSplitPartStartEnd