### PR TITLE
Fix typo in XMLBatchReader: "Failed to open ~open~ input file"

### DIFF
--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLBatchReader.java
@@ -91,7 +91,7 @@ public class XMLBatchReader implements ManagedReader<FileSchemaNegotiator> {
     } catch (Exception e) {
       throw UserException
         .dataReadError(e)
-        .message("Failed to open open input file: {}", split.getPath().toString())
+        .message("Failed to open input file: {}", split.getPath().toString())
         .addContext(errorContext)
         .addContext(e.getMessage())
         .build(logger);


### PR DESCRIPTION
# [No ticket]: Fix typo in XMLBatchReader error message

## Description

Fixes a typo.

## Documentation

When opening an XML file fails, the error message now says "Failed to open input file" instead of "Failed to open open input file".

## Testing

Untested.
