### PR TITLE
DRILL-7947: Unable to aggregate or filter nullable decimals in large record sets

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroColumnConverterFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroColumnConverterFactory.java
@@ -91,14 +91,15 @@ public class AvroColumnConverterFactory extends ColumnConverterFactory {
         });
       case VARDECIMAL:
         return new ColumnConverter.ScalarColumnConverter(value -> {
-          BigInteger bigInteger;
+          byte[] bytes;
           if (value instanceof ByteBuffer) {
             ByteBuffer decBuf = (ByteBuffer) value;
-            bigInteger = new BigInteger(decBuf.array());
+            bytes = decBuf.array();
           } else {
             GenericFixed genericFixed = (GenericFixed) value;
-            bigInteger = new BigInteger(genericFixed.bytes());
+            bytes = genericFixed.bytes();
           }
+          BigInteger bigInteger = bytes.length == 0 ? BigInteger.ZERO : new BigInteger(bytes);
           BigDecimal decimalValue = new BigDecimal(bigInteger, readerSchema.scale());
           writer.setDecimal(decimalValue);
         });

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetTableMetadataUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetTableMetadataUtils.java
@@ -360,7 +360,8 @@ public class ParquetTableMetadataUtils {
         case BINARY:
         case FIXED_LEN_BYTE_ARRAY:
           if (originalType == OriginalType.DECIMAL) {
-            return new BigInteger(getBytes(value));
+            byte[] bytes = getBytes(value);
+            return bytes.length == 0 ? BigInteger.ZERO : new BigInteger(bytes);
           } else if (originalType == OriginalType.INTERVAL) {
             return getBytes(value);
           } else {
@@ -402,9 +403,11 @@ public class ParquetTableMetadataUtils {
     } else if (value instanceof String) {
       return Integer.parseInt(value.toString());
     } else if (value instanceof byte[]) {
-      return new BigInteger((byte[]) value).intValue();
+      byte[] bytes = (byte[]) value;
+      return bytes.length == 0 ? 0 : new BigInteger(bytes).intValue();
     } else if (value instanceof Binary) {
-      return new BigInteger(((Binary) value).getBytes()).intValue();
+      byte[] bytes = ((Binary) value).getBytes();
+      return bytes.length == 0 ? 0 : new BigInteger(bytes).intValue();
     }
     throw new UnsupportedOperationException(String.format("Cannot obtain Integer using value %s", value));
   }
@@ -415,9 +418,11 @@ public class ParquetTableMetadataUtils {
     } else if (value instanceof String) {
       return Long.parseLong(value.toString());
     } else if (value instanceof byte[]) {
-      return new BigInteger((byte[]) value).longValue();
+      byte[] bytes = (byte[]) value;
+      return bytes.length == 0 ? 0L : new BigInteger(bytes).longValue();
     } else if (value instanceof Binary) {
-      return new BigInteger(((Binary) value).getBytes()).longValue();
+      byte[] bytes = ((Binary) value).getBytes();
+      return bytes.length == 0 ? 0L : new BigInteger(bytes).longValue();
     }
     throw new UnsupportedOperationException(String.format("Cannot obtain Integer using value %s", value));
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/DecimalUtility.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/DecimalUtility.java
@@ -67,7 +67,7 @@ public class DecimalUtility {
   public static BigDecimal getBigDecimalFromDrillBuf(DrillBuf bytebuf, int start, int length, int scale) {
     byte[] value = new byte[length];
     bytebuf.getBytes(start, value, 0, length);
-    BigInteger unscaledValue = new BigInteger(value);
+    BigInteger unscaledValue = length == 0 ? BigInteger.ZERO : new BigInteger(value);
     return new BigDecimal(unscaledValue, scale);
   }
 
@@ -337,9 +337,9 @@ public class DecimalUtility {
    * @return 1 if left > right, 0 if left = right, -1 if left < right.  two values that are numerically equal, but with different
    * scales (e.g., 2.00 and 2), are considered equal.
    */
-  public static int compareVarLenBytes(DrillBuf left, int leftStart, int leftEnd, int leftScale, byte right[], int rightScale, boolean absCompare) {
+  public static int compareVarLenBytes(DrillBuf left, int leftStart, int leftEnd, int leftScale, byte[] right, int rightScale, boolean absCompare) {
     java.math.BigDecimal bdLeft = getBigDecimalFromDrillBuf(left, leftStart, leftEnd - leftStart, leftScale);
-    java.math.BigDecimal bdRight = new BigDecimal(new BigInteger(right), rightScale);
+    java.math.BigDecimal bdRight = new BigDecimal(right.length == 0 ? BigInteger.ZERO : new BigInteger(right), rightScale);
     if (absCompare) {
       bdLeft = bdLeft.abs();
       bdRight = bdRight.abs();


### PR DESCRIPTION
# [DRILL-7947](https://issues.apache.org/jira/browse/DRILL-7947): Unable to aggregate or filter nullable decimals in large record sets

## Description
Enforced returning `BigInteger.ZERO` for the case when empty byte array is used to create `BigInteger`.

## Documentation
NA

## Testing
Checked manually.
