### PR TITLE
DRILL-7931: Rowtype mismatch in DrillReduceAggregatesRule

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillReduceAggregatesRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillReduceAggregatesRule.java
@@ -298,7 +298,14 @@ public class DrillReduceAggregatesRule extends RelOptRule {
       for (int ordinal : ordinals) {
         oldArgTypes.add(inputExprs.get(ordinal).getType());
       }
-
+      //to solve AggregateCall returns true with equals method but has
+      // different RelDataTypes
+      if (aggCallMapping.containsKey(oldCall) && !aggCallMapping.get(oldCall)
+        .getType().equals(oldCall.getType())) {
+        int index = newCalls.size() + nGroups;
+        newCalls.add(oldCall);
+        return rexBuilder.makeInputRef(oldCall.getType(), index);
+      }
       return rexBuilder.addAggCall(
           oldCall,
           nGroups,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -1239,4 +1239,18 @@ public class TestAggregateFunctions extends ClusterTest {
       client.resetSession(PlannerSettings.STREAMAGG.getOptionName());
     }
   }
+
+  @Test //DRILL-7931
+  public void testRowTypeMissMatch() throws Exception {
+    testBuilder()
+      .sqlQuery("select col1, stddev(col2) as g1, SUM(col2) as g2 FROM " +
+        "(values ('UA', 3), ('USA', 2), ('UA', 3), ('USA', 5), ('USA', 1), " +
+        "('UA', 9)) t(col1, col2) GROUP BY col1 order by col1")
+      .unOrdered()
+      .approximateEquality(0.000001)
+      .baselineColumns("col1", "g1", "g2")
+      .baselineValues("UA", 3.4641016151377544, 15L)
+      .baselineValues("USA", 2.0816659994661326, 8L)
+      .go();
+  }
 }


### PR DESCRIPTION
# [DRILL-7931](https://issues.apache.org/jira/browse/DRILL-7931): Rowtype mismatch in DrillReduceAggregatesRule

## Description
With stddev and sum for the same column c, stddev will be convert to sum(c) as $1, sum(c*c)  as $2, count() as $3, sum will be convert to $sum0(c) as $4 with return type "bigint not null". In the next iteration, $1 will be converted to $sum0(c) with return type "nullable bigint". In the equals method of AggregateCall.java, the return type is not included, so $4 will be considered already exist in aggCallMapping and return $sum0(c) with return type "nullable bigint" which causes the exception.

## Documentation
NA

## Testing
org.apache.drill.exec.fn.impl.TestAggregateFunctions.testRowTypeMissMatch