### PR TITLE
DRILL-7970: Add URL Parameters to HTTP Plugin

### DIFF
--- a/contrib/storage-http/README.md
+++ b/contrib/storage-http/README.md
@@ -45,6 +45,23 @@ The `connection` property can accept the following options.
 
 `url`: The base URL which Drill will query.
 
+##### Parameters in the URL
+Many APIs require parameters to be passed directly in the URL instead of as query arguments.  For example, github's API allows you to query an organization's repositories with the following
+URL:  https://github.com/orgs/{org}/repos
+
+As of Drill 1.20.0, you can simply set the URL in the connection using the curly braces.  If your API includes URL parameters you MUST
+include them in the `WHERE` clause in your query, or Drill will throw an error. 
+
+As an example, the API above, you would have to query as shown below:
+
+```sql
+SELECT * 
+FROM api.github
+WHERE org = 'apache'
+```
+
+This query would replace the `org`in the URL with the value from the `WHERE` clause, in this case `apache`. 
+
 `requireTail`: Set to `true` if the query must contain an additional part of the service
 URL as a table name, `false` if the URL needs no additional suffix other than that
 provided by `WHERE` clause filters. (See below.)

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -135,6 +135,10 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     if (subScan.tableSpec().tableName() != null) {
       baseUrl += subScan.tableSpec().tableName();
     }
+
+    // Add URL Parameters to baseURL
+    baseUrl = SimpleHttp.mapURLParameters(HttpUrl.parse(baseUrl), subScan.filters());
+
     HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
     if (apiConfig.params() != null && !apiConfig.params().isEmpty() &&
         subScan.filters() != null) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPushDownListener.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPushDownListener.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.http;
 
+import okhttp3.HttpUrl;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 import org.apache.drill.common.map.CaseInsensitiveMap;
@@ -30,6 +31,7 @@ import org.apache.drill.exec.store.base.filter.ExprNode.ColRelOpConstNode;
 import org.apache.drill.exec.store.base.filter.ExprNode.OrNode;
 import org.apache.drill.exec.store.base.filter.FilterPushDownListener;
 import org.apache.drill.exec.store.base.filter.FilterPushDownStrategy;
+import org.apache.drill.exec.store.http.util.SimpleHttp;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +47,7 @@ import java.util.Set;
  * <li>An AND'ed set of such expressions,</li>
  * <li>If the value is one with an unambiguous conversion to
  * a string. (That is, not dates, binary, maps, etc.)</li>
