### PR TITLE
DRILL-7871 StoragePluginStore instances for different users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Build and test
-        run: mvn install -V -ntp -DdirectMemoryMb=2500 -DmemoryMb=2000 # Note: the total GitHub Actions memory is 7000Mb
+        run: mvn install -V -ntp -DdirectMemoryMb=3200 -DmemoryMb=2000 # Note: the total GitHub Actions memory is 7000Mb
 
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs

--- a/common/src/main/java/org/apache/drill/common/config/DrillConfig.java
+++ b/common/src/main/java/org/apache/drill/common/config/DrillConfig.java
@@ -87,7 +87,7 @@ public class DrillConfig extends NestedConfig {
       }
       Constructor<?> constructor = clazz.getConstructor(argClasses);
       return (T) constructor.newInstance(constructorArgs);
-    }catch(Exception e){
+    } catch (Exception e) {
       throw UserException.unsupportedError(e)
           .message("Failure while attempting to load instance of the class of type %s requested at path %s.",
               iface.getName(), path).build(logger);

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPlugin.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPlugin.java
@@ -116,6 +116,7 @@ public abstract class TableFormatPlugin implements FormatPlugin {
     return name;
   }
 
+  // TODO: it can be deleted after modifying {@link MapRDBGroupScan#getStorageConfig()}. See more: DRILL-7961
   public synchronized AbstractStoragePlugin getStoragePlugin() {
     if (this.storagePlugin == null) {
       this.storagePlugin = context.getStorage().resolve(storageConfig,

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBGroupScan.java
@@ -275,6 +275,8 @@ public abstract class MapRDBGroupScan extends AbstractDbGroupScan {
 
   @JsonProperty("storage")
   public StoragePluginConfig getStorageConfig() {
+    // TODO: similar to other plugins, this line can be replaced with "return formatPlugin.getStorageConfig()".
+    //  But it requires verifying: checking JSON Group Scan for MapR-DB. See more: DRILL-7961
     return storagePlugin.getConfig();
   }
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/config/HBasePersistentStoreProvider.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/config/HBasePersistentStoreProvider.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.exec.exception.StoreException;
 import org.apache.drill.exec.store.hbase.DrillHBaseConstants;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
@@ -78,7 +77,7 @@ public class HBasePersistentStoreProvider extends BasePersistentStoreProvider {
 
 
   @Override
-  public <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> config) throws StoreException {
+  public <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> config) {
     switch(config.getMode()){
     case BLOB_PERSISTENT:
     case PERSISTENT:

--- a/distribution/src/main/resources/drill-override-example.conf
+++ b/distribution/src/main/resources/drill-override-example.conf
@@ -237,7 +237,8 @@ drill.exec: {
     # Annotation type "pam4j" is providing implementation using libpam4j
     # Based on annotation type configured below corresponding authenticator is used.
     impl: "pam",
-    pam_profiles: [ "sudo", "login" ]
+    pam_profiles: [ "sudo", "login" ],
+    separate_workspace: true
   },
   trace: {
     directory: "/tmp/drill-trace",

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
-import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
 import org.apache.drill.exec.store.SubSchemaWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,7 +119,7 @@ public class DynamicRootSchema extends DynamicSchema {
           schemaPlus.add(wrapper.getName(), wrapper);
         }
       }
-    } catch(PluginException | IOException ex) {
+    } catch(IOException ex) {
       logger.warn("Failed to load schema for \"" + schemaName + "\"!", ex);
       // We can't proceed further without a schema, throw a runtime exception.
       UserException.Builder exceptBuilder =

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -288,6 +288,7 @@ public final class ExecConstants {
   public static final String USER_AUTHENTICATOR_IMPL = "drill.exec.security.user.auth.impl";
   public static final String HTPASSWD_AUTHENTICATOR_PATH = "drill.exec.security.user.auth.htpasswd.path";
   public static final String PAM_AUTHENTICATOR_PROFILES = "drill.exec.security.user.auth.pam_profiles";
+  public static final String SEPARATE_WORKSPACE = "drill.exec.security.user.auth.separate_workspace";
   public static final String BIT_AUTHENTICATION_ENABLED = "drill.exec.security.bit.auth.enabled";
   public static final String BIT_AUTHENTICATION_MECHANISM = "drill.exec.security.bit.auth.mechanism";
   public static final String USE_LOGIN_PRINCIPAL = "drill.exec.security.bit.auth.use_login_principal";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -208,7 +208,8 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
         throw new ExecutionSetupException("Failure while reading plan options.", e);
       }
     }
-    fragmentOptions = new FragmentOptionManager(context.getOptionManager(), list);
+    fragmentOptions = new FragmentOptionManager(getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE)
+            ? connection.getSession().getSystemOptions() : context.getSystemOptionManager(), list);
 
     executionControls = new ExecutionControls(fragmentOptions, dbContext.getEndpoint());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -291,9 +291,8 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   public void reloadDrillOperatorTable() {
     // This is re-trying the query plan on failure so qualifies to reset the SQL statement.
     clearSQLStatementType();
-    table = new DrillOperatorTable(
-        drillbitContext.getFunctionImplementationRegistry(),
-        session.getSystemOptions());
+    table = new DrillOperatorTable(drillbitContext.getFunctionImplementationRegistry(),
+            session.getSystemOptions() != null ? session.getSystemOptions() : drillbitContext.getSystemOptionManager());
   }
 
   public QueryContextInformation getQueryContextInfo() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/opt/BasicOptimizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/opt/BasicOptimizer.java
@@ -204,7 +204,7 @@ public class BasicOptimizer extends Optimizer {
       try {
         final StoragePlugin storagePlugin = queryContext.getStorage().getPluginByConfig(config);
         final String user = userSession.getSession().getCredentials().getUserName();
-        return storagePlugin.getPhysicalScan(user, scan.getSelection(), userSession.getSession().getOptions());
+        return storagePlugin.getPhysicalScan(user, scan.getSelection(), userSession.getSession().getSessionOptions());
       } catch (IOException | PluginException e) {
         throw new OptimizerException("Failure while attempting to retrieve storage engine.", e);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/conversion/DrillCalciteCatalogReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/conversion/DrillCalciteCatalogReader.java
@@ -128,7 +128,7 @@ class DrillCalciteCatalogReader extends CalciteCatalogReader {
     Prepare.PreparingTable table = super.getTable(names);
     DrillTable drillTable;
     if (table != null && (drillTable = table.unwrap(DrillTable.class)) != null) {
-      drillTable.setOptions(session.getOptions());
+      drillTable.setOptions(session.getSessionOptions());
       drillTable.setTableMetadataProviderManager(tableCache.getUnchecked(DrillTableKey.of(names, drillTable)));
     }
     return table;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeSchemaHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeSchemaHandler.java
@@ -36,7 +36,6 @@ import org.apache.drill.exec.planner.sql.DirectPlan;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.StoragePlugin;
-import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
 import org.apache.drill.exec.store.dfs.FileSystemPlugin;
 import org.apache.drill.exec.store.dfs.WorkspaceConfig;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
@@ -86,14 +85,10 @@ public class DescribeSchemaHandler extends DefaultSqlHandler {
 
     AbstractSchema drillSchema = SchemaUtilites.unwrapAsDrillSchemaInstance(schemaPlus);
     StoragePlugin storagePlugin;
-    try {
-      storagePlugin = context.getStorage().getPlugin(drillSchema.getSchemaPath().get(0));
-      if (storagePlugin == null) {
-        throw new DrillRuntimeException(String.format("Unable to find storage plugin with the following name [%s].",
-          drillSchema.getSchemaPath().get(0)));
-      }
-    } catch (PluginException e) {
-      throw new DrillRuntimeException("Failure while retrieving storage plugin", e);
+    storagePlugin = context.getStorage().getPlugin(drillSchema.getSchemaPath().get(0));
+    if (storagePlugin == null) {
+      throw new DrillRuntimeException(String.format("Unable to find storage plugin with the following name [%s].",
+        drillSchema.getSchemaPath().get(0)));
     }
 
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/InboundImpersonationManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/InboundImpersonationManager.java
@@ -164,7 +164,7 @@ public class InboundImpersonationManager {
    * @param session    user session
    */
   public void replaceUserOnSession(final String targetName, final UserSession session) {
-    final String policiesString = session.getOptions()
+    final String policiesString = session.getSessionOptions()
         .getOption(ExecConstants.IMPERSONATION_POLICY_VALIDATOR);
     if (!policiesString.equals(this.policiesString)) {
       try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserConnectionConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserConnectionConfig.java
@@ -35,6 +35,7 @@ class UserConnectionConfig extends AbstractConnectionConfig {
   private final boolean authEnabled;
   private final boolean sslEnabled;
   private final InboundImpersonationManager impersonationManager;
+  private final boolean isSeparateWorkspace;
 
   private final UserServerRequestHandler handler;
 
@@ -86,6 +87,7 @@ class UserConnectionConfig extends AbstractConnectionConfig {
       logger.warn("The server is configured to use both SSL and SASL encryption (only one should be configured).");
     }
 
+    isSeparateWorkspace = config.getBoolean(ExecConstants.SEPARATE_WORKSPACE);
   }
 
   @Override
@@ -99,6 +101,10 @@ class UserConnectionConfig extends AbstractConnectionConfig {
 
   boolean isSSLEnabled() {
     return sslEnabled;
+  }
+
+  boolean isSeparateWorkspace() {
+    return isSeparateWorkspace;
   }
 
   InboundImpersonationManager getImpersonationManager() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
@@ -249,8 +249,9 @@ public class UserServer extends BasicServer<RpcType, BitToUserConnection> {
           .withCredentials(UserCredentials.newBuilder()
               .setUserName(userName)
               .build())
-          .withOptionManager(userWorker.getSystemOptions())
+          .withOptionManagers(userWorker.getDrillbitContext())
           .withUserProperties(inbound.getProperties())
+          .withStorage(userWorker.getDrillbitContext())
           .setSupportComplexTypes(inbound.getSupportComplexTypes())
           .build();
 
@@ -499,6 +500,7 @@ public class UserServer extends BasicServer<RpcType, BitToUserConnection> {
   public class BitToUserConnectionConfig {
     private final DateTime established;
     private final boolean isAuthEnabled;
+    private final boolean isSeparateWorkspace;
     private final boolean isEncryptionEnabled;
     private final boolean isSSLEnabled;
 
@@ -507,6 +509,7 @@ public class UserServer extends BasicServer<RpcType, BitToUserConnection> {
       isAuthEnabled = config.isAuthEnabled();
       isEncryptionEnabled = config.isEncryptionEnabled();
       isSSLEnabled = config.isSSLEnabled();
+      isSeparateWorkspace = config.isSeparateWorkspace();
     }
 
     public boolean isAuthEnabled() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
@@ -119,13 +119,22 @@ public class UserSession implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Call {@link #withCredentials) at first, it is necessary to instantinate {@link UserSystemOptionManager}
+     *
+     * @param context Drillbit system context
+     * @return this session builde
+     */
     public Builder withOptionManagers(DrillbitContext context) {
-      userSession.userSystemOptions = context.getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED)
-          && context.getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE)
-        ? new UserSystemOptionManager(context.getSystemOptionManager(), context.getLpPersistence(),
-            context.getStoreProvider(), context.getConfig(), context.getDefinitions(), userSession)
-        : context.getSystemOptionManager();
-      userSession.sessionOptions = new SessionOptionManager(userSession.userSystemOptions, userSession);
+      if (context.getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED)
+              && context.getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE)) {
+        userSession.userSystemOptions =
+            new UserSystemOptionManager(context.getSystemOptionManager(), context.getLpPersistence(),
+              context.getStoreProvider(), context.getConfig(), context.getDefinitions(), userSession);
+        userSession.sessionOptions = new SessionOptionManager(userSession.userSystemOptions, userSession);
+      } else {
+        userSession.sessionOptions = new SessionOptionManager(context.getSystemOptionManager(), userSession);
+      }
       return this;
     }
 
@@ -134,6 +143,12 @@ public class UserSession implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Call {@link #withCredentials) at first, it is necessary to instantinate {@link UserSystemOptionManager}
+     *
+     * @param context Drillbit system context
+     * @return this session builde
+     */
     public Builder withStorage(DrillbitContext context) {
       userSession.storagePlugins = context.getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED)
           && context.getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -228,7 +228,7 @@ public class Drillbit implements AutoCloseable {
     final DrillbitContext drillbitContext = manager.getContext();
     storageRegistry = drillbitContext.getStorage();
     storageRegistry.init();
-    drillbitContext.getOptionManager().init();
+    drillbitContext.getSystemOptionManager().init();
     javaPropertiesToSystemOptions();
     manager.getContext().getRemoteFunctionRegistry().init(context.getConfig(), storeProvider, coord);
     webServer.start();
@@ -346,7 +346,7 @@ public class Drillbit implements AutoCloseable {
       return;
     }
 
-    final SystemOptionManager optionManager = getContext().getOptionManager();
+    final SystemOptionManager optionManager = getContext().getSystemOptionManager();
 
     // parse out the properties, validate, and then set them
     final String[] systemProps = allSystemProps.split(",");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.netty.channel.EventLoopGroup;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.LogicalPlanPersistence;
+import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.compile.CodeCompiler;
@@ -40,6 +41,7 @@ import org.apache.drill.exec.rpc.security.AuthenticatorProvider;
 import org.apache.drill.exec.rpc.user.UserServer;
 import org.apache.drill.exec.rpc.user.UserServer.BitToUserConnection;
 import org.apache.drill.exec.rpc.user.UserServer.BitToUserConnectionConfig;
+import org.apache.drill.exec.server.options.OptionDefinition;
 import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.store.SchemaFactory;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -157,7 +159,7 @@ public class DrillbitContext implements AutoCloseable {
    * @return the system options manager. It is important to note that this manager only contains options at the
    * "system" level and not "session" level.
    */
-  public SystemOptionManager getOptionManager() {
+  public SystemOptionManager getSystemOptionManager() {
     return systemOptions;
   }
 
@@ -259,6 +261,9 @@ public class DrillbitContext implements AutoCloseable {
   public ExecutorService getScanDecodeExecutor() {
     return context.getScanDecodeExecutor();
   }
+  public CaseInsensitiveMap<OptionDefinition> getDefinitions() {
+    return context.getDefinitions();
+  }
 
   public LogicalPlanPersistence getLpPersistence() {
     return lpPersistence;
@@ -299,7 +304,7 @@ public class DrillbitContext implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    getOptionManager().close();
+    getSystemOptionManager().close();
     getFunctionImplementationRegistry().close();
     getRemoteFunctionRegistry().close();
     getCompiler().close();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
@@ -30,6 +30,9 @@ import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 
+/**
+ * Profile data within {@link PersistentStore}
+ */
 public class QueryProfileStoreContext {
 
   private static final String PROFILES = "profiles";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/UserQueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/UserQueryProfileStoreContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.coord.ClusterCoordinator;
+import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.exec.store.sys.PersistentStoreProvider;
+
+/**
+ * It is the same as {@link UserQueryProfileStoreContext}, but created for every {@link UserSession} in case
+ * {@link org.apache.drill.exec.ExecConstants#SEPARATE_WORKSPACE} enabled
+ */
+// todo: do we need it?
+public class UserQueryProfileStoreContext extends QueryProfileStoreContext {
+
+  private static final String PROFILES = "profiles";
+  private static final String RUNNING = "running";
+//  public static final String OPTIONS_PSTORE_NAME = "options";
+//  public static final String SYS_OPTIONS_PSTORE_NAME = "sys." + OPTIONS_PSTORE_NAME;
+
+  public UserQueryProfileStoreContext(DrillConfig config, PersistentStoreProvider storeProvider,
+                                      ClusterCoordinator coordinator) {
+    super(config, storeProvider, coordinator);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/QueryOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/QueryOptionManager.java
@@ -29,7 +29,7 @@ public class QueryOptionManager extends InMemoryOptionManager {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryOptionManager.class);
 
   public QueryOptionManager(OptionManager sessionOptions) {
-    super(sessionOptions, CaseInsensitiveMap.<OptionValue>newHashMap());
+    super(sessionOptions, CaseInsensitiveMap.newHashMap());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SessionOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SessionOptionManager.java
@@ -48,7 +48,7 @@ public class SessionOptionManager extends InMemoryOptionManager {
     CaseInsensitiveMap.newConcurrentMap();
 
   public SessionOptionManager(final OptionManager systemOptions, final UserSession session) {
-    super(systemOptions, CaseInsensitiveMap.<OptionValue>newConcurrentMap());
+    super(systemOptions, CaseInsensitiveMap.newConcurrentMap());
     this.session = session;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
@@ -68,6 +68,8 @@ public class TypeValidators {
     }
   }
 
+  // TODO: add validator to check context.getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED for separate_workspace
+
   public static class PowerOfTwoLongValidator extends PositiveLongValidator {
 
     public PowerOfTwoLongValidator(String name, long max, OptionDescription description) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/UserSystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/UserSystemOptionManager.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.options;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.config.LogicalPlanPersistence;
+import org.apache.drill.common.map.CaseInsensitiveMap;
+import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.exec.store.sys.PersistentStoreProvider;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.apache.drill.exec.store.sys.PersistentStore.USER_PSTORE_ROOT_NAME;
+
+/**
+ * It is the same as {@link SystemOptionManager}, but created for every {@link UserSession} in case
+ * {@link org.apache.drill.exec.ExecConstants#SEPARATE_WORKSPACE} enabled
+ */
+public class UserSystemOptionManager extends SystemOptionManager {
+  private static final Logger logger = LoggerFactory.getLogger(UserSystemOptionManager.class);
+
+  public UserSystemOptionManager(SystemOptionManager sysManager, LogicalPlanPersistence lpPersistence, PersistentStoreProvider provider,
+                                 DrillConfig bootConfig, CaseInsensitiveMap<OptionDefinition> definitions,
+                                 UserSession session) {
+    super(lpPersistence, provider, bootConfig, definitions, String.join("/", USER_PSTORE_ROOT_NAME,
+            session.getCredentials().getUserName(), OPTIONS_PSTORE_NAME));
+    init(sysManager);
+  }
+
+  public void init(SystemOptionManager sysManager) {
+    super.init();
+    for (final Map.Entry<String, PersistedOptionValue> entry : Lists.newArrayList(sysManager.options.getAll())) {
+      final String name = entry.getKey();
+      final OptionDefinition optionDefinition = getOptionDefinition(name);
+      final PersistedOptionValue persistedOptionValue = entry.getValue();
+      final OptionValue optionValue = persistedOptionValue
+              .toOptionValue(optionDefinition, OptionValue.OptionScope.SYSTEM);
+      options.put(optionDefinition.getValidator().getOptionName().toLowerCase(), optionValue.toPersisted());
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -373,7 +373,7 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     /**
-     * @return true, if auth is enabled and separate user workspaces used
+     * @return true, if auth is enabled and Separate User Workspaces used
      */
     public boolean separateWorkspace() {
       return value && separateWorkspace;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -183,10 +183,10 @@ public class DrillRoot {
     final DrillConfig config = dbContext.getConfig();
     final boolean userEncryptionEnabled =
             config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) ||
-                    config .getBoolean(ExecConstants.USER_SSL_ENABLED);
+                    config.getBoolean(ExecConstants.USER_SSL_ENABLED);
     final boolean bitEncryptionEnabled = config.getBoolean(ExecConstants.BIT_ENCRYPTION_SASL_ENABLED);
 
-    OptionManager optionManager = work.getContext().getOptionManager();
+    OptionManager optionManager = work.getContext().getSystemOptionManager();
     final boolean isUserLoggedIn = AuthDynamicFeature.isUserLoggedIn(sc);
     final boolean shouldShowAdminInfo = isUserLoggedIn && ((DrillUserPrincipal)sc.getUserPrincipal()).isAdminUser();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/LogsResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/LogsResources.java
@@ -63,6 +63,7 @@ public class LogsResources {
   @Inject DrillRestServer.UserAuthEnabled authEnabled;
   @Inject SecurityContext sc;
   @Inject WorkManager work;
+  @Inject WebUserConnection webUserConnection;
 
   private static final FileFilter file_filter = new FileFilter() {
     @Override
@@ -113,9 +114,9 @@ public class LogsResources {
   @Produces(MediaType.APPLICATION_JSON)
   public LogContent getLogJSON(@PathParam("name") final String name) throws IOException {
     File file = getFileByName(getLogFolder(), name);
-
-    final int maxLines = work.getContext().getOptionManager().getOption(ExecConstants.WEB_LOGS_MAX_LINES).num_val.intValue();
-
+    final int maxLines = authEnabled.separateWorkspace()
+            ? webUserConnection.getSession().getSystemOptions().getOption(ExecConstants.WEB_LOGS_MAX_LINES).num_val.intValue()
+            : work.getContext().getSystemOptionManager().getOption(ExecConstants.WEB_LOGS_MAX_LINES).num_val.intValue();
     try (BufferedReader br = new BufferedReader(new FileReader(file))) {
       @SuppressWarnings("serial")
       Map<Integer, String> cache = new LinkedHashMap<Integer, String>(maxLines, .75f, true) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -87,6 +87,9 @@ public class StatusResources {
   @Inject
   HttpServletRequest request;
 
+  @Inject
+  WebUserConnection webUserConnection;
+
   @GET
   @Path(StatusResources.PATH_STATUS_JSON)
   @Produces(MediaType.APPLICATION_JSON)
@@ -112,7 +115,9 @@ public class StatusResources {
   private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal)
   {
     List<OptionWrapper> options = new LinkedList<>();
-    OptionManager optionManager = work.getContext().getOptionManager();
+    OptionManager optionManager = authEnabled.separateWorkspace()
+      ? webUserConnection.getSession().getSystemOptions()
+      : work.getContext().getSystemOptionManager();
     OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
 
     for (OptionValue option : optionList) {
@@ -183,9 +188,9 @@ public class StatusResources {
   public Viewable updateSystemOption(@FormParam("name") String name,
                                    @FormParam("value") String value,
                                    @FormParam("kind") String kind) {
-    SystemOptionManager optionManager = work.getContext()
-      .getOptionManager();
-
+    SystemOptionManager optionManager = authEnabled.separateWorkspace()
+      ? webUserConnection.getSession().getSystemOptions()
+      : work.getContext().getSystemOptionManager();
     try {
       optionManager.setLocalOption(OptionValue.Kind.valueOf(kind), name, value);
     } catch (Exception e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -115,9 +115,7 @@ public class StatusResources {
   private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal)
   {
     List<OptionWrapper> options = new LinkedList<>();
-    OptionManager optionManager = authEnabled.separateWorkspace()
-      ? webUserConnection.getSession().getSystemOptions()
-      : work.getContext().getSystemOptionManager();
+    OptionManager optionManager = getSystemOptionManager();
     OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
 
     for (OptionValue option : optionList) {
@@ -188,9 +186,7 @@ public class StatusResources {
   public Viewable updateSystemOption(@FormParam("name") String name,
                                    @FormParam("value") String value,
                                    @FormParam("kind") String kind) {
-    SystemOptionManager optionManager = authEnabled.separateWorkspace()
-      ? webUserConnection.getSession().getSystemOptions()
-      : work.getContext().getSystemOptionManager();
+    SystemOptionManager optionManager = getSystemOptionManager();
     try {
       optionManager.setLocalOption(OptionValue.Kind.valueOf(kind), name, value);
     } catch (Exception e) {
@@ -202,6 +198,12 @@ public class StatusResources {
     } else {
       return getSystemPublicOptions(null);
     }
+  }
+
+  private SystemOptionManager getSystemOptionManager() {
+    return authEnabled.separateWorkspace()
+      ? webUserConnection.getSession().getSystemOptions()
+      : work.getContext().getSystemOptionManager();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -412,7 +412,7 @@ public class WebServer implements AutoCloseable {
    */
   private void generateOptionsDescriptionJSFile() throws IOException {
     // Obtain list of Options & their descriptions
-    OptionManager optionManager = this.drillbit.getContext().getOptionManager();
+    OptionManager optionManager = this.drillbit.getContext().getSystemOptionManager();
     OptionList publicOptions = optionManager.getPublicOptionList();
     List<OptionValue> options = new ArrayList<>(publicOptions);
     // Add internal options

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
@@ -92,7 +92,7 @@ public class WebUserConnection extends BaseWebUserConnection {
   }
 
   private void addResults(int rows, VectorAccessible batch) {
-    ValueVectorElementFormatter formatter = new ValueVectorElementFormatter(webSessionResources.getSession().getOptions());
+    ValueVectorElementFormatter formatter = new ValueVectorElementFormatter(webSessionResources.getSession().getSessionOptions());
     if (autoLimitRowCount > 0) {
       rows = Math.max(0, Math.min(rows, autoLimitRowCount - rowCount));
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillRestLoginService.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillRestLoginService.java
@@ -80,14 +80,15 @@ public class DrillRestLoginService implements LoginService {
 
       logger.info("WebUser {} logged in from {}:{}", username, request.getRemoteHost(), request.getRemotePort());
 
-      final SystemOptionManager sysOptions = drillbitContext.getOptionManager();
+      final SystemOptionManager sysOptions = drillbitContext.getSystemOptionManager();
 
       final boolean isAdmin = ImpersonationUtil.hasAdminPrivileges(username,
               ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(sysOptions),
               ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(sysOptions));
 
       // Create the UserPrincipal corresponding to logged in user.
-      final Principal userPrincipal = new DrillUserPrincipal(username, isAdmin);
+      final Principal userPrincipal = new DrillUserPrincipal(username, isAdmin,
+              drillbitContext.getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE));
 
       final Subject subject = new Subject();
       subject.getPrincipals().add(userPrincipal);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoLoginService.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoLoginService.java
@@ -125,12 +125,13 @@ public class DrillSpnegoLoginService extends SpnegoLoginService {
           logger.info("WebUser {} logged in from {}:{}", userShortName, request.getRemoteHost(),
             request.getRemotePort());
           logger.debug("Client Name: {}, realm: {} and shortName: {}", clientName, realm, userShortName);
-          final SystemOptionManager sysOptions = drillContext.getOptionManager();
+          final SystemOptionManager sysOptions = drillContext.getSystemOptionManager();
           final boolean isAdmin = ImpersonationUtil.hasAdminPrivileges(userShortName,
               ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(sysOptions),
               ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(sysOptions));
 
-          final Principal user = new DrillUserPrincipal(userShortName, isAdmin);
+          final Principal user = new DrillUserPrincipal(userShortName, isAdmin,
+                  drillContext.getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE));
           final Subject subject = new Subject();
           subject.getPrincipals().add(user);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
@@ -45,12 +45,13 @@ public class DrillUserPrincipal implements Principal {
       ImmutableList.of(new RolePrincipal(AUTHENTICATED_ROLE));
 
   private final String userName;
-
   private final boolean isAdmin;
+  private final boolean separateWorkspace;
 
-  public DrillUserPrincipal(final String userName, final boolean isAdmin) {
+  public DrillUserPrincipal(final String userName, final boolean isAdmin, boolean separateWorkspace) {
     this.userName = userName;
     this.isAdmin = isAdmin;
+    this.separateWorkspace = separateWorkspace;
   }
 
   public boolean isAdminUser() { return isAdmin; }
@@ -67,7 +68,7 @@ public class DrillUserPrincipal implements Principal {
    * @return true/false
    */
   public boolean canManageProfileOf(final String profileOwner) {
-    return isAdmin || userName.equals(profileOwner);
+    return separateWorkspace ? userName.equals(profileOwner) : isAdmin || userName.equals(profileOwner);
   }
 
   /**
@@ -77,7 +78,7 @@ public class DrillUserPrincipal implements Principal {
    * @return true/false
    */
   public boolean canManageQueryOf(final String queryUser) {
-    return isAdmin || userName.equals(queryUser);
+    return separateWorkspace ? userName.equals(queryUser) : isAdmin || userName.equals(queryUser);
   }
 
   /**
@@ -85,8 +86,11 @@ public class DrillUserPrincipal implements Principal {
    */
   public static class AnonDrillUserPrincipal extends DrillUserPrincipal {
 
+    /**
+     * In anonymous (auth disabled) mode all users are admins, but they shouldn't see sessions of authorized users
+     */
     public AnonDrillUserPrincipal() {
-      super(ANONYMOUS_USER, true /* in anonymous (auth disabled) mode all users are admins */);
+      super(ANONYMOUS_USER, true, true);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
@@ -385,7 +385,7 @@ public class ProfileResources {
   @GET
   @Path("/profiles/{queryid}")
   @Produces(MediaType.TEXT_HTML)
-  public Viewable getProfile(@PathParam("queryid") String queryId){
+  public Viewable getProfile(@PathParam("queryid") String queryId) {
     try {
       ProfileWrapper wrapper = new ProfileWrapper(getQueryProfile(queryId), work.getContext().getConfig(), request);
       return ViewableWithPermissions.create(authEnabled.get(), "/rest/profile/profile.ftl", sc, wrapper);
@@ -413,12 +413,12 @@ public class ProfileResources {
       final QueryInfo info = running.get(queryId);
       checkOrThrowQueryCancelAuthorization(info.getUser(), queryId);
       Ack a = work.getContext().getController().getTunnel(info.getForeman()).requestCancelQuery(id).checkedGet(2, TimeUnit.SECONDS);
-      if(a.getOk()){
+      if (a.getOk()) {
         return String.format("Query %s canceled on node %s.", queryId, info.getForeman().getAddress());
-      }else{
+      } else {
         return String.format("Attempted to cancel query %s on %s but the query is no longer active on that node.", queryId, info.getForeman().getAddress());
       }
-    }catch(Exception e){
+    } catch(Exception e) {
       logger.debug("Failure to find query as running profile.", e);
       return String.format
           ("Failure attempting to cancel query %s.  Unable to find information about where query is actively running.", queryId);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/stream/StreamingHttpConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/stream/StreamingHttpConnection.java
@@ -229,7 +229,7 @@ public class StreamingHttpConnection extends BaseWebUserConnection {
     JsonOutput gen = writer.jsonOutput();
     if (batchCount == 0) {
       startHeader();
-      if (getSession().getOptions().getBoolean(ExecConstants.ENABLE_REST_VERBOSE_ERRORS_KEY)) {
+      if (getSession().getSessionOptions().getBoolean(ExecConstants.ENABLE_REST_VERBOSE_ERRORS_KEY)) {
         emitErrorInfo();
       }
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/DrillSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/DrillSchemaFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -30,15 +29,15 @@ import org.slf4j.LoggerFactory;
 public class DrillSchemaFactory extends AbstractSchemaFactory {
   private static final Logger logger = LoggerFactory.getLogger(DrillSchemaFactory.class);
 
-  private final StoragePluginRegistryImpl registry;
+  private final StoragePluginRegistry registry;
 
-  public DrillSchemaFactory(String name, StoragePluginRegistryImpl registry) {
+  public DrillSchemaFactory(String name, StoragePluginRegistry registry) {
     super(name);
     this.registry = registry;
   }
 
   @Override
-  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) {
     Stopwatch watch = Stopwatch.createStarted();
     registry.registerSchemas(schemaConfig, parent);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistry.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.store.dfs.FormatPlugin;
@@ -30,10 +30,9 @@ import org.apache.drill.exec.store.dfs.FormatPlugin;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public interface StoragePluginRegistry extends Iterable<Map.Entry<String, StoragePlugin>>, AutoCloseable {
-  String PSTORE_NAME = "sys.storage_plugins";
 
   @SuppressWarnings("serial")
-  public static class PluginException extends Exception {
+  class PluginException extends Exception {
     public PluginException(String msg) {
       super(msg);
     }
@@ -52,7 +51,7 @@ public interface StoragePluginRegistry extends Iterable<Map.Entry<String, Storag
    * Indicates the requested plugin was not found.
    */
   @SuppressWarnings("serial")
-  public static class PluginNotFoundException extends PluginException {
+  class PluginNotFoundException extends PluginException {
     public PluginNotFoundException(String name) {
       super("No storage plugin exists with name: `" + name + "`");
     }
@@ -62,7 +61,7 @@ public interface StoragePluginRegistry extends Iterable<Map.Entry<String, Storag
    * Indicates an error when decoding a plugin from JSON.
    */
   @SuppressWarnings("serial")
-  public static class PluginEncodingException extends PluginException {
+  class PluginEncodingException extends PluginException {
     public PluginEncodingException(String msg, Exception e) {
       super(msg, e);
     }
@@ -120,9 +119,8 @@ public interface StoragePluginRegistry extends Iterable<Map.Entry<String, Storag
    *
    * @param name The name of the plugin
    * @return The StoragePlugin instance.
-   * @throws PluginException if plugin cannot be obtained
    */
-  StoragePlugin getPlugin(String name) throws PluginException, UserException;
+  StoragePlugin getPlugin(String name);
 
   /**
    * Get a plugin by configuration. If it doesn't exist, create it.
@@ -310,4 +308,12 @@ public interface StoragePluginRegistry extends Iterable<Map.Entry<String, Storag
   <T extends FormatPlugin> T resolveFormat(
       StoragePluginConfig storageConfig,
       FormatPluginConfig formatConfig, Class<T> desired);
+
+  /**
+   * Register schema for all plugins. See {@link SchemaFactory#registerSchemas(SchemaConfig, SchemaPlus) for details}
+   *
+   * @param schemaConfig Configuration for schema objects.
+   * @param parent Reference to parent schema.
+   */
+  void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/UserStoragePluginRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/UserStoragePluginRegistry.java
@@ -17,24 +17,17 @@
  */
 package org.apache.drill.exec.store;
 
-import java.util.Iterator;
-import java.util.Map.Entry;
-
-import org.apache.drill.common.logical.StoragePluginConfig;
-import org.apache.drill.exec.planner.logical.StoragePlugins;
-import org.apache.drill.exec.store.sys.PersistentStore;
+import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.exec.server.DrillbitContext;
 
 /**
- * Interface to the storage mechanism used to store storage plugin
- * configurations, typically in JSON format.
+ * It is the same as {@link StoragePluginRegistryImpl}, but created for every {@link UserSession} in case
+ * {@link org.apache.drill.exec.ExecConstants#SEPARATE_WORKSPACE} enabled
  */
-public interface StoragePluginStore {
-  boolean isInitialized();
-  void delete(String name);
-  Iterator<Entry<String, StoragePluginConfig>> load();
-  void put(String name, StoragePluginConfig config);
-  void putAll(StoragePlugins plugins);
-  StoragePluginConfig get(String name);
-  Iterator<Entry<String, StoragePluginConfig>> getPlugins(PersistentStore<StoragePluginConfig> pluginsTable);
-  void close();
+public class UserStoragePluginRegistry extends StoragePluginRegistryImpl {
+
+  public UserStoragePluginRegistry(DrillbitContext context, UserSession session) {
+    super(context, session.getCredentials().getUserName());
+    init();
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStore.java
@@ -26,6 +26,7 @@ import java.util.Map;
  * @param <V>  value type
  */
 public interface PersistentStore<V> extends Store<V> {
+  String USER_PSTORE_ROOT_NAME = "users";
 
   /**
    * Checks if lookup key is present in store.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ZookeeperPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ZookeeperPersistentStore.java
@@ -31,7 +31,6 @@ import org.apache.drill.common.collections.ImmutableEntry;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.coord.zk.PathUtils;
 import org.apache.drill.exec.coord.zk.ZookeeperClient;
-import org.apache.drill.exec.exception.StoreException;
 import org.apache.drill.exec.serialization.InstanceSerializer;
 import org.apache.drill.exec.store.sys.BasePersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
@@ -40,7 +39,7 @@ import org.apache.drill.exec.store.sys.VersionedPersistentStore;
 import org.apache.zookeeper.CreateMode;
 
 /**
- * Zookeeper based implementation of {@link org.apache.drill.exec.store.sys.PersistentStore}.
+ * Drill Zookeeper client. Based implementation of {@link org.apache.drill.exec.store.sys.PersistentStore}.
  */
 public class ZookeeperPersistentStore<V> extends BasePersistentStore<V> implements VersionedPersistentStore<V> {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ZookeeperPersistentStore.class);
@@ -48,7 +47,7 @@ public class ZookeeperPersistentStore<V> extends BasePersistentStore<V> implemen
   private final PersistentStoreConfig<V> config;
   private final ZookeeperClient client;
 
-  public ZookeeperPersistentStore(final CuratorFramework framework, final PersistentStoreConfig<V> config) throws StoreException {
+  public ZookeeperPersistentStore(final CuratorFramework framework, final PersistentStoreConfig<V> config) {
     this.config = Preconditions.checkNotNull(config);
     this.client = new ZookeeperClient(framework, PathUtils.join("/", config.getName()), CreateMode.PERSISTENT);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/CachingPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/CachingPersistentStoreProvider.java
@@ -42,7 +42,7 @@ public class CachingPersistentStoreProvider extends BasePersistentStoreProvider 
 
   @Override
   @SuppressWarnings("unchecked")
-  public <V> PersistentStore<V> getOrCreateStore(final PersistentStoreConfig<V> config) throws StoreException {
+  public <V> PersistentStore<V> getOrCreateStore(final PersistentStoreConfig<V> config) {
     CheckedFunction<PersistentStoreConfig<?>, PersistentStore<?>, StoreException> function = provider::getOrCreateStore;
     return (PersistentStore<V>) storeCache.computeIfAbsent(config, function);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
@@ -66,7 +66,7 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
 
   @Override
   public <V> PersistentStore<V> getOrCreateStore(final PersistentStoreConfig<V> config) throws StoreException {
-    switch(config.getMode()){
+    switch(config.getMode()) {
     case BLOB_PERSISTENT:
       return new LocalPersistentStore<>(fs, blobRoot, config);
     case PERSISTENT:
@@ -74,7 +74,7 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
       try {
         store.start();
       } catch (Exception e) {
-        throw new StoreException("unable to start zookeeper store", e);
+        throw new StoreException("Unable to start zookeeper store", e);
       }
       return store;
     default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/accessor/SqlAccessor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/accessor/SqlAccessor.java
@@ -65,7 +65,7 @@ public interface SqlAccessor {
   /**
    * Reports the class returned by getObject() of this accessor.
    * <p>
-   *  (Is for {@link ResultSetMetaData#getColumnClassName(...)}.)
+   *  (Is for {@link java.sql.ResultSetMetaData#getColumnClassName(int)})
    * </p>
    */
   Class<?> getObjectClass();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -146,7 +146,7 @@ public class Foreman implements Runnable {
     // Apply AutoLimit on resultSet (Usually received via REST APIs)
     final int autoLimit = queryRequest.getAutolimitRowcount();
     if (autoLimit > 0) {
-      connection.getSession().getOptions().setLocalOption(ExecConstants.QUERY_MAX_ROWS, autoLimit);
+      connection.getSession().getSessionOptions().setLocalOption(ExecConstants.QUERY_MAX_ROWS, autoLimit);
     }
     this.queryContext = new QueryContext(connection.getSession(), drillbitContext, queryId);
     this.queryManager = new QueryManager(queryId, queryRequest, drillbitContext.getStoreProvider(),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/FragmentsRunner.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/FragmentsRunner.java
@@ -241,7 +241,7 @@ public class FragmentsRunner {
       sendRemoteFragments(ep, intermediateFragmentMap.get(ep), endpointLatch, fragmentSubmitFailures);
     }
 
-    final long timeout = drillbitContext.getOptionManager().getLong(ExecConstants.FRAG_RUNNER_RPC_TIMEOUT) * numIntFragments;
+    final long timeout = drillbitContext.getSystemOptionManager().getLong(ExecConstants.FRAG_RUNNER_RPC_TIMEOUT) * numIntFragments;
     if (numIntFragments > 0 && !endpointLatch.awaitUninterruptibly(timeout)) {
       long numberRemaining = endpointLatch.getCount();
       throw UserException.connectionError()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/DistributedQueryQueue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/DistributedQueryQueue.java
@@ -207,7 +207,7 @@ public class DistributedQueryQueue implements QueryQueue {
 
   public DistributedQueryQueue(DrillbitContext context, StatusAdapter adapter) {
     statusAdapter = adapter;
-    optionManager = context.getOptionManager();
+    optionManager = context.getSystemOptionManager();
     clusterCoordinator = context.getClusterCoordinator();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/DynamicResourceManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/DynamicResourceManager.java
@@ -79,7 +79,7 @@ public class DynamicResourceManager implements ResourceManager {
       return;
     }
     nextUpdateTime = now + recheckDelayMs;
-    SystemOptionManager systemOptions = context.getOptionManager();
+    SystemOptionManager systemOptions = context.getSystemOptionManager();
     if (systemOptions.getOption(ExecConstants.ENABLE_QUEUE)) {
       if (queueingRm == null) {
         StatusAdapter statusAdapter = new StatusAdapter() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/EmbeddedQueryQueue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/EmbeddedQueryQueue.java
@@ -104,7 +104,7 @@ public class EmbeddedQueryQueue implements QueryQueue {
     queueTimeoutMs = config.getInt(TIMEOUT_MS);
     queueSize = config.getInt(QUEUE_SIZE);
     semaphore = new Semaphore(queueSize, true);
-    minimumOperatorMemory = context.getOptionManager()
+    minimumOperatorMemory = context.getSystemOptionManager()
         .getOption(ExecConstants.MIN_MEMORY_PER_BUFFERED_OP);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
@@ -142,7 +142,7 @@ public class MetadataProvider {
 
     @Override
     public void run() {
-      try(SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(dContext)) {
+      try(SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(dContext, session)) {
         responseSender.send(runInternal(session, schemaTreeProvider));
       } catch (final Throwable error) {
         logger.error("Unhandled metadata provider error", error);
@@ -570,7 +570,7 @@ public class MetadataProvider {
       final SchemaTreeProvider provider, final UserSession userSession, final MetastoreRegistry metastoreRegistry) {
     final SchemaPlus rootSchema =
         provider.createFullRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(config, userSession, provider));
-    return tableType.getRecordReader(rootSchema, filter, userSession.getOptions(), metastoreRegistry);
+    return tableType.getRecordReader(rootSchema, filter, userSession.getSessionOptions(), metastoreRegistry);
   }
 
   /**
@@ -595,7 +595,7 @@ public class MetadataProvider {
 
       @Override
       public OptionValue getOption(String optionKey) {
-        return session.getOptions().getOption(optionKey);
+        return session.getSessionOptions().getOption(optionKey);
       }
 
       @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
@@ -122,7 +122,7 @@ public class ServerMetaProvider {
       final GetServerMetaResp.Builder respBuilder = GetServerMetaResp.newBuilder();
       try {
         final ServerMeta.Builder metaBuilder = ServerMeta.newBuilder(DEFAULT);
-        PlannerSettings plannerSettings = new PlannerSettings(session.getOptions(), context.getFunctionImplementationRegistry());
+        PlannerSettings plannerSettings = new PlannerSettings(session.getSessionOptions(), context.getFunctionImplementationRegistry());
 
         DrillParserConfig config = new DrillParserConfig(plannerSettings);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.work.prepare;
 
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 
 import io.netty.util.concurrent.Future;
@@ -79,7 +80,7 @@ public class PreparedStatementProvider {
 
   /**
    * Static list of mappings from {@link MinorType} to JDBC ResultSet class name
-   * (to be returned through {@link ResultSetMetaData#getColumnClassName(int)}.
+   * (to be returned through {@link java.sql.ResultSetMetaData#getColumnClassName(int)}.
    */
   private static final Map<MinorType, String> DRILL_TYPE_TO_JDBC_CLASSNAME = ImmutableMap.<MinorType, String>builder()
       .put(MinorType.INT, Integer.class.getName())
@@ -138,7 +139,9 @@ public class PreparedStatementProvider {
         final QueryId limit0QueryId = userWorker.submitWork(wrapper, limit0Query);
 
         final long timeoutMillis =
-            userWorker.getSystemOptions().getOption(CREATE_PREPARE_STATEMENT_TIMEOUT_MILLIS).num_val;
+            userWorker.getDrillbitContext().getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE)
+          ? wrapper.getSession().getSystemOptions().getOption(CREATE_PREPARE_STATEMENT_TIMEOUT_MILLIS).num_val
+          : userWorker.getSystemOptions().getOption(CREATE_PREPARE_STATEMENT_TIMEOUT_MILLIS).num_val;
 
         try {
           if (!wrapper.await(timeoutMillis)) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/UserWorker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/UserWorker.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.rpc.ResponseSender;
 import org.apache.drill.exec.rpc.UserClientConnection;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.rpc.user.UserSession.QueryCountIncrementer;
+import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.work.WorkManager.WorkerBee;
 import org.apache.drill.exec.work.foreman.Foreman;
@@ -44,7 +45,7 @@ import org.apache.drill.exec.work.prepare.PreparedStatementProvider.PreparedStat
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UserWorker{
+public class UserWorker {
   static final Logger logger = LoggerFactory.getLogger(UserWorker.class);
 
   private final WorkerBee bee;
@@ -96,7 +97,11 @@ public class UserWorker{
   }
 
   public OptionManager getSystemOptions() {
-    return bee.getContext().getOptionManager();
+    return bee.getContext().getSystemOptionManager();
+  }
+
+  public DrillbitContext getDrillbitContext() {
+    return bee.getContext();
   }
 
   public QueryPlanFragments getQueryPlan(UserClientConnection connection,

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -241,7 +241,8 @@ drill.exec: {
     max_chained_user_hops: 3
   },
   security.user.auth: {
-    enabled: false
+    enabled: false,
+    separate_workspace: false
   },
   security.bit.auth: {
     enabled: false

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -88,10 +88,6 @@ public class PlanningBase extends ExecTest {
     final LogicalPlanPersistence logicalPlanPersistence = new LogicalPlanPersistence(config, scanResult);
     final SystemOptionManager systemOptions = new SystemOptionManager(logicalPlanPersistence, provider, config);
     systemOptions.init();
-    final UserSession userSession = UserSession.Builder.newBuilder().withOptionManagers(dbContext).build();
-    final SessionOptionManager sessionOptions = userSession.getSessionOptions();
-    final QueryOptionManager queryOptions = new QueryOptionManager(sessionOptions);
-    final ExecutionControls executionControls = new ExecutionControls(queryOptions, DrillbitEndpoint.getDefaultInstance());
 
     when(dbContext.getMetrics()).thenReturn(new MetricRegistry());
     when(dbContext.getAllocator()).thenReturn(allocator);
@@ -100,6 +96,11 @@ public class PlanningBase extends ExecTest {
     when(dbContext.getStoreProvider()).thenReturn(provider);
     when(dbContext.getClasspathScan()).thenReturn(scanResult);
     when(dbContext.getLpPersistence()).thenReturn(logicalPlanPersistence);
+
+    final UserSession userSession = UserSession.Builder.newBuilder().withOptionManagers(dbContext).build();
+    final SessionOptionManager sessionOptions = userSession.getSessionOptions();
+    final QueryOptionManager queryOptions = new QueryOptionManager(sessionOptions);
+    final ExecutionControls executionControls = new ExecutionControls(queryOptions, DrillbitEndpoint.getDefaultInstance());
 
     final StoragePluginRegistry registry = new StoragePluginRegistryImpl(dbContext);
     registry.init();
@@ -113,7 +114,7 @@ public class PlanningBase extends ExecTest {
     when(context.getStorage()).thenReturn(registry);
     when(context.getFunctionRegistry()).thenReturn(functionRegistry);
     when(context.getSession()).thenReturn(
-        UserSession.Builder.newBuilder().withOptionManagers(dbContext).setSupportComplexTypes(true).build());
+        UserSession.Builder.newBuilder().setSupportComplexTypes(true).build());
     when(context.getCurrentEndpoint()).thenReturn(DrillbitEndpoint.getDefaultInstance());
     when(context.getActiveEndpoints()).thenReturn(ImmutableList.of(DrillbitEndpoint.getDefaultInstance()));
     when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry));

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -88,15 +88,15 @@ public class PlanningBase extends ExecTest {
     final LogicalPlanPersistence logicalPlanPersistence = new LogicalPlanPersistence(config, scanResult);
     final SystemOptionManager systemOptions = new SystemOptionManager(logicalPlanPersistence, provider, config);
     systemOptions.init();
-    final UserSession userSession = UserSession.Builder.newBuilder().withOptionManager(systemOptions).build();
-    final SessionOptionManager sessionOptions = userSession.getOptions();
+    final UserSession userSession = UserSession.Builder.newBuilder().withOptionManagers(dbContext).build();
+    final SessionOptionManager sessionOptions = userSession.getSessionOptions();
     final QueryOptionManager queryOptions = new QueryOptionManager(sessionOptions);
     final ExecutionControls executionControls = new ExecutionControls(queryOptions, DrillbitEndpoint.getDefaultInstance());
 
     when(dbContext.getMetrics()).thenReturn(new MetricRegistry());
     when(dbContext.getAllocator()).thenReturn(allocator);
     when(dbContext.getConfig()).thenReturn(config);
-    when(dbContext.getOptionManager()).thenReturn(systemOptions);
+    when(dbContext.getSystemOptionManager()).thenReturn(systemOptions);
     when(dbContext.getStoreProvider()).thenReturn(provider);
     when(dbContext.getClasspathScan()).thenReturn(scanResult);
     when(dbContext.getLpPersistence()).thenReturn(logicalPlanPersistence);
@@ -113,7 +113,7 @@ public class PlanningBase extends ExecTest {
     when(context.getStorage()).thenReturn(registry);
     when(context.getFunctionRegistry()).thenReturn(functionRegistry);
     when(context.getSession()).thenReturn(
-        UserSession.Builder.newBuilder().withOptionManager(sessionOptions).setSupportComplexTypes(true).build());
+        UserSession.Builder.newBuilder().withOptionManagers(dbContext).setSupportComplexTypes(true).build());
     when(context.getCurrentEndpoint()).thenReturn(DrillbitEndpoint.getDefaultInstance());
     when(context.getActiveEndpoints()).thenReturn(ImmutableList.of(DrillbitEndpoint.getDefaultInstance()));
     when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
@@ -91,7 +91,7 @@ public class ExecTest extends DrillTest {
     when(context.getAllocator()).thenReturn(RootAllocatorFactory.newRoot(c));
     when(context.getOperatorCreatorRegistry()).thenReturn(new OperatorCreatorRegistry(ClassPathScanner.fromPrescan(c)));
     when(context.getConfig()).thenReturn(c);
-    when(context.getOptionManager()).thenReturn(optionManager);
+    when(context.getSystemOptionManager()).thenReturn(optionManager);
     when(context.getCompiler()).thenReturn(CodeCompilerTestFactory.getTestCompiler(c));
 
     return context;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassTransformation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassTransformation.java
@@ -56,9 +56,9 @@ public class TestClassTransformation extends BaseTestQuery {
     // configuration.
     System.setProperty(CodeCompiler.PREFER_POJ_CONFIG, "false");
     final UserSession userSession = UserSession.Builder.newBuilder()
-      .withOptionManager(getDrillbitContext().getOptionManager())
+      .withOptionManagers(getDrillbitContext())
       .build();
-    sessionOptions = userSession.getOptions();
+    sessionOptions = userSession.getSessionOptions();
   }
 
   @Test
@@ -232,7 +232,7 @@ public class TestClassTransformation extends BaseTestQuery {
 
   private <T, X extends T> CodeGenerator<T> newCodeGenerator(Class<T> iface, Class<X> impl) {
     final TemplateClassDefinition<T> template = new TemplateClassDefinition<>(iface, impl);
-    CodeGenerator<T> cg = CodeGenerator.get(template, getDrillbitContext().getOptionManager());
+    CodeGenerator<T> cg = CodeGenerator.get(template, getDrillbitContext().getSystemOptionManager());
     cg.plainJavaCapable(true);
 
     ClassGenerator<T> root = cg.getRoot();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/rm/TestMemoryCalculator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/rm/TestMemoryCalculator.java
@@ -66,7 +66,7 @@ public class TestMemoryCalculator extends PlanTestBase {
       .setUserName("foo")
       .build())
     .withUserProperties(UserProtos.UserProperties.getDefaultInstance())
-    .withOptionManager(bits[0].getContext().getOptionManager())
+    .withOptionManagers(bits[0].getContext())
     .build();
 
   private static final DrillbitEndpoint N1_EP1 = newDrillbitEndpoint("node1", 30010);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestCustomUserAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestCustomUserAuthenticator.java
@@ -71,14 +71,14 @@ public class TestCustomUserAuthenticator extends ClusterTest {
     ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher)
         .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
         .configProperty(ExecConstants.INITIAL_USER_PORT, QueryTestUtil.getFreePortNumber(31170, 300))
-        .configProperty(ExecConstants.INITIAL_BIT_PORT, QueryTestUtil.getFreePortNumber(31180, 300));
+        .configProperty(ExecConstants.INITIAL_BIT_PORT, QueryTestUtil.getFreePortNumber(31180, 300))
+        // Setup specific auth settings
+        .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, false)
+        .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, "NonExistingImpl");
 
-    // Setup specific auth settings
-    ClusterFixture cluster = builder.configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, false)
-        .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, "NonExistingImpl")
-        .build();
-
-    runTest(TEST_USER_1, TEST_USER_1_PASSWORD, cluster);
+    try (ClusterFixture cluster = builder.build()) {
+      runTest(TEST_USER_1, TEST_USER_1_PASSWORD, cluster);
+    }
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSaslCompatibility.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSaslCompatibility.java
@@ -288,7 +288,7 @@ public class TestUserBitSaslCompatibility extends BaseTestQuery {
    * @throws Exception
    */
   @Test
-  public void testDisableDrillbitClientAuth() throws Exception {
+  public void testDisableDrillbitClientAuth() {
     final DrillConfig newConfig = new DrillConfig(DrillConfig.create(cloneDefaultTestConfigProperties())
         .withValue(ExecConstants.USER_AUTHENTICATION_ENABLED,
             ConfigValueFactory.fromAnyRef(false)));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/testing/UserAuthenticatorTestImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/testing/UserAuthenticatorTestImpl.java
@@ -35,9 +35,9 @@ import static org.apache.drill.exec.impersonation.TestInboundImpersonation.OWNER
 import static org.apache.drill.exec.impersonation.TestInboundImpersonation.OWNER_PASSWORD;
 
 /**
- * Implement {@link org.apache.drill.exec.rpc.user.security.UserAuthenticator} for testing:
- * + UserAuthenticator and authentication of users from Java client to Drillbit.
- * + {@link TestInboundImpersonation user delegation}.
+ * Implement {@link org.apache.drill.exec.rpc.user.security.UserAuthenticator} for testing:</br>
+ * UserAuthenticator and authentication of users from Java client to Drillbit.</br>
+ * {@link org.apache.drill.exec.impersonation.TestInboundImpersonation} user delegation.
  */
 @UserAuthenticatorTemplate(type = UserAuthenticatorTestImpl.TYPE)
 public class UserAuthenticatorTestImpl implements UserAuthenticator {
@@ -45,10 +45,12 @@ public class UserAuthenticatorTestImpl implements UserAuthenticator {
 
   public static final String TEST_USER_1 = "testUser1";
   public static final String TEST_USER_2 = "testUser2";
+  public static final String TEST_USER_3 = "testUser3";
   public static final String ADMIN_USER = "admin";
   public static final String PROCESS_USER = ImpersonationUtil.getProcessUserName();
   public static final String TEST_USER_1_PASSWORD = "testUser1Password";
   public static final String TEST_USER_2_PASSWORD = "testUser2Password";
+  public static final String TEST_USER_3_PASSWORD = "testUser3Password";
   public static final String ADMIN_USER_PASSWORD = "adminUserPw";
   public static final String PROCESS_USER_PASSWORD = "processUserPw";
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
@@ -134,7 +134,7 @@ public class TestOptionsAuthEnabled extends BaseTestQuery {
       // Admin Users Tests
       // config file should have the 'fake' default admin user and it should be returned
       // by the option manager if the option has not been set by the user
-      String configAdminUser =  optionManager.getOption(ExecConstants.ADMIN_USERS_VALIDATOR);
+      String configAdminUser = optionManager.getOption(ExecConstants.ADMIN_USERS_VALIDATOR);
       assertEquals(configAdminUser, ExecConstants.ADMIN_USERS_VALIDATOR.DEFAULT_ADMIN_USERS);
 
       // Option accessor should never return the 'fake' default from the config

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
@@ -129,7 +129,7 @@ public class TestOptionsAuthEnabled extends BaseTestQuery {
 
     try (ClusterFixture cluster = ClusterFixture.standardCluster(dirTestWatcher);
          ClientFixture client = cluster.clientFixture()) {
-      OptionManager optionManager = cluster.drillbit().getContext().getOptionManager();
+      OptionManager optionManager = cluster.drillbit().getContext().getSystemOptionManager();
 
       // Admin Users Tests
       // config file should have the 'fake' default admin user and it should be returned

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
@@ -23,6 +23,7 @@ import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.QueryWrapper.RestQueryBuilder;
 import org.apache.drill.exec.server.rest.RestQueryRunner.QueryResult;
@@ -47,14 +48,16 @@ public class RestServerTest extends ClusterTest {
   }
 
   protected QueryResult runQuery(QueryWrapper q) throws Exception {
-    SystemOptionManager systemOptions = cluster.drillbit().getContext().getOptionManager();
+    DrillbitContext context = cluster.drillbit().getContext();
+    SystemOptionManager systemOptions = context.getSystemOptionManager();
     DrillUserPrincipal principal = new DrillUserPrincipal.AnonDrillUserPrincipal();
     WebSessionResources webSessionResources = new WebSessionResources(
-      cluster.drillbit().getContext().getAllocator(),
+      context.getAllocator(),
       new LocalAddress("test"),
       UserSession.Builder.newBuilder()
-        .withOptionManager(systemOptions)
+        .withOptionManagers(context)
         .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(principal.getName()).build())
+        .withStorage(context)
         .build(),
       Mockito.mock(Promise.class));
     WebUserConnection connection = new WebUserConnection.AnonWebUserConnection(webSessionResources);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
@@ -19,20 +19,19 @@ package org.apache.drill.exec.server.rest;
 
 import io.netty.util.concurrent.Promise;
 import io.netty.channel.local.LocalAddress;
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.DrillbitContext;
-import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.QueryWrapper.RestQueryBuilder;
 import org.apache.drill.exec.server.rest.RestQueryRunner.QueryResult;
-import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
 import org.apache.drill.exec.work.WorkManager;
 import org.apache.drill.exec.work.foreman.Foreman;
 import org.apache.drill.test.ClusterTest;
 import org.mockito.Mockito;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER;
 
 public class RestServerTest extends ClusterTest {
 
@@ -50,16 +49,11 @@ public class RestServerTest extends ClusterTest {
 
   protected QueryResult runQuery(QueryWrapper q) throws Exception {
     DrillbitContext context = cluster.drillbit().getContext();
-    SystemOptionManager systemOptions = context.getSystemOptionManager();
-//    DrillUserPrincipal principal = new DrillUserPrincipal.AnonDrillUserPrincipal();
-    DrillUserPrincipal principal = new DrillUserPrincipal(q.getUserName(), true,
-            cluster.drillbit().getContext().getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE));
     WebSessionResources webSessionResources = new WebSessionResources(
       context.getAllocator(),
       new LocalAddress("test"),
       UserSession.Builder.newBuilder()
-//        .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(q.userName).build())
-        .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(principal.getName()).build())
+        .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(PROCESS_USER).build())
         .withOptionManagers(context)
         .withStorage(context)
         .build(),

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.server.rest;
 
 import io.netty.util.concurrent.Promise;
 import io.netty.channel.local.LocalAddress;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
@@ -50,13 +51,16 @@ public class RestServerTest extends ClusterTest {
   protected QueryResult runQuery(QueryWrapper q) throws Exception {
     DrillbitContext context = cluster.drillbit().getContext();
     SystemOptionManager systemOptions = context.getSystemOptionManager();
-    DrillUserPrincipal principal = new DrillUserPrincipal.AnonDrillUserPrincipal();
+//    DrillUserPrincipal principal = new DrillUserPrincipal.AnonDrillUserPrincipal();
+    DrillUserPrincipal principal = new DrillUserPrincipal(q.getUserName(), true,
+            cluster.drillbit().getContext().getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE));
     WebSessionResources webSessionResources = new WebSessionResources(
       context.getAllocator(),
       new LocalAddress("test"),
       UserSession.Builder.newBuilder()
-        .withOptionManagers(context)
+//        .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(q.userName).build())
         .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName(principal.getName()).build())
+        .withOptionManagers(context)
         .withStorage(context)
         .build(),
       Mockito.mock(Promise.class));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapperImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapperImpersonation.java
@@ -20,20 +20,25 @@ package org.apache.drill.exec.server.rest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.rest.RestQueryRunner.QueryResult;
+import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
 import org.apache.drill.test.ClusterFixture;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public final class TestQueryWrapperImpersonation extends RestServerTest {
 
   @BeforeClass
-  public static void setupServer() throws Exception {
+  public static void setupServer() {
     startCluster(ClusterFixture.bareBuilder(dirTestWatcher)
       .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
-      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true));
+      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
+      .configProperty(ExecConstants.SEPARATE_WORKSPACE, true));
   }
 
   @Test
@@ -52,5 +57,36 @@ public final class TestQueryWrapperImpersonation extends RestServerTest {
     UserBitShared.QueryProfile queryProfile = getQueryProfile(result);
     assertNotNull(queryProfile);
     assertEquals("anonymous", queryProfile.getUser());
+  }
+
+  @Test
+  public void testSeparateUserWorkSpace() throws Exception {
+    QueryResult result1 = runQueryWithUsername(
+            "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "drilluser1");
+    UserBitShared.QueryProfile queryProfile1 = getQueryProfile(result1);
+    assertNotNull(queryProfile1);
+    assertEquals("drilluser1", queryProfile1.getUser());
+    QueryResult result2 = runQueryWithUsername(
+            "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "drilluser2");
+    UserBitShared.QueryProfile queryProfile2 = getQueryProfile(result2);
+    assertNotNull(queryProfile2);
+    assertEquals("drilluser2", queryProfile2.getUser());
+
+    final DrillUserPrincipal drillUser1PrincipalSeparateWorkspace = new DrillUserPrincipal("drilluser1", true,
+            cluster.drillbit().getContext().getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE));
+    assertFalse("The only drilluser2 can manage his profile",
+            drillUser1PrincipalSeparateWorkspace.canManageProfileOf(queryProfile2.getUser()));
+
+    shutdown();
+    startCluster(ClusterFixture.bareBuilder(dirTestWatcher)
+            .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
+            .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
+            .configProperty(ExecConstants.SEPARATE_WORKSPACE, false));
+    QueryResult result3 = runQueryWithUsername(
+            "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "drilluser3");
+    final DrillUserPrincipal drillUser1PrincipalCommonWorkspace = new DrillUserPrincipal("drilluser1", true,
+            cluster.drillbit().getContext().getConfig().getBoolean(ExecConstants.SEPARATE_WORKSPACE));
+    assertTrue("drilluser1 can manage drilluser3's profile too",
+            drillUser1PrincipalCommonWorkspace.canManageProfileOf(getQueryProfile(result3).getUser()));
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapperImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapperImpersonation.java
@@ -17,8 +17,10 @@
  */
 package org.apache.drill.exec.server.rest;
 
+import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
 import org.apache.drill.exec.server.rest.RestQueryRunner.QueryResult;
 import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
 import org.apache.drill.test.ClusterFixture;
@@ -26,6 +28,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -38,7 +42,14 @@ public final class TestQueryWrapperImpersonation extends RestServerTest {
     startCluster(ClusterFixture.bareBuilder(dirTestWatcher)
       .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
       .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
-      .configProperty(ExecConstants.SEPARATE_WORKSPACE, true));
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .configProperty(ExecConstants.SEPARATE_WORKSPACE, true)
+//      .configProperty(ExecConstants.ADMIN_USERS_KEY, "alfred")
+//      .configClientProperty(DrillProperties.USER, TEST_USER_1)
+      .configClientProperty(DrillProperties.USER, "alfred")
+      .configClientProperty(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD));
+//      .configClientProperty(ExecConstants.ADMIN_USERS_KEY, "alfred"));
   }
 
   @Test
@@ -47,6 +58,7 @@ public final class TestQueryWrapperImpersonation extends RestServerTest {
         "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "alfred");
     UserBitShared.QueryProfile queryProfile = getQueryProfile(result);
     assertNotNull(queryProfile);
+//    client.alterSystem(ExecConstants.ADMIN_USERS_KEY, "alfred");
     assertEquals("alfred", queryProfile.getUser());
   }
 
@@ -81,7 +93,11 @@ public final class TestQueryWrapperImpersonation extends RestServerTest {
     startCluster(ClusterFixture.bareBuilder(dirTestWatcher)
             .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
             .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
-            .configProperty(ExecConstants.SEPARATE_WORKSPACE, false));
+            .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, false)
+            .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+            .configProperty(ExecConstants.SEPARATE_WORKSPACE, false)
+            .configClientProperty(DrillProperties.USER, TEST_USER_1)
+            .configClientProperty(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD));
     QueryResult result3 = runQueryWithUsername(
             "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "drilluser3");
     final DrillUserPrincipal drillUser1PrincipalCommonWorkspace = new DrillUserPrincipal("drilluser1", true,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -110,7 +110,7 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
 
     final DrillbitContext drillbitContext = Mockito.mock(DrillbitContext.class);
     Mockito.when(drillbitContext.getConfig()).thenReturn(newConfig);
-    Mockito.when(drillbitContext.getOptionManager()).thenReturn(optionManager);
+    Mockito.when(drillbitContext.getSystemOptionManager()).thenReturn(optionManager);
 
     Authenticator.AuthConfiguration authConfiguration = Mockito.mock(Authenticator.AuthConfiguration.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
@@ -297,7 +297,7 @@ public class TestSpnegoAuthentication extends BaseTest {
 
     final DrillbitContext drillbitContext = Mockito.mock(DrillbitContext.class);
     Mockito.when(drillbitContext.getConfig()).thenReturn(newConfig);
-    Mockito.when(drillbitContext.getOptionManager()).thenReturn(optionManager);
+    Mockito.when(drillbitContext.getSystemOptionManager()).thenReturn(optionManager);
 
     final DrillSpnegoLoginService loginService = new DrillSpnegoLoginService(drillbitContext);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/BasePluginRegistry.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/BasePluginRegistry.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.exec.store.dfs.FileSystemConfig;
+import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
+import org.junit.After;
+import org.junit.ClassRule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BasePluginRegistry extends BaseTest {
+    @ClassRule
+    public static final BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();
+
+    protected static final String SYS_PLUGIN_NAME = "sys";
+    protected static final String S3_PLUGIN_NAME = "s3";
+
+    // Mixed-case name used to verify that names are forced to lower case.
+    protected static final String MY_PLUGIN_NAME = "myPlugin";
+
+    // Lower-case form after insertion into the registry.
+    protected static final String MY_PLUGIN_KEY = MY_PLUGIN_NAME.toLowerCase();
+
+    @After
+    public void cleanup() throws Exception {
+        FileUtils.cleanDirectory(dirTestWatcher.getStoreDir());
+    }
+
+    protected FileSystemConfig myConfig1() {
+        FileSystemConfig config = new FileSystemConfig("myConn",
+                new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
+        config.setEnabled(true);
+        return config;
+    }
+
+    protected FileSystemConfig myConfig2() {
+        Map<String, String> props = new HashMap<>();
+        props.put("foo", "bar");
+        FileSystemConfig config = new FileSystemConfig("myConn",
+                props, new HashMap<>(), new HashMap<>(),
+                PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
+        config.setEnabled(true);
+        return config;
+    }
+
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestPluginRegistry.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestPluginRegistry.java
@@ -28,11 +28,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ExecConstants;
@@ -43,13 +41,8 @@ import org.apache.drill.exec.store.StoragePluginRegistry.PluginFilter;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.dfs.FileSystemPlugin;
 import org.apache.drill.exec.store.easy.text.TextFormatPlugin.TextFormatConfig;
-import org.apache.drill.common.logical.security.PlainCredentialsProvider;
-import org.apache.drill.test.BaseDirTestWatcher;
-import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
-import org.junit.After;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 /**
@@ -63,42 +56,7 @@ import org.junit.Test;
  * This is several big tests because of the setup cost of
  * starting the Drillbits in the needed config.
  */
-public class TestPluginRegistry extends BaseTest {
-
-  @ClassRule
-  public static final BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();
-
-  private static final String SYS_PLUGIN_NAME = "sys";
-  private static final String S3_PLUGIN_NAME = "s3";
-
-  // Mixed-case name used to verify that names are forced to lower case.
-  private static final String MY_PLUGIN_NAME = "myPlugin";
-
-  // Lower-case form after insertion into the registry.
-  private static final String MY_PLUGIN_KEY = MY_PLUGIN_NAME.toLowerCase();
-
-  @After
-  public void cleanup() throws Exception {
-    FileUtils.cleanDirectory(dirTestWatcher.getStoreDir());
-  }
-
-  private FileSystemConfig myConfig1() {
-    FileSystemConfig config = new FileSystemConfig("myConn",
-        new HashMap<>(), new HashMap<>(), new HashMap<>(),
-        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
-    config.setEnabled(true);
-    return config;
-  }
-
-  private FileSystemConfig myConfig2() {
-    Map<String, String> props = new HashMap<>();
-    props.put("foo", "bar");
-    FileSystemConfig config = new FileSystemConfig("myConn",
-        props, new HashMap<>(), new HashMap<>(),
-        PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
-    config.setEnabled(true);
-    return config;
-  }
+public class TestPluginRegistry extends BasePluginRegistry {
 
   @Test
   public void testLifecycle() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestUserPluginRegistry.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestUserPluginRegistry.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store;
+
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.rpc.user.UserServer;
+import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
+import org.apache.drill.exec.store.dfs.FileSystemConfig;
+import org.apache.drill.exec.store.dfs.FileSystemPlugin;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2_PASSWORD;
+import static org.apache.drill.exec.util.StoragePluginTestUtils.CP_PLUGIN_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestUserPluginRegistry extends BasePluginRegistry {
+
+    @Test
+    public void testSeparatePluginsForUsers() throws Exception {
+        ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher)
+                .clusterSize(1)
+                .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
+                .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+                .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+                .configProperty(ExecConstants.SEPARATE_WORKSPACE, true);
+
+        try (ClusterFixture cluster = builder.build();
+             ClientFixture client1 = cluster.clientBuilder()
+                     .property(DrillProperties.USER, TEST_USER_1)
+                     .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+                     .build();
+             ClientFixture client2 = cluster.clientBuilder()
+                     .property(DrillProperties.USER, TEST_USER_2)
+                     .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+                     .build()) {
+
+            Map<String, StoragePluginRegistry> userStorage = new HashMap<>();
+            for (Map.Entry<UserServer.BitToUserConnection, UserServer.BitToUserConnectionConfig> userConnection : cluster.drillbit().getContext().getUserConnections()) {
+                UserSession session = userConnection.getKey().getSession();
+                userStorage.put(session.getCredentials().getUserName(), session.getStorage());
+            }
+
+            // Check the separate UserStoragePluginRegistry is used for each user
+            assertEquals(2, userStorage.size());
+            assertEquals("It should be UserStoragePluginRegistry for separate user", UserStoragePluginRegistry.class,
+                    userStorage.get(TEST_USER_1).getClass());
+            assertEquals("It should be UserStoragePluginRegistry for separate user", UserStoragePluginRegistry.class,
+                    userStorage.get(TEST_USER_2).getClass());
+            assertNotSame(userStorage.get(TEST_USER_1), userStorage.get(TEST_USER_2));
+
+            // Create a new plugin for TEST_USER_1
+            FileSystemConfig pConfig1 = myConfig1();
+            assertFalse(userStorage.get(TEST_USER_1).availablePlugins().contains(MY_PLUGIN_KEY));
+            userStorage.get(TEST_USER_1).put(MY_PLUGIN_NAME, pConfig1);
+
+            // Check plugin is created for TEST_USER_1
+            assertTrue(userStorage.get(TEST_USER_1).availablePlugins().contains(MY_PLUGIN_KEY));
+            StoragePlugin plugin = userStorage.get(TEST_USER_1).getPlugin(MY_PLUGIN_NAME);
+            assertNotNull(plugin);
+            assertSame(plugin, userStorage.get(TEST_USER_1).getPluginByConfig(pConfig1));
+
+            // Check TEST_USER_2 doesn't have TEST_USER_1's plugin
+            assertFalse(userStorage.get(TEST_USER_2).availablePlugins().contains(MY_PLUGIN_KEY));
+            StoragePlugin nullPlugin = userStorage.get(TEST_USER_2).getPlugin(MY_PLUGIN_NAME);
+            assertNull(nullPlugin);
+        }
+    }
+
+    @Test
+    public void testLifecycleSeparateWorkspace() throws Exception {
+        ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher)
+                .clusterSize(2)
+                .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
+                .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+                .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+                .configProperty(ExecConstants.SEPARATE_WORKSPACE, true);
+        builder.configClientProperty(DrillProperties.USER, TEST_USER_1);
+        builder.configClientProperty(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD);
+
+        try (ClusterFixture cluster = builder.build();
+             ClientFixture client = cluster.clientBuilder().build()) {
+            Map<String, StoragePluginRegistry> userStorage = new HashMap<>();
+            for (Map.Entry<UserServer.BitToUserConnection, UserServer.BitToUserConnectionConfig> userConnection : cluster.drillbit().getContext().getUserConnections()) {
+                UserSession session = userConnection.getKey().getSession();
+                userStorage.put(session.getCredentials().getUserName(), session.getStorage());
+            }
+            StoragePluginRegistry registry = userStorage.get(TEST_USER_1);
+            // Bootstrap file loaded.
+            assertNotNull(registry.getPlugin(CP_PLUGIN_NAME)); // Normal
+            assertNotNull(registry.getPlugin(SYS_PLUGIN_NAME)); // System
+            assertNull(registry.getStoredConfig(SYS_PLUGIN_NAME)); // Not editable
+
+            assertNull(registry.getPlugin("bogus"));
+
+            // Enabled plugins
+            Map<String, StoragePluginConfig> configMap = registry.enabledConfigs();
+            assertTrue(configMap.containsKey(CP_PLUGIN_NAME));
+            assertFalse(configMap.containsKey(S3_PLUGIN_NAME)); // Disabled, but still appears
+            assertFalse(configMap.containsKey(SYS_PLUGIN_NAME));
+
+            assertNotNull(registry.getDefinedConfig(CP_PLUGIN_NAME));
+            assertNull(registry.getDefinedConfig(S3_PLUGIN_NAME));
+            assertNotNull(registry.getDefinedConfig(SYS_PLUGIN_NAME));
+
+            // All stored plugins, including disabled
+            configMap = registry.storedConfigs();
+            assertTrue(configMap.containsKey(CP_PLUGIN_NAME));
+            assertTrue(configMap.containsKey(S3_PLUGIN_NAME)); // Disabled, but still appears
+            assertNotNull(configMap.get(S3_PLUGIN_NAME));
+            assertSame(registry.getStoredConfig(S3_PLUGIN_NAME), configMap.get(S3_PLUGIN_NAME));
+            assertFalse(configMap.containsKey(SYS_PLUGIN_NAME));
+            int bootstrapCount = configMap.size();
+
+            // Enabled only
+            configMap = registry.storedConfigs(StoragePluginRegistry.PluginFilter.ENABLED);
+            assertTrue(configMap.containsKey(CP_PLUGIN_NAME));
+            assertFalse(configMap.containsKey(S3_PLUGIN_NAME));
+
+            // Disabled only
+            configMap = registry.storedConfigs(StoragePluginRegistry.PluginFilter.DISABLED);
+            assertFalse(configMap.containsKey(CP_PLUGIN_NAME));
+            assertTrue(configMap.containsKey(S3_PLUGIN_NAME));
+
+            // Create a new plugin
+            FileSystemConfig pConfig11 = myConfig1();
+            registry.put(MY_PLUGIN_NAME, pConfig11);
+            StoragePlugin plugin1 = registry.getPlugin(MY_PLUGIN_NAME);
+            assertNotNull(plugin1);
+            assertSame(plugin1, registry.getPluginByConfig(pConfig11));
+            configMap = registry.storedConfigs();
+
+            // Names converted to lowercase in persistent storage
+            assertTrue(configMap.containsKey(MY_PLUGIN_KEY));
+            assertEquals(bootstrapCount + 1, configMap.size());
+
+            // Names are case-insensitive
+            assertSame(plugin1, registry.getPlugin(MY_PLUGIN_KEY));
+            assertSame(plugin1, registry.getPlugin(MY_PLUGIN_NAME.toUpperCase()));
+
+            // Update the plugin
+            FileSystemConfig pConfig2 = myConfig2();
+            registry.put(MY_PLUGIN_NAME, pConfig2);
+            StoragePlugin plugin2 = registry.getPlugin(MY_PLUGIN_NAME);
+            assertNotSame(plugin1, plugin2);
+            assertTrue(plugin2 instanceof FileSystemPlugin);
+            FileSystemPlugin fsStorage = (FileSystemPlugin) plugin2;
+            assertSame(pConfig2, fsStorage.getConfig());
+            assertSame(plugin2, registry.getPluginByConfig(pConfig2));
+
+            // Cannot create/update a plugin with null or blank name
+
+            FileSystemConfig pConfig3 = myConfig1();
+            try {
+                registry.put(null, pConfig3);
+                fail();
+            } catch (StoragePluginRegistry.PluginException e) {
+                // Expected
+            }
+            try {
+                registry.put("  ", pConfig3);
+                fail();
+            } catch (StoragePluginRegistry.PluginException e) {
+                // Expected
+            }
+        }
+    }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
@@ -69,7 +69,7 @@ public class ControlsInjectionUtil {
   public static void setControls(final UserSession session, final String controls) {
     validateControlsString(controls);
 
-    final SessionOptionManager options = session.getOptions();
+    final SessionOptionManager options = session.getSessionOptions();
     try {
       options.setLocalOption(DRILLBIT_CONTROL_INJECTIONS, controls);
     } catch (final Exception e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestCountDownLatchInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestCountDownLatchInjection.java
@@ -39,7 +39,7 @@ public class TestCountDownLatchInjection extends BaseTestQuery {
       .setUserName("foo")
       .build())
     .withUserProperties(UserProperties.getDefaultInstance())
-    .withOptionManager(bits[0].getContext().getOptionManager())
+    .withOptionManagers(bits[0].getContext())
     .build();
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestExceptionInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestExceptionInjection.java
@@ -42,7 +42,7 @@ public class TestExceptionInjection extends BaseTestQuery {
   private static final UserSession session = UserSession.Builder.newBuilder()
       .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName("foo").build())
       .withUserProperties(UserProperties.getDefaultInstance())
-      .withOptionManager(bits[0].getContext().getOptionManager())
+      .withOptionManagers(bits[0].getContext())
       .build();
 
   /**
@@ -233,7 +233,7 @@ public class TestExceptionInjection extends BaseTestQuery {
       final UserSession session = UserSession.Builder.newBuilder()
           .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName("foo").build())
           .withUserProperties(UserProperties.getDefaultInstance())
-          .withOptionManager(drillbitContext1.getOptionManager())
+          .withOptionManagers(drillbitContext1)
           .build();
 
       final String passthroughDesc = "<<injected from descPassthrough>>";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
@@ -49,7 +49,7 @@ public class TestPauseInjection extends BaseTestQuery {
         .setUserName("foo")
         .build())
       .withUserProperties(UserProperties.getDefaultInstance())
-      .withOptionManager(bits[0].getContext().getOptionManager())
+      .withOptionManagers(bits[0].getContext())
       .build();
 
   /**
@@ -199,7 +199,7 @@ public class TestPauseInjection extends BaseTestQuery {
           .setUserName("foo")
           .build())
         .withUserProperties(UserProperties.getDefaultInstance())
-        .withOptionManager(drillbitContext1.getOptionManager())
+        .withOptionManagers(drillbitContext1)
         .build();
 
       final DrillbitEndpoint drillbitEndpoint1 = drillbitContext1.getEndpoint();
@@ -275,7 +275,7 @@ public class TestPauseInjection extends BaseTestQuery {
           .setUserName("foo")
           .build())
         .withUserProperties(UserProperties.getDefaultInstance())
-        .withOptionManager(drillbitContext1.getOptionManager())
+        .withOptionManagers(drillbitContext1)
         .build();
 
       final DrillbitEndpoint drillbitEndpoint1 = drillbitContext1.getEndpoint();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.StoragePluginRegistryImpl;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.junit.runner.Description;
 
@@ -109,7 +109,7 @@ public class BaseDirTestWatcher extends DirTestWatcher {
     spillDir = makeSubDir(Paths.get("spill"));
     rootDir = makeSubDir(Paths.get("root"));
     tmpDir = makeSubDir(Paths.get("tmp"));
-    storeDir = makeSubDir(Paths.get(StoragePluginRegistry.PSTORE_NAME));
+    storeDir = makeSubDir(Paths.get(StoragePluginRegistryImpl.SYS_STORAGE_PSTORE_NAME));
     dfsTestTmpParentDir = makeSubDir(Paths.get("dfsTestTmp"));
     homeDir = makeSubDir(Paths.get("home"));
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
@@ -109,11 +109,8 @@ public class ClientFixture implements AutoCloseable {
     } else {
       client = new DrillClient(cluster.config(), cluster.serviceSet().getCoordinator());
     }
-    System.out.println("connecting client" );
     client.connect(builder.clientProps);
-    System.out.println("builder.clientProps.propertyNames(): " + builder.clientProps);
     cluster.clients.add(this);
-    System.out.println("cluster.clients.size() " + cluster.clients.size());
   }
 
   public DrillClient client() { return client; }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
@@ -72,7 +72,6 @@ public class ClientFixture implements AutoCloseable {
      * @param value property value
      * @return this builder
      */
-
     public ClientBuilder property(String key, Object value) {
       if (clientProps == null) {
         clientProps = new Properties();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
@@ -109,8 +109,11 @@ public class ClientFixture implements AutoCloseable {
     } else {
       client = new DrillClient(cluster.config(), cluster.serviceSet().getCoordinator());
     }
+    System.out.println("connecting client" );
     client.connect(builder.clientProps);
+    System.out.println("builder.clientProps.propertyNames(): " + builder.clientProps);
     cluster.clients.add(this);
+    System.out.println("cluster.clients.size() " + cluster.clients.size());
   }
 
   public DrillClient client() { return client; }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -296,6 +296,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
   public Drillbit drillbit() { return defaultDrillbit; }
   public Drillbit drillbit(String name) { return bits.get(name); }
   public Collection<Drillbit> drillbits() { return bits.values(); }
+  public Map<String, Drillbit> drillbitsWithNames() { return bits; }
   public RemoteServiceSet serviceSet() { return serviceSet; }
 
   public ClientFixture.ClientBuilder clientBuilder() {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixtureBuilder.java
@@ -205,7 +205,7 @@ public class ClusterFixtureBuilder {
    * @param bitNames array of (unique) Drillbit names
    * @return this builder
    */
-  public ClusterFixtureBuilder withBits(String...bitNames) {
+  public ClusterFixtureBuilder withBits(String... bitNames) {
     this.bitNames = bitNames;
     bitCount = bitNames.length;
     return this;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
@@ -78,7 +78,7 @@ public class ClusterTest extends DrillTest {
   protected static ClusterFixture cluster;
   protected static ClientFixture client;
 
-  protected static void startCluster(ClusterFixtureBuilder builder) throws Exception {
+  protected static void startCluster(ClusterFixtureBuilder builder) {
     cluster = builder.build();
     client = cluster.clientFixture();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryTestUtil.java
@@ -277,7 +277,7 @@ public class QueryTestUtil {
       final Drillbit drillbit, final ClassTransformer.ScalarReplacementOption srOption) {
     // set the system option
     final DrillbitContext drillbitContext = drillbit.getContext();
-    final SystemOptionManager optionManager = drillbitContext.getOptionManager();
+    final SystemOptionManager optionManager = drillbitContext.getSystemOptionManager();
     final OptionValue originalOptionValue = optionManager.getOption(ExecConstants.SCALAR_REPLACEMENT_OPTION);
     optionManager.setLocalOption(ExecConstants.SCALAR_REPLACEMENT_OPTION, srOption.name().toLowerCase());
 
@@ -298,7 +298,7 @@ public class QueryTestUtil {
    */
   public static void restoreScalarReplacementOption(final Drillbit drillbit, final String srOption) {
     final DrillbitContext drillbitContext = drillbit.getContext();
-    final OptionManager optionManager = drillbitContext.getOptionManager();
+    final OptionManager optionManager = drillbitContext.getSystemOptionManager();
     optionManager.setLocalOption(ExecConstants.SCALAR_REPLACEMENT_OPTION, srOption);
 
     // flush the code cache


### PR DESCRIPTION
# [DRILL-7871](https://issues.apache.org/jira/browse/DRILL-7871): StoragePluginStore instances for different users

## Description

This feature allows to have the separate plugin set per user. Profiles are restricted per user too.

## Documentation
To enable the feature:
`drill.exec.security.user.auth.separate_workspace`

See [doc](https://docs.google.com/document/d/1mFjDGPHID70SG5uwP8FZImI0eyEwjSmbTCaSzOU7sjc/edit#heading=h.r9daa8xzn6i5) fr more info

## Testing
Unit tests. Manual testing of Drill WebUI and JDBC connection via SqlLine. Details in [doc](https://docs.google.com/document/d/1mFjDGPHID70SG5uwP8FZImI0eyEwjSmbTCaSzOU7sjc/edit#heading=h.r9daa8xzn6i5)
