### PR TITLE
DRILL-7932: Update Hadoop to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       for example parquet-hadoop-bundle and derby dependencies.
     -->
     <hive.version>3.1.2</hive.version>
-    <hadoop.version>3.2.1</hadoop.version>
+    <hadoop.version>3.2.2</hadoop.version>
     <hbase.version>2.4.2</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>


### PR DESCRIPTION
# [DRILL-7932](https://issues.apache.org/jira/browse/DRILL-7932): Update Hadoop to 3.2.2

## Description

Update Hadoop to the latest version of the 3.2.x branch and pick up some security fixes along the way.

## Documentation
N/A

## Testing
Run test suite
