### PR TITLE
DRILL-5940: Add support for Avro messages with schema registry for Kafka

### DIFF
--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -35,6 +35,21 @@
     <kafka.TestSuite>**/TestKafkaSuit.class</kafka.TestSuite>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <name>Confluent</name>
+      <url>https://packages.confluent.io/maven/</url>
+      <releases>
+        <enabled>true</enabled>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -76,6 +91,12 @@
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-avro-serializer</artifactId>
+      <version>6.1.1</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
@@ -17,70 +17,56 @@
  */
 package org.apache.drill.exec.store.kafka;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.ops.FragmentContext;
-import org.apache.drill.exec.ops.OperatorContext;
-import org.apache.drill.exec.physical.impl.OutputMutator;
-import org.apache.drill.exec.store.AbstractRecordReader;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.kafka.decoders.MessageReader;
 import org.apache.drill.exec.store.kafka.decoders.MessageReaderFactory;
-import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import java.io.IOException;
 
-public class KafkaRecordReader extends AbstractRecordReader {
+public class KafkaRecordReader implements ManagedReader<SchemaNegotiator> {
   private static final Logger logger = LoggerFactory.getLogger(KafkaRecordReader.class);
-
-  private static final long DEFAULT_MESSAGES_PER_BATCH = 4000;
 
   private final ReadOptions readOptions;
   private final KafkaStoragePlugin plugin;
   private final KafkaPartitionScanSpec subScanSpec;
+  private final int maxRecords;
 
-  private VectorContainerWriter writer;
   private MessageReader messageReader;
-
   private long currentOffset;
   private MessageIterator msgItr;
-  private int currentMessageCount;
 
-  public KafkaRecordReader(KafkaPartitionScanSpec subScanSpec, List<SchemaPath> projectedColumns,
-      FragmentContext context, KafkaStoragePlugin plugin) {
-    setColumns(projectedColumns);
-    this.readOptions = new ReadOptions(context.getOptions());
+  public KafkaRecordReader(KafkaPartitionScanSpec subScanSpec, OptionManager options, KafkaStoragePlugin plugin, int maxRecords) {
+    this.readOptions = new ReadOptions(options);
     this.plugin = plugin;
     this.subScanSpec = subScanSpec;
+    this.maxRecords = maxRecords;
   }
 
   @Override
-  protected Collection<SchemaPath> transformColumns(Collection<SchemaPath> projectedColumns) {
-    Set<SchemaPath> transformed = new LinkedHashSet<>();
-    if (isStarQuery()) {
-      transformed.add(SchemaPath.STAR_COLUMN);
-    } else {
-      transformed.addAll(projectedColumns);
-    }
-    return transformed;
-  }
+  public boolean open(SchemaNegotiator negotiator) {
+    CustomErrorContext errorContext = new ChildErrorContext(negotiator.parentErrorContext()) {
+      @Override
+      public void addContext(UserException.Builder builder) {
+        super.addContext(builder);
+        builder.addContext("topic_name", subScanSpec.getTopicName());
+      }
+    };
+    negotiator.setErrorContext(errorContext);
 
-  @Override
-  public void setup(OperatorContext context, OutputMutator output) {
-    this.writer = new VectorContainerWriter(output, readOptions.isEnableUnionType());
     messageReader = MessageReaderFactory.getMessageReader(readOptions.getMessageReader());
-    messageReader.init(context.getManagedBuffer(), Lists.newArrayList(getColumns()), writer, readOptions);
+    messageReader.init(negotiator, readOptions, plugin);
     msgItr = new MessageIterator(messageReader.getConsumer(plugin), subScanSpec, readOptions.getPollTimeOut());
+
+    return true;
   }
 
   /**
@@ -88,60 +74,48 @@ public class KafkaRecordReader extends AbstractRecordReader {
    * take care of polling multiple times for this given batch next invocation
    */
   @Override
-  public int next() {
-    writer.allocate();
-    writer.reset();
-    Stopwatch watch = logger.isDebugEnabled() ? Stopwatch.createStarted() : null;
-    currentMessageCount = 0;
-
-    try {
-      while (currentOffset < subScanSpec.getEndOffset() && msgItr.hasNext()) {
-        ConsumerRecord<byte[], byte[]> consumerRecord = msgItr.next();
-        currentOffset = consumerRecord.offset();
-        writer.setPosition(currentMessageCount);
-        boolean status = messageReader.readMessage(consumerRecord);
-        // increment record count only if message was read successfully
-        if (status) {
-          if (++currentMessageCount >= DEFAULT_MESSAGES_PER_BATCH) {
-            break;
-          }
-        }
+  public boolean next() {
+    RowSetLoader rowWriter = messageReader.getResultSetLoader().writer();
+    while (!rowWriter.isFull()) {
+      if (!nextLine(rowWriter)) {
+        return false;
       }
-
-      if (currentMessageCount > 0) {
-        messageReader.ensureAtLeastOneField();
-      }
-      writer.setValueCount(currentMessageCount);
-      if (watch != null) {
-        logger.debug("Took {} ms to process {} records.", watch.elapsed(TimeUnit.MILLISECONDS), currentMessageCount);
-      }
-      logger.debug("Last offset consumed for {}:{} is {}", subScanSpec.getTopicName(), subScanSpec.getPartitionId(),
-          currentOffset);
-      return currentMessageCount;
-    } catch (Exception e) {
-      String msg = "Failure while reading messages from kafka. Record reader was at record: " + (currentMessageCount + 1);
-      throw UserException.dataReadError(e)
-        .message(msg)
-        .addContext(e.getMessage())
-        .build(logger);
     }
+    return messageReader.endBatch();
+  }
+
+  private boolean nextLine(RowSetLoader rowWriter) {
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
+
+    if (currentOffset >= subScanSpec.getEndOffset() || !msgItr.hasNext()) {
+      return false;
+    }
+    ConsumerRecord<byte[], byte[]> consumerRecord = msgItr.next();
+    currentOffset = consumerRecord.offset();
+    messageReader.readMessage(consumerRecord);
+    return true;
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     logger.debug("Last offset processed for {}:{} is - {}", subScanSpec.getTopicName(), subScanSpec.getPartitionId(),
         currentOffset);
     logger.debug("Total time to fetch messages from {}:{} is - {} milliseconds", subScanSpec.getTopicName(),
         subScanSpec.getPartitionId(), msgItr.getTotalFetchTime());
     plugin.registerToClose(msgItr);
-    messageReader.close();
+    try {
+      messageReader.close();
+    } catch (IOException e) {
+      logger.warn("Error closing Kafka message reader: {}", e.getMessage(), e);
+    }
   }
 
   @Override
   public String toString() {
     return "KafkaRecordReader[readOptions=" + readOptions
         + ", currentOffset=" + currentOffset
-        + ", currentMessageCount=" + currentMessageCount
         + "]";
   }
 }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.exceptions.ChildErrorContext;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
@@ -114,8 +115,9 @@ public class KafkaRecordReader implements ManagedReader<SchemaNegotiator> {
 
   @Override
   public String toString() {
-    return "KafkaRecordReader[readOptions=" + readOptions
-        + ", currentOffset=" + currentOffset
-        + "]";
+    return new PlanStringBuilder(this)
+        .field("readOptions", readOptions)
+        .field("currentOffset", currentOffset)
+        .toString();
   }
 }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/MetaDataField.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/MetaDataField.java
@@ -17,25 +17,33 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import org.apache.drill.common.types.TypeProtos;
+
 /**
  * MetaData fields provide additional information about each message.
  * It is expected that one should not modify the fieldName of each constant as it breaks the compatibility.
  */
 public enum MetaDataField {
 
-  KAFKA_TOPIC("kafkaTopic"),
-  KAFKA_PARTITION_ID("kafkaPartitionId"),
-  KAFKA_OFFSET("kafkaMsgOffset"),
-  KAFKA_TIMESTAMP("kafkaMsgTimestamp"),
-  KAFKA_MSG_KEY("kafkaMsgKey");
+  KAFKA_TOPIC("kafkaTopic", TypeProtos.MinorType.VARCHAR),
+  KAFKA_PARTITION_ID("kafkaPartitionId", TypeProtos.MinorType.BIGINT),
+  KAFKA_OFFSET("kafkaMsgOffset", TypeProtos.MinorType.BIGINT),
+  KAFKA_TIMESTAMP("kafkaMsgTimestamp", TypeProtos.MinorType.BIGINT),
+  KAFKA_MSG_KEY("kafkaMsgKey", TypeProtos.MinorType.VARCHAR);
 
   private final String fieldName;
+  private final TypeProtos.MinorType fieldType;
 
-  MetaDataField(final String fieldName) {
+  MetaDataField(final String fieldName, TypeProtos.MinorType type) {
     this.fieldName = fieldName;
+    this.fieldType = type;
   }
 
   public String getFieldName() {
     return fieldName;
+  }
+
+  public TypeProtos.MinorType getFieldType() {
+    return fieldType;
   }
 }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/AvroMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/AvroMessageReader.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.kafka.decoders;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.ColumnConverter;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.exec.store.avro.AvroColumnConverterFactory;
+import org.apache.drill.exec.store.kafka.KafkaStoragePlugin;
+import org.apache.drill.exec.store.kafka.MetaDataField;
+import org.apache.drill.exec.store.kafka.ReadOptions;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class AvroMessageReader implements MessageReader {
+  private static final Logger logger = LoggerFactory.getLogger(AvroMessageReader.class);
+
+  private KafkaAvroDeserializer deserializer;
+  private ColumnConverter converter;
+  private ResultSetLoader loader;
+
+  @Override
+  public void init(SchemaNegotiator negotiator, ReadOptions readOptions, KafkaStoragePlugin plugin) {
+    Properties kafkaConsumerProps = plugin.getConfig().getKafkaConsumerProps();
+    Map<String, Object> propertiesMap = kafkaConsumerProps.entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+    deserializer = new KafkaAvroDeserializer(null, propertiesMap);
+    TupleMetadata providedSchema = negotiator.providedSchema();
+    loader = negotiator.build();
+    AvroColumnConverterFactory factory = new AvroColumnConverterFactory(providedSchema);
+    converter = factory.getRootConverter(providedSchema, new TupleSchema(), loader.writer());
+  }
+
+  @Override
+  public void readMessage(ConsumerRecord<?, ?> record) {
+    RowSetLoader rowWriter = loader.writer();
+    byte[] recordArray = (byte[]) record.value();
+    GenericRecord genericRecord = (GenericRecord) deserializer.deserialize(null, recordArray);
+
+    Schema schema = genericRecord.getSchema();
+
+    if (Schema.Type.RECORD != schema.getType()) {
+      throw UserException.dataReadError()
+          .message("Root object must be record type. Found: %s", schema.getType())
+          .addContext("Reader", this)
+          .build(logger);
+    }
+
+    rowWriter.start();
+    converter.convert(genericRecord);
+    writeValue(rowWriter, MetaDataField.KAFKA_TOPIC, record.topic());
+    writeValue(rowWriter, MetaDataField.KAFKA_PARTITION_ID, record.partition());
+    writeValue(rowWriter, MetaDataField.KAFKA_OFFSET, record.offset());
+    writeValue(rowWriter, MetaDataField.KAFKA_TIMESTAMP, record.timestamp());
+    writeValue(rowWriter, MetaDataField.KAFKA_MSG_KEY, record.key() != null ? record.key().toString() : null);
+    rowWriter.save();
+  }
+
+  private <T> void writeValue(RowSetLoader rowWriter, MetaDataField metaDataField, T value) {
+    if (rowWriter.tupleSchema().column(metaDataField.getFieldName()) == null) {
+      ColumnMetadata colSchema = MetadataUtils.newScalar(metaDataField.getFieldName(), metaDataField.getFieldType(), TypeProtos.DataMode.OPTIONAL);
+      rowWriter.addColumn(colSchema);
+    }
+    rowWriter.column(metaDataField.getFieldName()).setObject(value);
+  }
+
+  @Override
+  public KafkaConsumer<byte[], byte[]> getConsumer(KafkaStoragePlugin plugin) {
+    return new KafkaConsumer<>(plugin.getConfig().getKafkaConsumerProps(),
+        new ByteArrayDeserializer(), new ByteArrayDeserializer());
+  }
+
+  @Override
+  public ResultSetLoader getResultSetLoader() {
+    return loader;
+  }
+
+  @Override
+  public boolean endBatch() {
+    return loader.hasRows();
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      deserializer.close();
+      loader.close();
+    } catch (Exception e) {
+      logger.warn("Error while closing AvroMessageReader: {}", e.getMessage());
+    }
+  }
+}

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
@@ -17,36 +17,28 @@
  */
 package org.apache.drill.exec.store.kafka.decoders;
 
-import static org.apache.drill.exec.store.kafka.MetaDataField.KAFKA_MSG_KEY;
-import static org.apache.drill.exec.store.kafka.MetaDataField.KAFKA_OFFSET;
-import static org.apache.drill.exec.store.kafka.MetaDataField.KAFKA_PARTITION_ID;
-import static org.apache.drill.exec.store.kafka.MetaDataField.KAFKA_TIMESTAMP;
-import static org.apache.drill.exec.store.kafka.MetaDataField.KAFKA_TOPIC;
-
-import java.io.IOException;
-import java.util.List;
-
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.store.easy.json.JsonProcessor;
-import org.apache.drill.exec.store.easy.json.reader.BaseJsonProcessor;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
+import org.apache.drill.exec.store.easy.json.parser.TokenIterator;
 import org.apache.drill.exec.store.kafka.KafkaStoragePlugin;
+import org.apache.drill.exec.store.kafka.MetaDataField;
 import org.apache.drill.exec.store.kafka.ReadOptions;
-import org.apache.drill.exec.vector.complex.fn.JsonReader;
-import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
-
-import io.netty.buffer.DrillBuf;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.StringJoiner;
 
 /**
  * MessageReader class which will convert ConsumerRecord into JSON and writes to
@@ -55,61 +47,78 @@ import io.netty.buffer.DrillBuf;
 public class JsonMessageReader implements MessageReader {
 
   private static final Logger logger = LoggerFactory.getLogger(JsonMessageReader.class);
-  private JsonReader jsonReader;
-  private VectorContainerWriter writer;
-  private ObjectMapper objectMapper;
+
+  private final SingleElementIterator<InputStream> stream = new SingleElementIterator<>();
+
+  private KafkaJsonLoader kafkaJsonLoader;
+  private ResultSetLoader resultSetLoader;
+  private SchemaNegotiator negotiator;
+  private ReadOptions readOptions;
+  private Properties kafkaConsumerProps;
 
   @Override
-  public void init(DrillBuf buf, List<SchemaPath> columns, VectorContainerWriter writer, ReadOptions readOptions) {
-    // set skipOuterList to false as it doesn't applicable for JSON records and it's only applicable for JSON files.
-    this.jsonReader = new JsonReader.Builder(buf)
-      .schemaPathColumns(columns)
-      .allTextMode(readOptions.isAllTextMode())
-      .readNumbersAsDouble(readOptions.isReadNumbersAsDouble())
-      .enableNanInf(readOptions.isAllowNanInf())
-      .enableEscapeAnyChar(readOptions.isAllowEscapeAnyChar())
-      .build();
-    jsonReader.setIgnoreJSONParseErrors(readOptions.isSkipInvalidRecords());
-    this.writer = writer;
-    this.objectMapper = BaseJsonProcessor.getDefaultMapper()
-      .configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, readOptions.isAllowNanInf())
-      .configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, readOptions.isAllowEscapeAnyChar());
+  public void init(SchemaNegotiator negotiator, ReadOptions readOptions, KafkaStoragePlugin plugin) {
+    this.negotiator = negotiator;
+    this.resultSetLoader = negotiator.build();
+    this.readOptions = readOptions;
+    this.kafkaConsumerProps = plugin.getConfig().getKafkaConsumerProps();
   }
 
   @Override
-  public boolean readMessage(ConsumerRecord<?, ?> record) {
+  public void readMessage(ConsumerRecord<?, ?> record) {
     byte[] recordArray = (byte[]) record.value();
-    String data = new String(recordArray, Charsets.UTF_8);
     try {
-      JsonNode jsonNode = objectMapper.readTree(data);
-      if (jsonNode != null && jsonNode.isObject()) {
-        ObjectNode objectNode = (ObjectNode) jsonNode;
-        objectNode.put(KAFKA_TOPIC.getFieldName(), record.topic());
-        objectNode.put(KAFKA_PARTITION_ID.getFieldName(), record.partition());
-        objectNode.put(KAFKA_OFFSET.getFieldName(), record.offset());
-        objectNode.put(KAFKA_TIMESTAMP.getFieldName(), record.timestamp());
-        objectNode.put(KAFKA_MSG_KEY.getFieldName(), record.key() != null ? record.key().toString() : null);
-      } else {
-        throw new IOException("Unsupported node type: " + (jsonNode == null ? "NO CONTENT" : jsonNode.getNodeType()));
+      parseAndWrite(record, recordArray);
+    } catch (TokenIterator.RecoverableJsonException e) {
+      if (!readOptions.isSkipInvalidRecords()) {
+        throw e;
       }
-      jsonReader.setSource(jsonNode);
-      return convertJsonReadState(jsonReader.write(writer));
-    } catch (IOException | IllegalArgumentException e) {
-      String message = String.format("JSON record %s: %s", data, e.getMessage());
-      if (jsonReader.ignoreJSONParseError()) {
-        logger.debug("Skipping {}", message, e);
-        return false;
-      }
-      throw UserException.dataReadError(e)
-        .message("Failed to read " + message)
-        .addContext("MessageReader", JsonMessageReader.class.getName())
-        .build(logger);
     }
   }
 
+  private void parseAndWrite(ConsumerRecord<?, ?> record, byte[] recordArray) {
+    stream.setValue(new ByteArrayInputStream(recordArray));
+    if (kafkaJsonLoader == null) {
+      JsonLoaderOptions jsonLoaderOptions = new JsonLoaderOptions();
+      jsonLoaderOptions.allTextMode = readOptions.isAllTextMode();
+      jsonLoaderOptions.readNumbersAsDouble = readOptions.isReadNumbersAsDouble();
+      jsonLoaderOptions.skipMalformedRecords = readOptions.isSkipInvalidRecords();
+      jsonLoaderOptions.allowNanInf = readOptions.isAllowNanInf();
+      jsonLoaderOptions.enableEscapeAnyChar = readOptions.isAllowEscapeAnyChar();
+      jsonLoaderOptions.skipMalformedDocument = readOptions.isSkipInvalidRecords();
+
+      kafkaJsonLoader = (KafkaJsonLoader) new KafkaJsonLoader.KafkaJsonLoaderBuilder()
+          .resultSetLoader(resultSetLoader)
+          .standardOptions(negotiator.queryOptions())
+          .options(jsonLoaderOptions)
+          .errorContext(negotiator.parentErrorContext())
+          .fromStream(() -> stream)
+          .build();
+    }
+
+    RowSetLoader rowWriter = resultSetLoader.writer();
+    rowWriter.start();
+    if (kafkaJsonLoader.parser().next()) {
+      writeValue(rowWriter, MetaDataField.KAFKA_TOPIC, record.topic());
+      writeValue(rowWriter, MetaDataField.KAFKA_PARTITION_ID, record.partition());
+      writeValue(rowWriter, MetaDataField.KAFKA_OFFSET, record.offset());
+      writeValue(rowWriter, MetaDataField.KAFKA_TIMESTAMP, record.timestamp());
+      writeValue(rowWriter, MetaDataField.KAFKA_MSG_KEY, record.key() != null ? record.key().toString() : null);
+      rowWriter.save();
+    }
+  }
+
+  private <T> void writeValue(RowSetLoader rowWriter, MetaDataField metaDataField, T value) {
+    if (rowWriter.tupleSchema().column(metaDataField.getFieldName()) == null) {
+      ColumnMetadata colSchema = MetadataUtils.newScalar(metaDataField.getFieldName(), metaDataField.getFieldType(), TypeProtos.DataMode.OPTIONAL);
+      rowWriter.addColumn(colSchema);
+    }
+    rowWriter.column(metaDataField.getFieldName()).setObject(value);
+  }
+
   @Override
-  public void ensureAtLeastOneField() {
-    jsonReader.ensureAtLeastOneField(writer);
+  public ResultSetLoader getResultSetLoader() {
+    return resultSetLoader;
   }
 
   @Override
@@ -119,10 +128,16 @@ public class JsonMessageReader implements MessageReader {
   }
 
   @Override
+  public boolean endBatch() {
+    kafkaJsonLoader.endBatch();
+    return resultSetLoader.hasRows();
+  }
+
+  @Override
   public void close() {
-    this.writer.clear();
     try {
-      this.writer.close();
+      kafkaJsonLoader.close();
+      resultSetLoader.close();
     } catch (Exception e) {
       logger.warn("Error while closing JsonMessageReader: {}", e.getMessage());
     }
@@ -130,26 +145,29 @@ public class JsonMessageReader implements MessageReader {
 
   @Override
   public String toString() {
-    return "JsonMessageReader[jsonReader=" + jsonReader + "]";
+    return new StringJoiner(", ", JsonMessageReader.class.getSimpleName() + "[", "]")
+        .add("kafkaJsonLoader=" + kafkaJsonLoader)
+        .add("resultSetLoader=" + resultSetLoader)
+        .toString();
   }
 
-  /**
-   * Converts {@link JsonProcessor.ReadState} into true / false result.
-   *
-   * @param jsonReadState JSON reader read state
-   * @return true if read was successful, false otherwise
-   * @throws IllegalArgumentException if unexpected read state was encountered
-   */
-  private boolean convertJsonReadState(JsonProcessor.ReadState jsonReadState) {
-    switch (jsonReadState) {
-      case WRITE_SUCCEED:
-      case END_OF_STREAM:
-        return true;
-      case JSON_RECORD_PARSE_ERROR:
-      case JSON_RECORD_PARSE_EOF_ERROR:
-        return false;
-      default:
-        throw new IllegalArgumentException("Unexpected JSON read state: " + jsonReadState);
+  public static class SingleElementIterator<T> implements Iterator<T> {
+    private T value;
+
+    @Override
+    public boolean hasNext() {
+      return value != null;
+    }
+
+    @Override
+    public T next() {
+      T value = this.value;
+      this.value = null;
+      return value;
+    }
+
+    public void setValue(T value) {
+      this.value = value;
     }
   }
 }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
@@ -17,7 +17,9 @@
  */
 package org.apache.drill.exec.store.kafka.decoders;
 
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
@@ -71,7 +73,11 @@ public class JsonMessageReader implements MessageReader {
       parseAndWrite(record, recordArray);
     } catch (TokenIterator.RecoverableJsonException e) {
       if (!readOptions.isSkipInvalidRecords()) {
-        throw e;
+        throw UserException.dataReadError(e)
+            .message(String.format("Error happened when parsing invalid record. " +
+                "Please set `%s` option to 'true' to skip invalid records.", ExecConstants.KAFKA_READER_SKIP_INVALID_RECORDS))
+            .addContext(resultSetLoader.errorContext())
+            .build(logger);
       }
     }
   }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/KafkaJsonLoader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/KafkaJsonLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.kafka.decoders;
+
+import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
+
+public class KafkaJsonLoader extends JsonLoaderImpl {
+
+  protected KafkaJsonLoader(KafkaJsonLoaderBuilder builder) {
+    super(builder);
+  }
+
+  @Override
+  public void endBatch() {
+    super.endBatch();
+  }
+
+  public static class KafkaJsonLoaderBuilder extends JsonLoaderBuilder {
+    @Override
+    public KafkaJsonLoader build() {
+      return new KafkaJsonLoader(this);
+    }
+  }
+}

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/MessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/MessageReader.java
@@ -17,17 +17,14 @@
  */
 package org.apache.drill.exec.store.kafka.decoders;
 
-import java.io.Closeable;
-import java.util.List;
-
-import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.store.kafka.KafkaStoragePlugin;
 import org.apache.drill.exec.store.kafka.ReadOptions;
-import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
-import io.netty.buffer.DrillBuf;
+import java.io.Closeable;
 
 /**
  * MessageReader interface provides mechanism to handle various Kafka Message
@@ -35,11 +32,13 @@ import io.netty.buffer.DrillBuf;
  */
 public interface MessageReader extends Closeable {
 
-  void init(DrillBuf buf, List<SchemaPath> columns, VectorContainerWriter writer, ReadOptions readOptions);
+  void init(SchemaNegotiator negotiator, ReadOptions readOptions, KafkaStoragePlugin plugin);
 
-  boolean readMessage(ConsumerRecord<?, ?> message);
-
-  void ensureAtLeastOneField();
+  void readMessage(ConsumerRecord<?, ?> message);
 
   KafkaConsumer<byte[], byte[]> getConsumer(KafkaStoragePlugin plugin);
+
+  ResultSetLoader getResultSetLoader();
+
+  boolean endBatch();
 }

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
@@ -67,6 +67,18 @@ public class KafkaQueriesTest extends KafkaTestBase {
   }
 
   @Test
+  public void testAvroResultCount() {
+    try {
+      client.alterSession(ExecConstants.KAFKA_RECORD_READER,
+          "org.apache.drill.exec.store.kafka.decoders.AvroMessageReader");
+      String queryString = String.format(TestQueryConstants.MSG_SELECT_QUERY, TestQueryConstants.AVRO_TOPIC);
+      runKafkaSQLVerifyCount(queryString, TestKafkaSuit.NUM_JSON_MSG);
+    } finally {
+      client.resetSession(ExecConstants.KAFKA_RECORD_READER);
+    }
+  }
+
+  @Test
   public void testPartitionMinOffset() throws Exception {
     // following kafka.tools.GetOffsetShell for earliest as -2
     Map<TopicPartition, Long> startOffsetsMap = fetchOffsets(-2);
@@ -141,6 +153,19 @@ public class KafkaQueriesTest extends KafkaTestBase {
     String query = String.format(TestQueryConstants.MSG_SELECT_QUERY, TestQueryConstants.JSON_TOPIC);
     String plan = queryBuilder().sql(query).explainJson();
     queryBuilder().physical(plan).run();
+  }
+
+  @Test
+  public void testPhysicalPlanSubmissionAvro() throws Exception {
+    try {
+      client.alterSession(ExecConstants.KAFKA_RECORD_READER,
+          "org.apache.drill.exec.store.kafka.decoders.AvroMessageReader");
+      String query = String.format(TestQueryConstants.MSG_SELECT_QUERY, TestQueryConstants.AVRO_TOPIC);
+      String plan = queryBuilder().sql(query).explainJson();
+      queryBuilder().physical(plan).run();
+    } finally {
+      client.resetSession(ExecConstants.KAFKA_RECORD_READER);
+    }
   }
 
   @Test

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaTestBase.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaTestBase.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.kafka;
 
 import java.util.Map;
 
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.kafka.cluster.EmbeddedKafkaCluster;
@@ -33,6 +34,8 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+
+import static org.apache.drill.exec.store.kafka.KafkaMessageGenerator.SCHEMA_REGISTRY_URL;
 
 public class KafkaTestBase extends ClusterTest {
   protected static KafkaStoragePluginConfig storagePluginConfig;
@@ -52,6 +55,7 @@ public class KafkaTestBase extends ClusterTest {
     Map<String, String> kafkaConsumerProps = Maps.newHashMap();
     kafkaConsumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, embeddedKafkaCluster.getKafkaBrokerList());
     kafkaConsumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "drill-test-consumer");
+    kafkaConsumerProps.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
     storagePluginConfig = new KafkaStoragePluginConfig(kafkaConsumerProps);
     storagePluginConfig.setEnabled(true);
     pluginRegistry.put(KafkaStoragePluginConfig.NAME, storagePluginConfig);

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuit.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuit.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import kafka.zk.KafkaZkClient;
 import org.apache.drill.categories.KafkaStorageTest;
 import org.apache.drill.categories.SlowTest;
@@ -85,8 +86,11 @@ public class TestKafkaSuit extends BaseTest {
             "kafka.server", "SessionExpireListener",
             Option.<String>empty(), Option.<ZKClientConfig>empty());
         createTopicHelper(TestQueryConstants.JSON_TOPIC, 1);
+        createTopicHelper(TestQueryConstants.AVRO_TOPIC, 1);
         KafkaMessageGenerator generator = new KafkaMessageGenerator(embeddedKafkaCluster.getKafkaBrokerList(), StringSerializer.class);
+        KafkaMessageGenerator avroGenerator = new KafkaMessageGenerator(embeddedKafkaCluster.getKafkaBrokerList(), KafkaAvroSerializer.class);
         generator.populateJsonMsgIntoKafka(TestQueryConstants.JSON_TOPIC, NUM_JSON_MSG);
+        avroGenerator.populateAvroMsgIntoKafka(TestQueryConstants.AVRO_TOPIC, NUM_JSON_MSG);
       }
       initCount.incrementAndGet();
       runningSuite = true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureOptions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureOptions.java
@@ -47,6 +47,13 @@ public class JsonStructureOptions {
    */
   public boolean skipMalformedRecords;
 
+  /**
+   * This property works only when {@link #skipMalformedRecords} enabled.
+   * If true, {@link TokenIterator.RecoverableJsonException} will be populated for the case of
+   * malformed empty document, so it will be possible to handle this exception by caller.
+   */
+  public boolean skipMalformedDocument;
+
   public boolean enableEscapeAnyChar;
 
   public JsonStructureOptions() { }

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -336,6 +336,7 @@
               <exclude>javax.xml.stream:stax-api</exclude>
               <exclude>javax.activation:activation</exclude>
               <exclude>commons-cli:commons-cli</exclude>
+              <exclude>org.apache.commons:commons-collections4</exclude>
               <exclude>commons-io:commons-io</exclude>
               <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
@@ -622,6 +623,7 @@
                     <exclude>javax.xml.stream:stax-api</exclude>
                     <exclude>javax.activation:activation</exclude>
                     <exclude>commons-cli:commons-cli</exclude>
+                    <exclude>org.apache.commons:commons-collections4</exclude>
                     <exclude>commons-io:commons-io</exclude>
                     <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
                     <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <findbugs.version>3.0.0</findbugs.version>
     <netty.tcnative.classifier />
     <commons.io.version>2.7</commons.io.version>
+    <commons.collections.version>4.4</commons.collections.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
     <curator.version>5.1.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
@@ -1085,6 +1086,10 @@
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>
@@ -1825,6 +1830,11 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>${zookeeper.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>${commons.collections.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
# [DRILL-5940](https://issues.apache.org/jira/browse/DRILL-5940): Add support for Avro messages with schema registry for Kafka

## Description
- Refactored `KafkaRecordReader` to use EVF.
- Updated `JsonMessageReader` to use V2 JSON reader
- Added `AvroMessageReader` for processing messages serialized as Avro records and added schema registry support.

To be able to deserialize Kafka messages of Avro type, schema registry URL should be specified in the Kafka storage plugin `kafkaConsumerProps` (and other schema registry options if required):
``` 
"schema.registry.url": "http://localhost:8081"
```
After that, `store.kafka.record.reader` session option should be set to `org.apache.drill.exec.store.kafka.decoders.AvroMessageReader`.

## Documentation
NA

## Testing
Added UT that reads Avro messages.
