### PR TITLE
DRILL-7930: Fix GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Build and test
-        run: mvn install -V -ntp -DdirectMemoryMb=4500 -DmemoryMb=1300
+        run: mvn install -V -ntp -DdirectMemoryMb=2500 -DmemoryMb=2000 # Note: the total GitHub Actions memory is 7000Mb
 
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     name: Main Build
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 100
     strategy:
       matrix:
         # Java versions to run unit tests


### PR DESCRIPTION
# [DRILL-7930](https://issues.apache.org/jira/browse/DRILL-7930): Fix GitHub actions

## Description

Fix Github memory issues
It should be draft PR until the build will be contentiously green

## Testing

This draft PR is aimed to run GitHub actions and fix the issues