### PR TITLE
DRILL-7933: Update OkHTTP to Version 4.9.1

### DIFF
--- a/contrib/storage-http/pom.xml
+++ b/contrib/storage-http/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Storage : HTTP</name>
 
   <properties>
-    <okhttp.version>4.5.0</okhttp.version>
+    <okhttp.version>4.9.1</okhttp.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# [DRILL-7933](https://issues.apache.org/jira/browse/DRILL-7933): Update OkHTTP to Version 4.9.1

## Description
Update OkHTTP to version 4.9.1.

## Documentation
No user facing changes.

## Testing
Existing unit tests pass. 
