### PR TITLE
DRILL-5177: Use much cheaper estimated record count when determining stats for a mongo scan

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -492,7 +492,7 @@ public class MongoGroupScan extends AbstractGroupScan implements
       MongoClient client = storagePlugin.getClient();
       MongoDatabase db = client.getDatabase(scanSpec.getDbName());
       MongoCollection<Document> collection = db.getCollection(scanSpec.getCollectionName());
-      long numDocs = collection.countDocuments();
+      long numDocs = collection.estimatedDocumentCount();
 
       if (maxRecords > 0 && numDocs > 0) {
         recordCount = Math.min(maxRecords, numDocs);


### PR DESCRIPTION
# [DRILL-5177](https://issues.apache.org/jira/browse/DRILL-5177): Use much cheaper estimated record count when determining stats for a mongo scan

## Description

Mongo provides a much cheaper method for getting an estimated row count, the current implementation issues an expensive aggregate query that gets an accurate row count, but mongo DB is very slow to execute this on large collections.

## Documentation
No doc change, just an internal perf improvement.

## Testing
So far just a manual test.
