### PR TITLE
DRILL-7952: Fix Scan Stats for Mongo Plugin

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -508,7 +508,7 @@ public class MongoGroupScan extends AbstractGroupScan implements
         String json = collection.find().first().toJson(codec);
         approxDiskCost = json.getBytes().length * recordCount;
       }
-      return new ScanStats(GroupScanProperty.EXACT_ROW_COUNT, recordCount, 1, approxDiskCost);
+      return new ScanStats(GroupScanProperty.ESTIMATED_TOTAL_COST, recordCount, 1, approxDiskCost);
     } catch (Exception e) {
       throw new DrillRuntimeException(e.getMessage(), e);
     }


### PR DESCRIPTION
# [DRILL-7952](https://issues.apache.org/jira/browse/DRILL-7952): Fix Scan Stats for Mongo Plugin

## Description
Updates ScanStats in Mongo Group Scan to reflect the estimated row count instead of the exact count.

## Documentation
No user facing changes

## Testing
Ran existing unit tests