### PR TITLE
Update 025-tutorial-develop-a-simple-function.md

### DIFF
--- a/_docs/en/develop-custom-functions/025-tutorial-develop-a-simple-function.md
+++ b/_docs/en/develop-custom-functions/025-tutorial-develop-a-simple-function.md
@@ -222,7 +222,13 @@ Add the JAR files to Drill, by copying them to the following location:
 
 `<Drill installation directory>/jars/3rdparty`  
 
-**Note:** This tutorial shows the manual method for adding JAR files to Drill, however as of Drill 1.9, the Dynamic UDF feature provides a new method for users.
+**Note 1:** This tutorial shows the manual method for adding JAR files to Drill, however as of Drill 1.9, the Dynamic UDF feature provides a new method for users.
+
+**Note 2:** When your drill instance is attached to a docker and runs within a container, you need to copy the two maven generated JAR files using docker's cp command.
+
+            The syntax for the same is: docker cp SRC_PATH CONTAINER:<Drill installation directory>/jars/3rdparty
+            
+            Example: docker cp C:Users\apacheUser\xyz.jar cfd0a7cf635b:/opt/drill/jars/3rdparty
 
 ## Test the New Function
 


### PR DESCRIPTION
Many developers use apache drill within the docker container (which is  mentioned at https://drill.apache.org/docs/running-drill-on-docker/)  and it is tough getting through the copying of jars within it as that is the most crucial step. I faced this problem and had to google a lot on dockers.

# [DRILL-XXXX](https://issues.apache.org/jira/browse/DRILL-XXXX): Update document for copying jars when drill runs within docker container

(Please replace `PR Title` with actual PR Title)

## Description

(Please describe the change. If more than one ticket is fixed, include a reference to those tickets.)

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
I used the stated docker command to copy the local jars to the container
