### PR TITLE
DRILL-7936: Remove usage of Guava Files#createTempDir method

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/DrillFileUtils.java
+++ b/common/src/main/java/org/apache/drill/common/util/DrillFileUtils.java
@@ -43,4 +43,19 @@ public class DrillFileUtils {
   public static String getResourceAsString(String fileName) throws IOException {
     return Files.asCharSource(getResourceAsFile(fileName), Charsets.UTF_8).read();
   }
+
+  /**
+   * Creates a temporary directory under the default temporary directory location.
+   * This is a safe replacement for Guava {@code Files#createTempDir()}
+   *
+   * @return a temporary directory
+   * @throws IllegalStateException if the directory cannot be created
+   */
+  public static File createTempDir() {
+    try {
+      return java.nio.file.Files.createTempDirectory(System.currentTimeMillis() + "-").toFile();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to create temporary directory");
+    }
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.drill.common.expression.fn.FunctionReplacementUtils;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
-import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import com.typesafe.config.ConfigFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.common.config.ConfigConstants;
@@ -49,6 +48,7 @@ import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.coord.store.TransientStoreEvent;
 import org.apache.drill.exec.coord.store.TransientStoreListener;
@@ -532,7 +532,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
   /**
    * First tries to get drill temporary directory value from from config ${drill.tmp-dir},
    * then checks environmental variable $DRILL_TMP_DIR.
-   * If value is still missing, generates directory using {@link Files#createTempDir()}.
+   * If value is still missing, generates directory using {@link DrillFileUtils#createTempDir()}.
    * If temporary directory was generated, sets {@link #deleteTmpDir} to true
    * to delete directory on drillbit exit.
    *
@@ -549,7 +549,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
 
     if (drillTempDir == null) {
       deleteTmpDir = true;
-      return Files.createTempDir();
+      return DrillFileUtils.createTempDir();
     }
 
     return new File(drillTempDir);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateFunctionHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateFunctionHandler.java
@@ -18,12 +18,12 @@
 package org.apache.drill.exec.planner.sql.handlers;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.FunctionValidationException;
 import org.apache.drill.exec.exception.JarValidationException;
@@ -236,7 +236,7 @@ public class CreateFunctionHandler extends DefaultSqlHandler {
       this.registryBinary = new Path(remoteRegistry.getRegistryArea(), binaryName);
       this.registrySource = new Path(remoteRegistry.getRegistryArea(), sourceName);
 
-      this.localTmpDir = new Path(Files.createTempDir().toURI());
+      this.localTmpDir = new Path(DrillFileUtils.createTempDir().toURI());
       this.fs = remoteRegistry.getFs();
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillException;
+import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.rest.header.ResponseHeadersSettingFilter;
 import org.apache.drill.exec.server.rest.ssl.SslContextFactoryConfigurator;
@@ -394,7 +395,7 @@ public class WebServer implements AutoCloseable {
    */
   public File getOrCreateTmpJavaScriptDir() {
     if (tmpJavaScriptDir == null && this.drillbit.getContext() != null) {
-      tmpJavaScriptDir = org.apache.drill.shaded.guava.com.google.common.io.Files.createTempDir();
+      tmpJavaScriptDir = DrillFileUtils.createTempDir();
       // Perform All auto generated files at this point
       try {
         generateOptionsDescriptionJSFile();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/StorageStrategyTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/StorageStrategyTest.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.store;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.shaded.guava.com.google.common.io.Files;
+import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.fs.FileSystem;
@@ -173,7 +173,7 @@ public class StorageStrategyTest extends BaseTest {
   }
 
   private Path prepareStorageDirectory() throws IOException {
-    File storageDirectory = Files.createTempDir();
+    File storageDirectory = DrillFileUtils.createTempDir();
     storageDirectory.deleteOnExit();
     Path path = new Path(storageDirectory.toURI().getPath());
     fs.setPermission(path, FULL_PERMISSION);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/FileSystemUtilTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/FileSystemUtilTestBase.java
@@ -18,8 +18,8 @@
 package org.apache.drill.exec.util;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
-import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
+import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.fs.FileSystem;
@@ -68,7 +68,7 @@ public class FileSystemUtilTestBase extends BaseTest {
     fs = ExecTest.getLocalFileSystem();
 
     // create temporary directory with sub-folders and files
-    final File tempDir = Files.createTempDir();
+    final File tempDir = DrillFileUtils.createTempDir();
     Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(tempDir)));
     base = new Path(tempDir.toURI().getPath());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseFixture.java
@@ -21,9 +21,9 @@ import java.io.File;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.drill.shaded.guava.com.google.common.io.Files;
 
 import io.netty.buffer.DrillBuf;
 
@@ -46,7 +46,7 @@ public class BaseFixture {
    */
 
   public static File getTempDir(final String dirName) {
-    final File dir = Files.createTempDir();
+    final File dir = DrillFileUtils.createTempDir();
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
       public void run() {


### PR DESCRIPTION
# [DRILL-7936](https://issues.apache.org/jira/browse/DRILL-7936): Remove usage of Guava Files#createTempDir method

## Description

Guava's `Files#createTempDir()` method has some security issues, and since better alternatives exist (including Java 7 `Files#createTempDirectory(String)` method), the function has been deprecated in Guava 30.0 (but the security issues haven't been addressed).

Introduce a drop-in replacement for this method in `DrillFileUtils` based on the Java7 Files API and replace usage of the Guava method with the new method in the codebase.

## Documentation
N/A

## Testing
Unit tests run locally
