### PR TITLE
DRILL-7972: ClassCastException when joining RDBMS and Elasticsearch tables

### DIFF
--- a/contrib/storage-cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CalciteUtils.java
+++ b/contrib/storage-cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CalciteUtils.java
@@ -22,7 +22,6 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.exec.store.cassandra.CassandraStorageConfig;
@@ -40,9 +39,9 @@ public class CalciteUtils {
   private static final VertexDrelConverterRule VERTEX_DREL_CONVERTER_RULE =
       new VertexDrelConverterRule(CassandraRel.CONVENTION);
 
-  private static final ConverterRule ENUMERABLE_INTERMEDIATE_PREL_CONVERTER_RULE =
+  private static final RelOptRule ENUMERABLE_INTERMEDIATE_PREL_CONVERTER_RULE =
       new EnumerableIntermediatePrelConverterRule(
-          new CassandraEnumerablePrelContext(CassandraStorageConfig.NAME));
+          new CassandraEnumerablePrelContext(CassandraStorageConfig.NAME), CassandraRel.CONVENTION);
 
   public static CassandraTableScan tableScanCreator(RelOptCluster cluster, RelTraitSet traitSet,
       RelOptTable table, CassandraTable cassandraTable,

--- a/contrib/storage-elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/CalciteUtils.java
+++ b/contrib/storage-elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/CalciteUtils.java
@@ -48,9 +48,9 @@ public class CalciteUtils {
   public static final VertexDrelConverterRule ELASTIC_DREL_CONVERTER_RULE =
       new VertexDrelConverterRule(ElasticsearchRel.CONVENTION);
 
-  public static final EnumerableIntermediatePrelConverterRule ENUMERABLE_INTERMEDIATE_PREL_CONVERTER_RULE =
+  public static final RelOptRule ENUMERABLE_INTERMEDIATE_PREL_CONVERTER_RULE =
       new EnumerableIntermediatePrelConverterRule(
-          new ElasticSearchEnumerablePrelContext(ElasticsearchStorageConfig.NAME));
+          new ElasticSearchEnumerablePrelContext(ElasticsearchStorageConfig.NAME), ElasticsearchRel.CONVENTION);
 
   public static Set<RelOptRule> elasticSearchRules() {
     // filters Calcite implementations of some rules and adds alternative versions specific for Drill

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/DrillJdbcConvention.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/DrillJdbcConvention.java
@@ -60,7 +60,7 @@ class DrillJdbcConvention extends JdbcConvention {
         .collect(Collectors.toList());
     this.rules = ImmutableSet.<RelOptRule>builder()
         .addAll(calciteJdbcRules)
-        .add(JdbcIntermediatePrelConverterRule.INSTANCE)
+        .add(new JdbcIntermediatePrelConverterRule(this))
         .add(new VertexDrelConverterRule(this))
         .add(new DrillJdbcRuleBase.DrillJdbcProjectRule(Convention.NONE, this))
         .add(new DrillJdbcRuleBase.DrillJdbcProjectRule(DrillRel.DRILL_LOGICAL, this))

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/EnumerableIntermediatePrelConverterRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/EnumerableIntermediatePrelConverterRule.java
@@ -17,31 +17,45 @@
  */
 package org.apache.drill.exec.store.enumerable.plan;
 
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.drill.exec.planner.logical.DrillRel;
 import org.apache.drill.exec.planner.logical.DrillRelFactories;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
 import org.apache.drill.exec.planner.physical.Prel;
 
-import java.util.function.Predicate;
-
-public class EnumerableIntermediatePrelConverterRule extends ConverterRule {
+public class EnumerableIntermediatePrelConverterRule extends RelOptRule {
 
   private final EnumerablePrelContext context;
+  private final RelTrait inTrait;
+  private final RelTrait outTrait;
 
-  public EnumerableIntermediatePrelConverterRule(EnumerablePrelContext context) {
-    super(VertexDrel.class, (Predicate<RelNode>) input -> true, DrillRel.DRILL_LOGICAL,
-        Prel.DRILL_PHYSICAL, DrillRelFactories.LOGICAL_BUILDER,
-        "EnumerableIntermediatePrelConverterRule:" + context.getPlanPrefix());
+  public EnumerableIntermediatePrelConverterRule(EnumerablePrelContext context, Convention convention) {
+    super(
+        RelOptHelper.some(VertexDrel.class, DrillRel.DRILL_LOGICAL,
+            RelOptHelper.any(RelNode.class, convention)),
+        DrillRelFactories.LOGICAL_BUILDER, "EnumerableIntermediatePrelConverterRule" + convention);
     this.context = context;
+    this.inTrait = DrillRel.DRILL_LOGICAL;
+    this.outTrait = Prel.DRILL_PHYSICAL;
   }
 
   @Override
-  public RelNode convert(RelNode in) {
-    return new EnumerableIntermediatePrel(
+  public void onMatch(RelOptRuleCall call) {
+    VertexDrel in = call.rel(0);
+    RelNode intermediatePrel = new EnumerableIntermediatePrel(
         in.getCluster(),
-        in.getTraitSet().replace(getOutTrait()),
+        in.getTraitSet().replace(outTrait),
         in.getInput(0),
         context);
+    call.transformTo(intermediatePrel);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    return super.matches(call) && call.rel(0).getTraitSet().contains(inTrait);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/EnumPluginTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/EnumPluginTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.enumerable;
+
+import org.apache.drill.exec.store.enumerable.plan.EnumMockPlugin;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EnumPluginTest extends ClusterTest {
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
+
+    EnumMockPlugin.EnumMockStoragePluginConfig config = new EnumMockPlugin.EnumMockStoragePluginConfig();
+    config.setEnabled(true);
+    cluster.defineStoragePlugin("mocked_enum", config);
+    cluster.defineStoragePlugin("mocked_enum2", config);
+  }
+
+  @Test // DRILL-7972
+  public void testIntermConvRuleConvention() throws Exception {
+    queryBuilder()
+        .sql("select t1.a, t2.a from mocked_enum.mock_enum_table t1 " +
+            "join mocked_enum2.mock_enum_table t2 on t1.a=t2.a")
+        .planMatcher()
+        .include("mocked_enum", "mocked_enum2")
+        .match();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockPlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockPlugin.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.enumerable.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.planner.PlannerPhase;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.store.AbstractStoragePlugin;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.SchemaFactory;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Mock plugin implementation for testing "enumerable" rel nodes transformation.
+ */
+public class EnumMockPlugin extends AbstractStoragePlugin {
+
+  private final SchemaFactory schemaFactory;
+
+  private final EnumMockStoragePluginConfig config;
+
+  private final Convention convention;
+
+  public EnumMockPlugin(EnumMockStoragePluginConfig config, DrillbitContext inContext, String inName) {
+    super(inContext, inName);
+    this.config = config;
+    EnumMockSchema schema = new EnumMockSchema(inName, this);
+    this.schemaFactory = (SchemaConfig schemaConfig, SchemaPlus parent) -> parent.add(inName, schema);
+    this.convention = new Convention.Impl(inName, EnumMockRel.class);
+  }
+
+  @Override
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
+    schemaFactory.registerSchemas(schemaConfig, parent);
+  }
+
+  @Override
+  public boolean supportsRead() {
+    return true;
+  }
+
+  @Override
+  public StoragePluginConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  public Set<? extends RelOptRule> getOptimizerRules(OptimizerRulesContext optimizerContext, PlannerPhase phase) {
+    switch (phase) {
+      case PHYSICAL:
+      case LOGICAL:
+        return ImmutableSet.of(
+            new EnumerableIntermediatePrelConverterRule(
+                new EnumMockRel.MockEnumerablePrelContext(convention), convention),
+            new VertexDrelConverterRule(convention));
+      case LOGICAL_PRUNE_AND_JOIN:
+      case LOGICAL_PRUNE:
+      case PARTITION_PRUNING:
+      case JOIN_PLANNING:
+      default:
+        return Collections.emptySet();
+    }
+  }
+
+  public Convention getConvention() {
+    return convention;
+  }
+
+  @JsonTypeName(EnumMockStoragePluginConfig.NAME)
+  public static class EnumMockStoragePluginConfig extends StoragePluginConfig {
+    public static final String NAME = "enum_mock";
+
+    @JsonCreator
+    public EnumMockStoragePluginConfig() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof EnumMockStoragePluginConfig;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockRel.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockRel.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.enumerable.plan;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public interface EnumMockRel extends RelNode {
+
+  class MockEnumerablePrelContext implements EnumerablePrelContext {
+
+    private final Convention convention;
+
+    public MockEnumerablePrelContext(Convention convention) {
+      this.convention = convention;
+    }
+
+    @Override
+    public String generateCode(RelOptCluster cluster, RelNode relNode) {
+      return null;
+    }
+
+    @Override
+    public RelNode transformNode(RelNode input) {
+      assert input.getTraitSet().getTrait(0).equals(convention) : "Conventions should match";
+      return input;
+    }
+
+    @Override
+    public Map<String, Integer> getFieldsMap(RelNode transformedNode) {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public String getPlanPrefix() {
+      return "mock_prel";
+    }
+
+    @Override
+    public String getTablePath(RelNode input) {
+      return null;
+    }
+  }
+
+  class EnumMockTableScan extends TableScan implements EnumMockRel {
+
+    protected EnumMockTableScan(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table) {
+      super(cluster, traitSet, table);
+    }
+
+    @Override
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+      assert inputs.isEmpty();
+      return new EnumMockTableScan(getCluster(), traitSet, table);
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+      return 5;
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockSchema.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.enumerable.plan;
+
+import org.apache.calcite.schema.Table;
+import org.apache.drill.exec.store.AbstractSchema;
+import org.apache.drill.exec.store.StoragePlugin;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class EnumMockSchema extends AbstractSchema {
+  private final StoragePlugin plugin;
+  private final Map<String, EnumMockTable> tables;
+
+  public EnumMockSchema(String name, StoragePlugin plugin) {
+    super(Collections.emptyList(), name);
+    this.plugin = plugin;
+    this.tables = new HashMap<>();
+  }
+
+  @Override
+  public String getTypeName() {
+    return EnumMockPlugin.EnumMockStoragePluginConfig.NAME;
+  }
+
+  @Override
+  public Table getTable(String name) {
+    return tables.computeIfAbsent(name, key -> new EnumMockTable(plugin, key, null, null));
+  }
+
+  @Override
+  public Set<String> getTableNames() {
+    return Collections.singleton("mock_enum_table");
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/enumerable/plan/EnumMockTable.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.enumerable.plan;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.drill.exec.planner.logical.DynamicDrillTable;
+import org.apache.drill.exec.store.StoragePlugin;
+
+public class EnumMockTable extends DynamicDrillTable implements TranslatableTable {
+
+  public EnumMockTable(StoragePlugin plugin, String storageEngineName, String userName, Object selection) {
+    super(plugin, storageEngineName, userName, selection);
+  }
+
+  @Override
+  public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
+    EnumMockPlugin plugin = (EnumMockPlugin) getPlugin();
+    return new EnumMockRel.EnumMockTableScan(context.getCluster(),
+        context.getCluster().traitSetOf(plugin.getConvention()), relOptTable);
+  }
+}

--- a/exec/java-exec/src/test/resources/drill-module.conf
+++ b/exec/java-exec/src/test/resources/drill-module.conf
@@ -27,6 +27,7 @@ drill: {
     packages += "org.apache.drill.exec.store",
     packages += "org.apache.drill.exec.testing",
     packages += "org.apache.drill.exec.rpc.user.security.testing"
+    packages += "org.apache.drill.exec.store.enumerable.plan"
   }
   test.query.printing.silent : false,
   exec: {


### PR DESCRIPTION
# [DRILL-7972](https://issues.apache.org/jira/browse/DRILL-7972): ClassCastException when joining RDBMS and Elasticsearch tables

## Description
Updated `JdbcIntermediatePrelConverterRule` and `EnumerableIntermediatePrelConverterRule` to consider the convention of the input rel node when applying the rule, so now `EnumerableIntermediatePrelConverterRule` cannot be applied to `VertexDrel` rel node that has input with JDBC convention and vise versa.

Improved `FragmentContextImpl` to allow returning full root schema for both root and non-root fragments, since schema may be used when reading "enumerable" plugins.

## Documentation
NA

## Testing
Checked manually, no unit test added since the issue may be reproduced only with two different storage plugins.
