### PR TITLE
DRILL-7968: ANALYZE TABLE ... REFRESH METADATA fails with FLOAT4 column.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoWriters.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoWriters.java
@@ -28,10 +28,12 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.vector.BigIntVector;
 import org.apache.drill.exec.vector.BitVector;
+import org.apache.drill.exec.vector.Float4Vector;
 import org.apache.drill.exec.vector.Float8Vector;
 import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.exec.vector.NullableBigIntVector;
 import org.apache.drill.exec.vector.NullableBitVector;
+import org.apache.drill.exec.vector.NullableFloat4Vector;
 import org.apache.drill.exec.vector.NullableFloat8Vector;
 import org.apache.drill.exec.vector.NullableIntVector;
 import org.apache.drill.exec.vector.NullableTimeStampVector;
@@ -59,6 +61,8 @@ public class PojoWriters {
       return new NBigIntWriter(fieldName);
     } else if (type == Boolean.class) {
       return new NBooleanWriter(fieldName);
+    } else if (type == Float.class) {
+      return new NFloatWriter(fieldName);
     } else if (type == Double.class) {
       return new NDoubleWriter(fieldName);
     } else if (type.isEnum()) {
@@ -72,6 +76,8 @@ public class PojoWriters {
       // primitives
     } else if (type == int.class) {
       return new IntWriter(fieldName);
+    } else if (type == float.class) {
+      return new FloatWriter(fieldName);
     } else if (type == double.class) {
       return new DoubleWriter(fieldName);
     } else if (type == boolean.class) {
@@ -130,6 +136,21 @@ public class PojoWriters {
 
   }
 
+  /**
+   * Pojo writer for float. Does not expect to write null value.
+   */
+  public static class FloatWriter extends AbstractPojoWriter<Float4Vector> {
+
+    public FloatWriter(String fieldName) {
+      super(fieldName, Types.required(MinorType.FLOAT4));
+    }
+
+    @Override
+    public void writeField(Object value, int outboundIndex) {
+      vector.getMutator().setSafe(outboundIndex, (float) value);
+    }
+
+  }
   /**
    * Pojo writer for double. Does not expect to write null value.
    */
@@ -276,6 +297,24 @@ public class PojoWriters {
     public void writeField(Object value, int outboundIndex) {
       if (value != null) {
         vector.getMutator().setSafe(outboundIndex, (Boolean) value ? 1 : 0);
+      }
+    }
+
+  }
+
+  /**
+   * Pojo writer for Float. If null is encountered does not write it.
+   */
+  public static class NFloatWriter extends AbstractPojoWriter<NullableFloat4Vector> {
+
+    public NFloatWriter(String fieldName) {
+      super(fieldName, Types.optional(MinorType.FLOAT4));
+    }
+
+    @Override
+    public void writeField(Object value, int outboundIndex) {
+      if (value != null) {
+        vector.getMutator().setSafe(outboundIndex, (Float) value);
       }
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
@@ -3533,14 +3533,13 @@ public class TestMetastoreCommands extends ClusterTest {
 
   @Test
   public void testAnalyzeAllTypes7kRows() throws Exception {
-    // See DRILL-7968.  More rows are produced here to test an ANALYZE code path
-    // not exercised by the Parquet test files found above.
+    // DRILL-7968.
 
     // enable CROSS JOIN
     client.alterSession(PlannerSettings.NLJOIN_FOR_SCALAR.getOptionName(), false);
     String tableName = "alltypes_7k";
     // create a ~7k row table with the schema of alltypes_optional.parquet
-    run("create table dfs.tmp.%s as select a.* from dfs.tmp.`alltypes_optional.parquet` a cross join cp.`employee.json` e", tableName);
+    run("create table dfs.tmp.%s as select a.* from cp.`parquet/alltypes_optional.parquet` a cross join cp.`employee.json` e", tableName);
 
     try {
       testBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
@@ -3531,6 +3531,40 @@ public class TestMetastoreCommands extends ClusterTest {
     run("analyze table dfs.%s.%s refresh metadata", workspaceName, tableName);
   }
 
+  @Test
+  public void testAnalyzeAllTypes7kRows() throws Exception {
+    // See DRILL-7968.  More rows are produced here to test an ANALYZE code path
+    // not exercised by the Parquet test files found above.
+
+    // enable CROSS JOIN
+    client.alterSession(PlannerSettings.NLJOIN_FOR_SCALAR.getOptionName(), false);
+    String tableName = "alltypes_7k";
+    // create a ~7k row table with the schema of alltypes_optional.parquet
+    run("create table dfs.tmp.%s as select a.* from dfs.tmp.`alltypes_optional.parquet` a cross join cp.`employee.json` e", tableName);
+
+    try {
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      String query = "select * from dfs.tmp.`%s`";
+
+      queryBuilder()
+          .sql(query, tableName)
+          .planMatcher()
+          .include("usedMetastore=true")
+          .match();
+
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+      client.resetSession(PlannerSettings.NLJOIN_FOR_SCALAR.getOptionName());
+    }
+  }
+
   public static <T> ColumnStatistics<T> getColumnStatistics(T minValue, T maxValue,
       long rowCount, TypeProtos.MinorType minorType) {
     return new ColumnStatistics<>(


### PR DESCRIPTION
This commit adds support for java.lang.Float to PojoWriters.java and a
test for the problem described in DRILL-7968 to TestMetastoreCommands.java.

For tables with fewer than ~200 rows and a FLOAT4 column there is no bug: the ANALYZE command succeeds and, indeed, this case is exercised by tests in TestMetastoreCommands.java and alltypes_{required,optional}.parquet which both contain a FLOAT4 column.

But for tables with more than ~200 rows and a FLOAT4 column the ANALYZE command fails with

```
SQL Error: EXECUTION_ERROR ERROR: PojoRecordReader doesn't yet support conversions from the type [class java.lang.Float].

Failed to setup reader: DynamicPojoRecordReader
```

E.g. you can reproduce the above with

```sql
create table dfs.tmp.test_analyze as
select cast(1 as float) from cp.`employee.json`;

analyze table dfs.tmp.test_analyze refresh metadata;
```

## Documentation
No user-visible change.

## Testing
TestMetastoreCommands.java and ad hoc SQL testing.
