### PR TITLE
[DOC UPDATE] Wildcard Matching Documentation

### DIFF
--- a/_docs/query-data/query-a-file-system/040-querying-directories.md
+++ b/_docs/query-data/query-a-file-system/040-querying-directories.md
@@ -152,3 +152,22 @@ Starting in Drill 1.16, Drill uses a Value operator instead of a Scan operator t
  
 You can use [query directory functions]({{site.baseurl}}/docs/query-directory-functions/) to restrict a query to one of a number of subdirectories and to prevent Drill from scanning all data in directories.
 
+## Querying Multiple Directories in One Query by Wildcard Matching
+
+You can query multiple directories and multiple files in one query with the help of Wildcard Matching conveniently.
+
+1. Query a set of directories:
+   
+        SELECT * FROM dfs.`multilevel/parquet/{1994,1995}`;
+
+2. Query all files in a directory:
+
+        SELETCT * FROM dfs.`multilevel/parquet/1994/*`;
+
+3. Query multiple directories by single character wildcard matching:
+
+        SELECT * FROM dfs.`multilevel/parquet/199?/*`
+   
+4. Query multiple directories by single character range wildcard matching:
+
+        SELECT * FROM dfs.`multilevel/parquet/199[4-5]/*`


### PR DESCRIPTION
# [DOC UPDATE] Wildcard Matching Documentation

## Description

Documented Wildcard Matching function with example.

## Documentation

Documented in:  
https://drill.apache.org/docs/querying-directories/

## Testing
UT reference to:
https://github.com/apache/drill/blob/4aefcef2b665c5737471664912a26ef6ed9a6cfc/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestGlob.java
