### PR TITLE
DRILL-7981: Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -180,6 +180,10 @@
           <groupId>org.owasp.encoder</groupId>
           <artifactId>encoder</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <javax.el.version>3.0.0</javax.el.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <jna.version>5.8.0</jna.version>
-    <commons.compress.version>1.20</commons.compress.version>
+    <commons.compress.version>1.21</commons.compress.version>
     <hikari.version>4.0.3</hikari.version>
     <netty.version>4.1.59.Final</netty.version>
     <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
# [DRILL-7981](https://issues.apache.org/jira/browse/DRILL-7981): Bump commons-compress from 1.20 to 1.21 for CVE-2021-36090

## Description

When reading a specially crafted ZIP archive, Compress can be made to allocate large amounts of memory that finally leads to an out of memory error even for very small inputs. This could be used to mount a denial of service attack against services that use Compress' zip package.

## Documentation
N/A

## Testing
N/A
