### PR TITLE
DRILL-7135: Update to Jetty 9.4

### DIFF
--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/WebServer.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/WebServer.java
@@ -42,6 +42,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.drill.exec.server.rest.CsrfTokenInjectFilter;
 import org.apache.drill.exec.server.rest.CsrfTokenValidateFilter;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.yarn.appMaster.Dispatcher;
 import org.apache.drill.yarn.core.DrillOnYarnConfig;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
@@ -65,11 +66,9 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.server.handler.ErrorHandler;
-import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -79,7 +78,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.joda.time.DateTime;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 
 /**
@@ -306,7 +304,7 @@ public class WebServer implements AutoCloseable {
   }
 
   /**
-   * It creates A {@link SessionHandler} which contains a {@link HashSessionManager}
+   * It creates A {@link SessionHandler}
    *
    * @param config Drill configs
    * @param securityHandler Set of initparameters that are used by the Authentication
@@ -314,10 +312,10 @@ public class WebServer implements AutoCloseable {
    */
   private SessionHandler createSessionHandler(Config config,
       final SecurityHandler securityHandler) {
-    SessionManager sessionManager = new HashSessionManager();
-    sessionManager.setMaxInactiveInterval(
+    SessionHandler sessionHandler = new SessionHandler();
+    sessionHandler.setMaxInactiveInterval(
         config.getInt(DrillOnYarnConfig.HTTP_SESSION_MAX_IDLE_SECS));
-    sessionManager.addEventListener(new HttpSessionListener() {
+    sessionHandler.addEventListener(new HttpSessionListener() {
       @Override
       public void sessionCreated(HttpSessionEvent se) {
         // No-op
@@ -340,7 +338,7 @@ public class WebServer implements AutoCloseable {
       }
     });
 
-    return new SessionHandler(sessionManager);
+    return sessionHandler;
   }
 
   /**

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -503,6 +503,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -27,8 +27,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.server.rest.header.ResponseHeadersSettingFilter;
-import org.apache.drill.exec.server.rest.ssl.SslContextFactoryConfigurator;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.expr.fn.registry.FunctionHolder;
 import org.apache.drill.exec.expr.fn.registry.LocalFunctionRegistry;
@@ -40,6 +38,8 @@ import org.apache.drill.exec.server.options.OptionValidator.OptionDescription;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.rest.auth.DrillErrorHandler;
 import org.apache.drill.exec.server.rest.auth.DrillHttpSecurityHandlerProvider;
+import org.apache.drill.exec.server.rest.header.ResponseHeadersSettingFilter;
+import org.apache.drill.exec.server.rest.ssl.SslContextFactoryConfigurator;
 import org.apache.drill.exec.work.WorkManager;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.security.SecurityHandler;
@@ -49,10 +49,8 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ErrorHandler;
-import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -266,17 +264,18 @@ public class WebServer implements AutoCloseable {
   }
 
   /**
-   * Create a {@link SessionHandler} which contains a {@link HashSessionManager}
+   * Create a {@link SessionHandler}
    *
    * @param securityHandler Set of init parameters that are used by the Authentication
    * @return session handler
    */
   private SessionHandler createSessionHandler(final SecurityHandler securityHandler) {
-    SessionManager sessionManager = new HashSessionManager();
-    sessionManager.setMaxInactiveInterval(config.getInt(ExecConstants.HTTP_SESSION_MAX_IDLE_SECS));
+    SessionHandler sessionHandler = new SessionHandler();
+    //SessionManager sessionManager = new HashSessionManager();
+    sessionHandler.setMaxInactiveInterval(config.getInt(ExecConstants.HTTP_SESSION_MAX_IDLE_SECS));
     // response cookie will be returned with HttpOnly flag
-    sessionManager.getSessionCookieConfig().setHttpOnly(true);
-    sessionManager.addEventListener(new HttpSessionListener() {
+    sessionHandler.getSessionCookieConfig().setHttpOnly(true);
+    sessionHandler.addEventListener(new HttpSessionListener() {
       @Override
       public void sessionCreated(HttpSessionEvent se) { }
 
@@ -305,7 +304,7 @@ public class WebServer implements AutoCloseable {
       }
     });
 
-    return new SessionHandler(sessionManager);
+    return sessionHandler;
   }
 
   public int getPort() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.server.rest.auth;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
-import org.eclipse.jetty.security.MappedLoginService.RolePrincipal;
+import org.eclipse.jetty.security.AbstractLoginService.RolePrincipal;
 
 import java.security.Principal;
 import java.util.List;

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       for example parquet-hadoop-bundle and derby dependencies.
     -->
     <hive.version>3.1.2</hive.version>
-    <hadoop.version>3.2.1</hadoop.version>
+    <hadoop.version>3.2.2</hadoop.version>
     <hbase.version>2.4.2</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.9.1</avro.version>
     <metrics.version>4.0.2</metrics.version>
-    <jetty.version>9.3.28.v20191105</jetty.version>
+    <jetty.version>9.4.41.v20210516</jetty.version>
     <jersey.version>2.25.1</jersey.version>
     <asm.version>7.3.1</asm.version>
     <excludedGroups />
@@ -2850,43 +2850,10 @@
           <!--Eclipse Jetty dependecies-->
           <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
+            <artifactId>jetty-bom</artifactId>
             <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-            <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-security</artifactId>
-            <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-            <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-io</artifactId>
-            <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${jetty.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-xml</artifactId>
-            <version>${jetty.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
           </dependency>
           <!--Eclipse Jetty dependecies-->
 


### PR DESCRIPTION
# [DRILL-7135](https://issues.apache.org/jira/browse/DRILL-7135): Update to Jetty 9.4 and Hadoop 3.2.2

## Description

Jetty 9.3 is not a supported version anymore and doesn't get any
security fixes.

Update Jetty version used by Drill to the latest 9.4 version (9.4.41). This also requires updating to Hadoop 3.2.2, which is also based on Jetty 9.4.x.


## Documentation
N/A

## Testing
N/A
