### PR TITLE
DRILL-7942 Update Mockito to latest 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
     <logback.version>1.2.3</logback.version>
-    <mockito.version>2.28.2</mockito.version>
+    <mockito.version>3.11.0</mockito.version>
     <!--
       Currently Hive storage plugin only supports Apache Hive 3.1.2 or vendor specific variants of the
       Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated,


### PR DESCRIPTION
# [DRILL-7942](https://issues.apache.org/jira/browse/DRILL-7942): Update Mockito to latest 3.x

## Description

Update Mockito to 3.11.0 (latest version at the moment).

This will make it easier to build Drill with newer JDKs.

## Documentation

No need of documentation changes.

## Testing

The test suite has been executed.
