### PR TITLE
DRILL-7940: Fix Kafka key with avro schema can not displayed correctly

### DIFF
--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/AvroMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/AvroMessageReader.java
@@ -52,7 +52,7 @@ public class AvroMessageReader implements MessageReader {
   private KafkaAvroDeserializer deserializer;
   private ColumnConverter converter;
   private ResultSetLoader loader;
-  private Boolean keyConvert;
+  private boolean deserializeKey;
 
   @Override
   public void init(SchemaNegotiator negotiator, ReadOptions readOptions, KafkaStoragePlugin plugin) {
@@ -66,7 +66,7 @@ public class AvroMessageReader implements MessageReader {
     converter = factory.getRootConverter(providedSchema, new TupleSchema(), loader.writer());
 
     String keyDeserializer = kafkaConsumerProps.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
-    keyConvert = keyDeserializer != null && keyDeserializer.equals(KafkaAvroDeserializer.class.getName());
+    deserializeKey = keyDeserializer != null && keyDeserializer.equals(KafkaAvroDeserializer.class.getName());
   }
 
   @Override
@@ -95,9 +95,8 @@ public class AvroMessageReader implements MessageReader {
   }
 
   private Object getKeyValue(byte[] keyValue) {
-    if (keyConvert) {
-      GenericRecord genericRecord = (GenericRecord) deserializer.deserialize(null, keyValue);
-      return genericRecord.toString();
+    if (deserializeKey) {
+      return deserializer.deserialize(null, keyValue).toString();
     } else {
       return new String(keyValue);
     }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/AvroMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/AvroMessageReader.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.store.avro.AvroColumnConverterFactory;
 import org.apache.drill.exec.store.kafka.KafkaStoragePlugin;
 import org.apache.drill.exec.store.kafka.MetaDataField;
 import org.apache.drill.exec.store.kafka.ReadOptions;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -51,6 +52,7 @@ public class AvroMessageReader implements MessageReader {
   private KafkaAvroDeserializer deserializer;
   private ColumnConverter converter;
   private ResultSetLoader loader;
+  private Boolean keyConvert;
 
   @Override
   public void init(SchemaNegotiator negotiator, ReadOptions readOptions, KafkaStoragePlugin plugin) {
@@ -62,6 +64,9 @@ public class AvroMessageReader implements MessageReader {
     loader = negotiator.build();
     AvroColumnConverterFactory factory = new AvroColumnConverterFactory(providedSchema);
     converter = factory.getRootConverter(providedSchema, new TupleSchema(), loader.writer());
+
+    String keyDeserializer = kafkaConsumerProps.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+    keyConvert = keyDeserializer != null && keyDeserializer.equals(KafkaAvroDeserializer.class.getName());
   }
 
   @Override
@@ -85,8 +90,17 @@ public class AvroMessageReader implements MessageReader {
     writeValue(rowWriter, MetaDataField.KAFKA_PARTITION_ID, record.partition());
     writeValue(rowWriter, MetaDataField.KAFKA_OFFSET, record.offset());
     writeValue(rowWriter, MetaDataField.KAFKA_TIMESTAMP, record.timestamp());
-    writeValue(rowWriter, MetaDataField.KAFKA_MSG_KEY, record.key() != null ? record.key().toString() : null);
+    writeValue(rowWriter, MetaDataField.KAFKA_MSG_KEY, record.key() != null ? getKeyValue((byte[]) record.key()) : null);
     rowWriter.save();
+  }
+
+  private Object getKeyValue(byte[] keyValue) {
+    if (keyConvert) {
+      GenericRecord genericRecord = (GenericRecord) deserializer.deserialize(null, keyValue);
+      return genericRecord.toString();
+    } else {
+      return new String(keyValue);
+    }
   }
 
   private <T> void writeValue(RowSetLoader rowWriter, MetaDataField metaDataField, T value) {

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
@@ -17,12 +17,14 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.apache.drill.categories.KafkaStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -71,6 +73,12 @@ public class KafkaQueriesTest extends KafkaTestBase {
     try {
       client.alterSession(ExecConstants.KAFKA_RECORD_READER,
           "org.apache.drill.exec.store.kafka.decoders.AvroMessageReader");
+
+      KafkaStoragePluginConfig config = (KafkaStoragePluginConfig) cluster.drillbit().getContext()
+              .getStorage().getStoredConfig(KafkaStoragePluginConfig.NAME);
+      config.getKafkaConsumerProps().put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+              KafkaAvroDeserializer.class.getName());
+
       String queryString = String.format(TestQueryConstants.MSG_SELECT_QUERY, TestQueryConstants.AVRO_TOPIC);
       runKafkaSQLVerifyCount(queryString, TestKafkaSuit.NUM_JSON_MSG);
     } finally {


### PR DESCRIPTION
# [DRILL-7940](https://issues.apache.org/jira/browse/DRILL-7940): Kafka key with avro schema can not displayed correctly

## Description

When using drill 1.19.0-snapshot to query kafka avro message, if kafka key data is avro, drill can not return key data right.
Now add a new method `AvroMessageReader.getKeyValue` to identify the actual type and data of key. It now cast avro key to string with json type.


## Documentation
No.

## Testing
set `key.deserializer` in `KafkaQueriesTest.testAvroResultCount` test case class
