### PR TITLE
[DOC UPDATE] Update dead links

### DIFF
--- a/_docs/connect-a-data-source/036-configuring-storage-plugins.md
+++ b/_docs/connect-a-data-source/036-configuring-storage-plugins.md
@@ -19,7 +19,7 @@ You can use the Drill Web UI to update or add a new storage plugin configuration
 To create a name and new configuration:
 
 1. [Start the Drill shell]({{site.baseurl}}/docs/starting-drill-on-linux-and-mac-os-x/).
-2. [Start the Web UI]({{site.baseurl}}/docs/starting-the-web-console/). The Storage tab appears in the Web UI if you are [authorized]({{site.baseurl}}/docs/configuring-web-console-and-rest-api-security/) to view, update, or add storage plugins. 
+2. [Start the Web UI]({{site.baseurl}}/docs/starting-the-web-ui/). The Storage tab appears in the Web UI if you are [authorized]({{site.baseurl}}/docs/configuring-web-ui-and-rest-api-security/) to view, update, or add storage plugins. 
 3. On the Storage tab, enter a name in **New Storage Plugin**.
    Each configuration registered with Drill must have a distinct
 name. Names are case-sensitive.  


### PR DESCRIPTION
# [DRILL-7949](https://issues.apache.org/jira/browse/DRILL-7949): [DOC UPDATE] Update dead links

## Description
Update two dead links to live links:  
`/docs/starting-the-web-console/` to `/docs/starting-the-web-ui/`;  
`/docs/configuring-web-console-and-rest-api-security` to `/docs/configuring-web-ui-and-rest-api-security/`


## Documentation
This is a doc update, no doc related

## Testing
This is a doc update, no test related