### PR TITLE
DRILL-7929: Update Kafka unit tests to use ClusterTest

### DIFF
--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaFilterPushdownTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaFilterPushdownTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.kafka;
 
-import org.apache.drill.PlanTestBase;
 import org.apache.drill.categories.KafkaStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -59,8 +58,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString, expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -75,8 +77,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString, expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -91,8 +96,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -108,8 +116,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowInPlan)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowInPlan))
+        .match();
   }
 
   /**
@@ -124,8 +135,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -140,8 +154,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -157,8 +174,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -174,48 +194,66 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset = 10");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"equal" such that value < startOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset = -1");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"greater_than" such that value = endOffset-1
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset > 9");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"greater_than_or_equal" such that value = endOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset >= 10");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"less_than" such that value = startOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset < 0");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"less_than_or_equal" such that value < startOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset <= -1");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -231,24 +269,33 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset = 9");
 
     runKafkaSQLVerifyCount(queryString, expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"greater_than" such that value = endOffset-2
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset > 8");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
 
     //"greater_than_or_equal" such that value = endOffset-1
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset >= 9");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -265,8 +312,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -283,8 +333,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowInPlan)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowInPlan))
+        .match();
   }
 
   /**
@@ -301,8 +354,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2, predicate3);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCount)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCount))
+        .match();
   }
 
   /**
@@ -321,8 +377,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2, predicate3, predicate4);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCountInPlan)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCountInPlan))
+        .match();
   }
 
   /**
@@ -340,8 +399,11 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCountInPlan)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCountInPlan))
+        .match();
   }
 
   /**
@@ -360,7 +422,10 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2, predicate3);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    PlanTestBase.testPlanMatchingPatterns(queryString, JSON_FORMAT,
-        new String[] {String.format(EXPECTED_PATTERN, expectedRowCountInPlan)}, null);
+    queryBuilder()
+        .sql(queryString)
+        .jsonPlanMatcher()
+        .include(String.format(EXPECTED_PATTERN, expectedRowCountInPlan))
+        .match();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -672,6 +672,18 @@ public class QueryBuilder {
     return new PlanMatcher(plan);
   }
 
+  /**
+   * Submits explain plan statement
+   * and creates plan matcher instance based on return query plan.
+   *
+   * @return plan matcher
+   * @throws Exception if the query fails
+   */
+  public PlanMatcher jsonPlanMatcher() throws Exception {
+    String plan = explainJson();
+    return new PlanMatcher(plan);
+  }
+
   private QuerySummary produceSummary(BufferingQueryEventListener listener) throws Exception {
     long start = System.currentTimeMillis();
     int recordCount = 0;


### PR DESCRIPTION
# [DRILL-7929](https://issues.apache.org/jira/browse/DRILL-7929): Update Kafka unit tests to use ClusterTest

## Description
Replaced deprecated `PlanTestBase` with `ClusterTest` and updated tests

## Documentation
NA

## Testing
Checked that tests pass.
