### PR TITLE
[MINOR UPDATE]: Add an .editorconfig file providing style hints to editors and IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # https://editorconfig.org/
 
 # top-most EditorConfig file

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# Default, notably applicable to Java, XML, JavaScript and Shell
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# C and C++
+[*.{c, cpp}]
+indent_size = 4
+
+# Ignore third party JS
+[**/static/js**]
+indent_style = ignore
+indent_size = ignore
+
+# Ignore minified JS
+[**.min.js]
+indent_style = ignore
+indent_size = ignore
+


### PR DESCRIPTION
## Description

Non-code change.

EditorConfig (https://editorconfig.org/) is an editor-neutral file format
that holds code style settings.  This particular config has been defined
to reflect the style convetions in the Drill codebase (most significantly,
indentation is with 2 spaces).  Many mainstream editors and IDEs will
recognise this file and set themselves up accordingly, making it easier to
contribute code following the project's conventions.  Editors that do not
understand EditorConfig are unaffected.

Note that .editorconfig only contains global conventions for the codebase, not
individual users' editor preferences, which must be masked by .gitignore.
Other Apache projects with a .editorconfig file in their code repo are
Superset, Subversion, Thrift, Submarine and presumably some more.