### PR TITLE
DRILL-7937: INTERNAL_ERROR when querying Parquet File with decimals

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableFixedByteAlignedReaders.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableFixedByteAlignedReaders.java
@@ -321,6 +321,8 @@ public class NullableFixedByteAlignedReaders {
         case FIXED_LEN_BYTE_ARRAY:
         case BINARY:
           if (usingDictionary) {
+            recordsReadInThisIteration = Math.min(pageReader.currentPageCount
+                - pageReader.valuesRead, recordsToReadInThisPass - valuesReadInCurrentPass);
             NullableVarDecimalVector.Mutator mutator = valueVec.getMutator();
             for (int i = 0; i < recordsReadInThisIteration; i++) {
               Binary currDictValToWrite = pageReader.dictionaryValueReader.readBytes();


### PR DESCRIPTION
# [DRILL-7937](https://issues.apache.org/jira/browse/DRILL-7937): INTERNAL_ERROR when querying Parquet File with decimals

## Description
Fixed number of records to read for the case of dictionary encoding to avoid IOBE error when reaching the end of the buffer.

## Documentation
NA

## Testing
Checked manually, no unit test is provided since it is reproduced on large data files only.
