### PR TITLE
DRILL-7950: Drill classpath includes both avatica-core:jar:1.15.0 and avatica:jar:1.17.0

### DIFF
--- a/contrib/storage-cassandra/pom.xml
+++ b/contrib/storage-cassandra/pom.xml
@@ -52,6 +52,10 @@
           <groupId>com.datastax.cassandra</groupId>
           <artifactId>cassandra-driver-core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite.avatica</groupId>
+          <artifactId>avatica-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/contrib/storage-elasticsearch/pom.xml
+++ b/contrib/storage-elasticsearch/pom.xml
@@ -49,7 +49,12 @@
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
-        </exclusion></exclusions>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite.avatica</groupId>
+          <artifactId>avatica-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>


### PR DESCRIPTION
# [DRILL-7950](https://issues.apache.org/jira/browse/DRILL-7950): Drill classpath includes both avatica-core:jar:1.15.0 and avatica:jar:1.17.0

## Description
```
mvn dependency:tree -Dincludes=org.apache.calcite.avatica:avatica* -pl contrib/storage-cassandra,contrib/storage-elasticsearch

[INFO] ----------< org.apache.drill.contrib:drill-storage-cassandra >----------
[INFO] Building Drill : Contrib : Storage : Cassandra 1.19.0              [1/2]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ drill-storage-cassandra ---
[INFO] org.apache.drill.contrib:drill-storage-cassandra:jar:1.19.0
[INFO] +- org.apache.drill.exec:drill-java-exec:jar:1.19.0:compile
[INFO] |  \- org.apache.calcite.avatica:avatica:jar:1.17.0:compile
[INFO] \- com.github.vvysotskyi.drill-calcite:calcite-cassandra:jar:1.21.0-drill-r2:compile
[INFO]    \- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
[INFO]       \- org.apache.calcite.avatica:avatica-metrics:jar:1.15.0:compile
[INFO]
[INFO] --------< org.apache.drill.contrib:drill-storage-elasticsearch >--------
[INFO] Building Drill : Contrib : Storage : ElasticSearch 1.19.0          [2/2]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ drill-storage-elasticsearch ---
[INFO] org.apache.drill.contrib:drill-storage-elasticsearch:jar:1.19.0
[INFO] +- org.apache.drill.exec:drill-java-exec:jar:1.19.0:compile
[INFO] |  \- org.apache.calcite.avatica:avatica:jar:1.17.0:compile
[INFO] \- com.github.vvysotskyi.drill-calcite:calcite-elasticsearch:jar:1.21.0-drill-r2:compile
[INFO]    \- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
[INFO]       \- org.apache.calcite.avatica:avatica-metrics:jar:1.15.0:compile
```

## Documentation
NA

## Testing
NA