+ * <li>A field from the URL.  For instance in some APIs you have parameters that are part of the path.</li>
  * </ul>
  */
 public class HttpPushDownListener implements FilterPushDownListener {
@@ -82,8 +85,19 @@ public class HttpPushDownListener implements FilterPushDownListener {
 
     HttpScanPushDownListener(HttpGroupScan groupScan) {
       this.groupScan = groupScan;
+      // Add fields from config
       for (String field : groupScan.getHttpConfig().params()) {
         filterParams.put(field, field);
+      }
+
+      // Add fields from the URL path as denoted by {}
+      HttpUrl url = HttpUrl.parse(groupScan.getHttpConfig().url());
+      if (url != null) {
+        List<String> urlParams = SimpleHttp.getURLParameters(url);
+        assert urlParams != null;
+        for (String urlField : urlParams) {
+          filterParams.put(urlField, urlField);
+        }
       }
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.store.http.HttpApiConfig;
 import org.apache.drill.exec.store.http.HttpApiConfig.HttpMethod;
 import org.apache.drill.exec.store.http.HttpStoragePluginConfig;
 import org.apache.drill.exec.store.http.HttpSubScan;
+import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +43,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -74,13 +77,23 @@ public class SimpleHttp {
   private String responseURL;
 
   public SimpleHttp(HttpSubScan scanDefn, HttpUrl url, File tempDir,
-      HttpProxyConfig proxyConfig, CustomErrorContext errorContext) {
+                    HttpProxyConfig proxyConfig, CustomErrorContext errorContext) {
     this.scanDefn = scanDefn;
     this.url = url;
     this.tempDir = tempDir;
     this.proxyConfig = proxyConfig;
     this.errorContext = errorContext;
     this.client = setupHttpClient();
+  }
+
+  // For Testing Only
+  public SimpleHttp(String url) {
+    this.url = HttpUrl.parse(url);
+    this.client = null;
+    this.scanDefn = null;
+    this.tempDir = null;
+    this.proxyConfig = null;
+    this.errorContext = null;
   }
 
   /**
@@ -130,11 +143,12 @@ public class SimpleHttp {
           new InetSocketAddress(proxyConfig.host, proxyConfig.port)));
       if (proxyConfig.username != null) {
         builder.proxyAuthenticator(new Authenticator() {
-          @Override public Request authenticate(Route route, Response response) {
+          @Override
+          public Request authenticate(Route route, Response response) {
             String credential = Credentials.basic(proxyConfig.username, proxyConfig.password);
             return response.request().newBuilder()
-              .header("Proxy-Authorization", credential)
-              .build();
+                .header("Proxy-Authorization", credential)
+                .build();
           }
         });
       }
@@ -143,7 +157,22 @@ public class SimpleHttp {
     return builder.build();
   }
 
-  public String url() { return url.toString(); }
+  public String url() {
+    return url.toString();
+  }
+
+  /**
+   * Returns the URL-decoded URL
+   *
+   * @return Returns the URL-decoded URL
+   */
+  public String decodedURL() {
+    try {
+      return URLDecoder.decode(url.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return url.toString();
+    }
+  }
 
   public InputStream getInputStream() {
 
@@ -176,8 +205,8 @@ public class SimpleHttp {
     try {
       // Execute the request
       Response response = client
-        .newCall(request)
-        .execute();
+          .newCall(request)
+          .execute();
 
       // Preserve the response
       responseMessage = response.message();
@@ -186,14 +215,14 @@ public class SimpleHttp {
       responseURL = response.request().url().toString();
 
       // If the request is unsuccessful, throw a UserException
-      if (! isSuccessful(responseCode)) {
+      if (!isSuccessful(responseCode)) {
         throw UserException
-          .dataReadError()
-          .message("HTTP request failed")
-          .addContext("Response code", response.code())
-          .addContext("Response message", response.message())
-          .addContext(errorContext)
-          .build(logger);
+            .dataReadError()
+            .message("HTTP request failed")
+            .addContext("Response code", response.code())
+            .addContext("Response message", response.message())
+            .addContext(errorContext)
+            .build(logger);
       }
       logger.debug("HTTP Request for {} successful.", url());
       logger.debug("Response Headers: {} ", response.headers());
@@ -202,11 +231,11 @@ public class SimpleHttp {
       return Objects.requireNonNull(response.body()).byteStream();
     } catch (IOException e) {
       throw UserException
-        .dataReadError(e)
-        .message("Failed to read the HTTP response body")
-        .addContext("Error message", e.getMessage())
-        .addContext(errorContext)
-        .build(logger);
+          .dataReadError(e)
+          .message("Failed to read the HTTP response body")
+          .addContext("Error message", e.getMessage())
+          .addContext(errorContext)
+          .build(logger);
     }
   }
 
@@ -215,21 +244,23 @@ public class SimpleHttp {
    * with okhttp3.  The issue is that in some cases, a user may not want Drill to throw
    * errors on 400 response codes.  This function will return true/false depending on the
    * configuration for the specific connection.
+   *
    * @param responseCode An int of the connection code
    * @return True if the response code is 200-299 and possibly 400-499, false if other
    */
   private boolean isSuccessful(int responseCode) {
     if (scanDefn.tableSpec().connectionConfig().errorOn400()) {
-      return ((responseCode >= 200 && responseCode <=299) ||
-        (responseCode >= 400 && responseCode <=499));
+      return ((responseCode >= 200 && responseCode <= 299) ||
+          (responseCode >= 400 && responseCode <= 499));
     } else {
-      return responseCode >= 200 && responseCode <=299;
+      return responseCode >= 200 && responseCode <= 299;
     }
   }
 
   /**
    * Gets the HTTP response code from the HTTP call.  Note that this value
    * is only available after the getInputStream() method has been called.
+   *
    * @return int value of the HTTP response code
    */
   public int getResponseCode() {
@@ -239,6 +270,7 @@ public class SimpleHttp {
   /**
    * Gets the HTTP response code from the HTTP call.  Note that this value
    * is only available after the getInputStream() method has been called.
+   *
    * @return int of HTTP response code
    */
   public String getResponseMessage() {
@@ -248,6 +280,7 @@ public class SimpleHttp {
   /**
    * Gets the HTTP response code from the HTTP call.  Note that this value
    * is only available after the getInputStream() method has been called.
+   *
    * @return The HTTP response protocol
    */
   public String getResponseProtocol() {
@@ -257,6 +290,7 @@ public class SimpleHttp {
   /**
    * Gets the HTTP response code from the HTTP call.  Note that this value
    * is only available after the getInputStream() method has been called.
+   *
    * @return The HTTP response URL
    */
   public String getResponseURL() {
@@ -266,6 +300,7 @@ public class SimpleHttp {
   /**
    * Returns true if the url has url parameters, as indicated by the presence of
    * {param} in a url.
+   *
    * @return True if there are URL params, false if not
    */
   public boolean hasURLParameters() {
@@ -277,28 +312,53 @@ public class SimpleHttp {
    * APIs sometimes are structured with parameters in the URL itself.  For instance, to request a list of
    * an organization's repositories in github, the URL is: https://api.github.com/orgs/{org}/repos, where
    * you can replace the org with the actual organization name.
+   *
    * @return A list of URL parameters enclosed by curly braces.
    */
   public List<String> getURLParameters() {
     List<String> parameters = new ArrayList<>();
-    Matcher matcher = URL_PARAM_REGEX.matcher(this.url.toString());
+    String decodedURL;
+    try {
+      decodedURL = URLDecoder.decode(this.url.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
+    Matcher matcher = URL_PARAM_REGEX.matcher(decodedURL);
+    String param;
     while (matcher.find()) {
-      parameters.add(matcher.group());
+      param = matcher.group();
+      param = param.replace("{", "");
+      param = param.replace("}", "");
+      parameters.add(param);
     }
     return parameters;
   }
 
-  public void URLParameters(List<String> params) {
-    
-  }
+  public String mapURLParameters(Map<String, String> filters) {
+    List<String> params = getURLParameters();
+    String tempUrl = decodedURL();
+    for (String param : params) {
+      String value = filters.get(param);
 
+      // If the param is not populated, throw an exception
+      if (Strings.isNullOrEmpty(value)) {
+        throw UserException
+            .parseError()
+            .message("API Query with URL Parameters must be populated. Parameter " + param + " must be included in WHERE clause.")
+            .addContext(errorContext)
+            .build(logger);
+      } else {
+        tempUrl = tempUrl.replace("/{" + param + "}", "/" + value);
+      }
+    }
+    return tempUrl;
+  }
 
   /**
    * Configures response caching using a provided temp directory.
    *
-   * @param builder
-   *          Builder the Builder object to which the caching is to be
-   *          configured
+   * @param builder Builder the Builder object to which the caching is to be
+   *                configured
    */
   private void setupCache(Builder builder) {
     int cacheSize = 10 * 1024 * 1024;   // TODO Add cache size in MB to config
@@ -306,12 +366,12 @@ public class SimpleHttp {
     if (!cacheDirectory.exists()) {
       if (!cacheDirectory.mkdirs()) {
         throw UserException
-          .dataWriteError()
-          .message("Could not create the HTTP cache directory")
-          .addContext("Path", cacheDirectory.getAbsolutePath())
-          .addContext("Please check the temp directory or disable HTTP caching.")
-          .addContext(errorContext)
-          .build(logger);
+            .dataWriteError()
+            .message("Could not create the HTTP cache directory")
+            .addContext("Path", cacheDirectory.getAbsolutePath())
+            .addContext("Please check the temp directory or disable HTTP caching.")
+            .addContext(errorContext)
+            .build(logger);
       }
     }
 
@@ -321,11 +381,11 @@ public class SimpleHttp {
       builder.cache(cache);
     } catch (Exception e) {
       throw UserException.dataWriteError(e)
-        .message("Could not create the HTTP cache")
-        .addContext("Path", cacheDirectory.getAbsolutePath())
-        .addContext("Please check the temp directory or disable HTTP caching.")
-        .addContext(errorContext)
-        .build(logger);
+          .message("Could not create the HTTP cache")
+          .addContext("Path", cacheDirectory.getAbsolutePath())
+          .addContext("Please check the temp directory or disable HTTP caching.")
+          .addContext(errorContext)
+          .build(logger);
     }
   }
 
@@ -343,7 +403,7 @@ public class SimpleHttp {
 
     FormBody.Builder formBodyBuilder = new FormBody.Builder();
     String[] lines = postBody.split("\\r?\\n");
-    for(String line : lines) {
+    for (String line : lines) {
 
       // If the string is in the format key=value split it,
       // Otherwise ignore

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -161,18 +161,6 @@ public class SimpleHttp {
     return url.toString();
   }
 
-  /**
-   * Returns the URL-decoded URL
-   *
-   * @return Returns the URL-decoded URL
-   */
-  public String decodedURL() {
-    try {
-      return URLDecoder.decode(url.toString(), "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      return url.toString();
-    }
-  }
 
   public InputStream getInputStream() {
 
@@ -298,63 +286,6 @@ public class SimpleHttp {
   }
 
   /**
-   * Returns true if the url has url parameters, as indicated by the presence of
-   * {param} in a url.
-   *
-   * @return True if there are URL params, false if not
-   */
-  public boolean hasURLParameters() {
-    Matcher matcher = URL_PARAM_REGEX.matcher(this.url.toString());
-    return matcher.find();
-  }
-
-  /**
-   * APIs sometimes are structured with parameters in the URL itself.  For instance, to request a list of
-   * an organization's repositories in github, the URL is: https://api.github.com/orgs/{org}/repos, where
-   * you can replace the org with the actual organization name.
-   *
-   * @return A list of URL parameters enclosed by curly braces.
-   */
-  public List<String> getURLParameters() {
-    List<String> parameters = new ArrayList<>();
-    String decodedURL;
-    try {
-      decodedURL = URLDecoder.decode(this.url.toString(), "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      return null;
-    }
-    Matcher matcher = URL_PARAM_REGEX.matcher(decodedURL);
-    String param;
-    while (matcher.find()) {
-      param = matcher.group();
-      param = param.replace("{", "");
-      param = param.replace("}", "");
-      parameters.add(param);
-    }
-    return parameters;
-  }
-
-  public String mapURLParameters(Map<String, String> filters) {
-    List<String> params = getURLParameters();
-    String tempUrl = decodedURL();
-    for (String param : params) {
-      String value = filters.get(param);
-
-      // If the param is not populated, throw an exception
-      if (Strings.isNullOrEmpty(value)) {
-        throw UserException
-            .parseError()
-            .message("API Query with URL Parameters must be populated. Parameter " + param + " must be included in WHERE clause.")
-            .addContext(errorContext)
-            .build(logger);
-      } else {
-        tempUrl = tempUrl.replace("/{" + param + "}", "/" + value);
-      }
-    }
-    return tempUrl;
-  }
-
-  /**
    * Configures response caching using a provided temp directory.
    *
    * @param builder Builder the Builder object to which the caching is to be
@@ -414,6 +345,81 @@ public class SimpleHttp {
       }
     }
     return formBodyBuilder;
+  }
+
+  /**
+   * Returns the URL-decoded URL
+   *
+   * @return Returns the URL-decoded URL
+   */
+  public static String decodedURL(HttpUrl url) {
+    try {
+      return URLDecoder.decode(url.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return url.toString();
+    }
+  }
+
+  /**
+   * Returns true if the url has url parameters, as indicated by the presence of
+   * {param} in a url.
+   *
+   * @return True if there are URL params, false if not
+   */
+  public static boolean hasURLParameters(HttpUrl url) {
+    String decodedUrl = SimpleHttp.decodedURL(url);
+    Matcher matcher = URL_PARAM_REGEX.matcher(decodedUrl);
+    return matcher.find();
+  }
+
+  /**
+   * APIs sometimes are structured with parameters in the URL itself.  For instance, to request a list of
+   * an organization's repositories in github, the URL is: https://api.github.com/orgs/{org}/repos, where
+   * you can replace the org with the actual organization name.
+   *
+   * @return A list of URL parameters enclosed by curly braces.
+   */
+  public static List<String> getURLParameters(HttpUrl url) {
+    List<String> parameters = new ArrayList<>();
+    String decodedURL;
+    try {
+      decodedURL = URLDecoder.decode(url.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
+    Matcher matcher = URL_PARAM_REGEX.matcher(decodedURL);
+    String param;
+    while (matcher.find()) {
+      param = matcher.group();
+      param = param.replace("{", "");
+      param = param.replace("}", "");
+      parameters.add(param);
+    }
+    return parameters;
+  }
+
+  public static String mapURLParameters(HttpUrl url, Map<String, String> filters) {
+
+    if (! hasURLParameters(url)) {
+      return url.toString();
+    }
+
+    List<String> params = SimpleHttp.getURLParameters(url);
+    String tempUrl = SimpleHttp.decodedURL(url);
+    for (String param : params) {
+      String value = filters.get(param);
+
+      // If the param is not populated, throw an exception
+      if (Strings.isNullOrEmpty(value)) {
+        throw UserException
+          .parseError()
+          .message("API Query with URL Parameters must be populated. Parameter " + param + " must be included in WHERE clause.")
+          .build(logger);
+      } else {
+        tempUrl = tempUrl.replace("/{" + param + "}", "/" + value);
+      }
+    }
+    return tempUrl;
   }
 
   /**

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -398,8 +398,20 @@ public class SimpleHttp {
     return parameters;
   }
 
+  /**
+   * Used for APIs which have parameters in the URL.  This function maps the filters pushed down
+   * from the query into the URL.  For example the API: github.com/orgs/{org}/repos requires a user to
+   * specify an organization and replace {org} with an actual organization.  The filter is passed down from
+   * the query.
+   *
+   * Note that if a URL contains URL parameters and one is not provided in the filters, Drill will throw
+   * a UserException.
+   *
+   * @param url The HttpUrl containing URL Parameters
+   * @param filters:  A HashMap of filters
+   * @return A string of the URL with the URL parameters replaced by filter values
+   */
   public static String mapURLParameters(HttpUrl url, Map<String, String> filters) {
-
     if (! hasURLParameters(url)) {
       return url.toString();
     }
@@ -407,8 +419,14 @@ public class SimpleHttp {
     List<String> params = SimpleHttp.getURLParameters(url);
     String tempUrl = SimpleHttp.decodedURL(url);
     for (String param : params) {
-      String value = filters.get(param);
+      if (filters == null) {
+        throw UserException
+            .parseError()
+            .message("API Query with URL Parameters must be populated. Parameter " + param + " must be included in WHERE clause.")
+            .build(logger);
+      }
 
+      String value = filters.get(param);
       // If the param is not populated, throw an exception
       if (Strings.isNullOrEmpty(value)) {
         throw UserException

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -44,9 +44,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
@@ -57,6 +60,7 @@ import java.util.regex.Pattern;
  */
 public class SimpleHttp {
   private static final Logger logger = LoggerFactory.getLogger(SimpleHttp.class);
+  private static final Pattern URL_PARAM_REGEX = Pattern.compile("\\{([A-Za-z0-9_]+)\\}");
 
   private final OkHttpClient client;
   private final HttpSubScan scanDefn;
@@ -258,6 +262,36 @@ public class SimpleHttp {
   public String getResponseURL() {
     return responseURL;
   }
+
+  /**
+   * Returns true if the url has url parameters, as indicated by the presence of
+   * {param} in a url.
+   * @return True if there are URL params, false if not
+   */
+  public boolean hasURLParameters() {
+    Matcher matcher = URL_PARAM_REGEX.matcher(this.url.toString());
+    return matcher.find();
+  }
+
+  /**
+   * APIs sometimes are structured with parameters in the URL itself.  For instance, to request a list of
+   * an organization's repositories in github, the URL is: https://api.github.com/orgs/{org}/repos, where
+   * you can replace the org with the actual organization name.
+   * @return A list of URL parameters enclosed by curly braces.
+   */
+  public List<String> getURLParameters() {
+    List<String> parameters = new ArrayList<>();
+    Matcher matcher = URL_PARAM_REGEX.matcher(this.url.toString());
+    while (matcher.find()) {
+      parameters.add(matcher.group());
+    }
+    return parameters;
+  }
+
+  public void URLParameters(List<String> params) {
+    
+  }
+
 
   /**
    * Configures response caching using a provided temp directory.

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -140,12 +140,17 @@ public class TestHttpPlugin extends ClusterTest {
     HttpApiConfig mockXmlConfig = new HttpApiConfig("http://localhost:8091/xml", "GET", headers,
       "basic", "user", "pass", null, null, "results", null, "xml", 2,false);
 
+    HttpApiConfig mockGithubWithParam = new HttpApiConfig("https://github.com/orgs/{org}/repos", "GET", headers,
+      "basic", "user", "pass", null, Arrays.asList("lat", "lng", "date"), "results", false, null, 0, false);
+
+
     Map<String, HttpApiConfig> configs = new HashMap<>();
     configs.put("sunrise", mockSchema);
     configs.put("mocktable", mockTable);
     configs.put("mockpost", mockPostConfig);
     configs.put("mockcsv", mockCsvConfig);
     configs.put("mockxml", mockXmlConfig);
+    configs.put("github", mockGithubWithParam);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
         new HttpStoragePluginConfig(false, configs, 2, "", 80, "", "", "", PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
@@ -179,6 +184,17 @@ public class TestHttpPlugin extends ClusterTest {
 
     RowSetUtilities.verify(expected, results);
   }
+
+  @Test
+  public void testURLParameters() throws Exception {
+    String sql = "SELECT * FROM local.github WHERE org='apache'";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+
+    //String x = queryBuilder().sql(sql).explainJson();
+    //System.out.println(x);
+  }
+
 
   /**
    * Evaluates the HTTP plugin with the results from an API that returns the

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -21,6 +21,7 @@ package org.apache.drill.exec.store.http;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.util.DrillFileUtils;
@@ -140,8 +141,9 @@ public class TestHttpPlugin extends ClusterTest {
     HttpApiConfig mockXmlConfig = new HttpApiConfig("http://localhost:8091/xml", "GET", headers,
       "basic", "user", "pass", null, null, "results", null, "xml", 2,false);
 
-    HttpApiConfig mockGithubWithParam = new HttpApiConfig("https://github.com/orgs/{org}/repos", "GET", headers,
-      "basic", "user", "pass", null, Arrays.asList("lat", "lng", "date"), "results", false, null, 0, false);
+    //"https://localhost:8091/orgs/{org}/repos"
+    HttpApiConfig mockGithubWithParam = new HttpApiConfig("http://localhost:8091/orgs/{org}/repos", "GET", headers,
+      "none", null, null, null, Arrays.asList("lat", "lng", "date"), "results", false, null, 0, false);
 
 
     Map<String, HttpApiConfig> configs = new HashMap<>();
@@ -184,17 +186,6 @@ public class TestHttpPlugin extends ClusterTest {
 
     RowSetUtilities.verify(expected, results);
   }
-
-  @Test
-  public void testURLParameters() throws Exception {
-    String sql = "SELECT * FROM local.github WHERE org='apache'";
-    RowSet results = client.queryBuilder().sql(sql).rowSet();
-
-
-    //String x = queryBuilder().sql(sql).explainJson();
-    //System.out.println(x);
-  }
-
 
   /**
    * Evaluates the HTTP plugin with the results from an API that returns the
@@ -324,6 +315,56 @@ public class TestHttpPlugin extends ClusterTest {
       .build();
 
     RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void simpleTestWithMockServerWithURLParams() throws Exception {
+    String sql = "SELECT _response_url FROM local.github\n" +
+        "WHERE `org` = 'apache'";
+
+    try (MockWebServer server = startServer()) {
+
+      server.enqueue(
+          new MockResponse()
+              .setResponseCode(200)
+              .setBody(TEST_JSON_RESPONSE)
+      );
+
+      RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("_response_url", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.OPTIONAL)
+          .build();
+
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow("http://localhost:8091/orgs/apache/repos")
+          .build();
+
+      RowSetUtilities.verify(expected, results);
+    }
+  }
+
+  /**
+   * When the user has configured an API connection with URL parameters,
+   * it is mandatory that those parameters are included in the WHERE clause. Drill
+   * will throw an exception if that parameter is not present.
+   * @throws Exception if anything goes wrong
+   */
+  @Test
+  public void testUrlParamError() throws Exception {
+    String sql = "SELECT _response_url FROM local.github\n";
+
+    try (MockWebServer server = startServer()) {
+      server.enqueue(
+          new MockResponse()
+              .setResponseCode(200)
+              .setBody(TEST_JSON_RESPONSE)
+      );
+      run(sql);
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("API Query with URL Parameters must be populated."));
+    }
   }
 
   @Test

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestSimpleHttpClient.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestSimpleHttpClient.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.http;
+
+import org.apache.drill.exec.store.http.util.SimpleHttp;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestSimpleHttpClient {
+
+  @Test
+  public void testUrlParameters() throws Exception {
+    // Http client setup
+    SimpleHttp http = new SimpleHttp("https://github.com/orgs/{org}/repos");
+    Map<String, String> filters = new HashMap<>();
+    filters.put("org", "apache");
+    filters.put("param1", "value1");
+    filters.put("param2", "value2");
+    assertEquals(http.mapURLParameters(filters), "https://github.com/orgs/apache/repos");
+
+
+    SimpleHttp http2 = new SimpleHttp("https://github.com/orgs/{org}/{repos}");
+    Map<String, String> filters2 = new HashMap<>();
+    filters.put("org", "apache");
+    filters.put("param1", "value1");
+    filters.put("repos", "drill");
+    assertEquals(http2.mapURLParameters(filters), "https://github.com/orgs/apache/drill");
+  }
+}

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestURLParameters.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestURLParameters.java
@@ -18,6 +18,7 @@
 
 package org.apache.drill.exec.store.http;
 
+import okhttp3.HttpUrl;
 import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.junit.Test;
 
@@ -26,24 +27,31 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestSimpleHttpClient {
+public class TestURLParameters {
 
   @Test
   public void testUrlParameters() throws Exception {
     // Http client setup
-    SimpleHttp http = new SimpleHttp("https://github.com/orgs/{org}/repos");
+    HttpUrl githubSingleParam = HttpUrl.parse("https://github.com/orgs/{org}/repos");
     Map<String, String> filters = new HashMap<>();
     filters.put("org", "apache");
     filters.put("param1", "value1");
     filters.put("param2", "value2");
-    assertEquals(http.mapURLParameters(filters), "https://github.com/orgs/apache/repos");
+    assertEquals(SimpleHttp.mapURLParameters(githubSingleParam, filters), "https://github.com/orgs/apache/repos");
 
 
-    SimpleHttp http2 = new SimpleHttp("https://github.com/orgs/{org}/{repos}");
+    HttpUrl githubMultiParam = HttpUrl.parse("https://github.com/orgs/{org}/{repos}");
     Map<String, String> filters2 = new HashMap<>();
-    filters.put("org", "apache");
-    filters.put("param1", "value1");
-    filters.put("repos", "drill");
-    assertEquals(http2.mapURLParameters(filters), "https://github.com/orgs/apache/drill");
+    filters2.put("org", "apache");
+    filters2.put("param1", "value1");
+    filters2.put("repos", "drill");
+    assertEquals(SimpleHttp.mapURLParameters(githubMultiParam, filters2), "https://github.com/orgs/apache/drill");
+
+    HttpUrl githubNoParam = HttpUrl.parse("https://github.com/orgs/org/repos");
+    Map<String, String> filters3 = new HashMap<>();
+    filters3.put("org", "apache");
+    filters3.put("param1", "value1");
+    filters3.put("repos", "drill");
+    assertEquals(SimpleHttp.mapURLParameters(githubNoParam, filters3), "https://github.com/orgs/org/repos");
   }
 }


### PR DESCRIPTION
# [DRILL-7970](https://issues.apache.org/jira/browse/DRILL-7970): Add URL Parameters to HTTP Plugin

## Description
Many APIs require that arguments are passed as part of the URL.  For instance, github's API allows you to get information about an organization's repositories with the following URL:  https://api.github.com/orgs/{org}/repos

This PR adds a capability where filters can be pushed down into the URL from a query so that a user could execute a query:

```sql
SELECT * 
FROM api.github
WHERE org='apache'
``` 
In this query, the value for the `org` parameter would be populated in the URL. 

## Documentation
Updated the `README.md` document.  
To enable URL parameters, a user simply must add curly braces around a parameter which should be passed down.  Note that Drill will throw an exception in the event an API has a URL parameter and one is not supplied in the query.

## Testing
Added two additional unit tests to testing class for the HTTP plugin as well as an additional test for the http client. 