### PR TITLE
DRILL-7971: Support Elasticsearch authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       avoid_bad_dependencies plugin found in the file.
     -->
     <calcite.groupId>com.github.vvysotskyi.drill-calcite</calcite.groupId>
-    <calcite.version>1.21.0-drill-r2</calcite.version>
+    <calcite.version>1.21.0-drill-r3</calcite.version>
     <avatica.version>1.17.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.9.0</sqlline.version>


### PR DESCRIPTION
# [DRILL-7971](https://issues.apache.org/jira/browse/DRILL-7971): Support Elasticsearch authentication

## Description
Cherry-picked required commits for adding support of Elasticsearch authentication and updated version of the fork in Drill (https://issues.apache.org/jira/browse/CALCITE-4180)

## Documentation
NA

## Testing
Checked manually.
