### PR TITLE
DRILL-7946: Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <commons.compress.version>1.20</commons.compress.version>
     <hikari.version>3.4.2</hikari.version>
     <netty.version>4.1.59.Final</netty.version>
-    <httpclient.version>4.5.12</httpclient.version>
+    <httpclient.version>4.5.13</httpclient.version>
     <libthrift.version>0.14.0</libthrift.version>
     <derby.version>10.14.2.0</derby.version>
     <commons.cli.version>1.4</commons.cli.version>


### PR DESCRIPTION
# [DRILL-7946](https://issues.apache.org/jira/browse/DRILL-7946): Bump HttpClient from 4.5.12 to 4.5.13 for CVE-2020-13956

## Description

CVE-2020-13956

Vulnerable versions: < 4.5.13
Patched version: 4.5.13

Apache HttpClient versions prior to version 4.5.13 and 5.0.3 can misinterpret malformed authority component in request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.

## Documentation
N/A

## Testing
Waiting for the unit tests passed.
