### PR TITLE
DRILL-7986: Drill crashes when using the streaming connection with arrays

### DIFF
--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/BaseScalarReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/BaseScalarReader.java
@@ -73,26 +73,20 @@ public abstract class BaseScalarReader extends AbstractScalarReader {
    */
   public interface BufferAccessor {
     DrillBuf buffer();
-    void rebind();
   }
 
   private static class SingleVectorBufferAccessor implements BufferAccessor {
     private final VectorAccessor va;
-    private DrillBuf buffer;
 
     public SingleVectorBufferAccessor(VectorAccessor va) {
       this.va = va;
-      rebind();
     }
 
     @Override
-    public void rebind() {
+    public DrillBuf buffer() {
       BaseDataValueVector vector = va.vector();
-      buffer = vector.getBuffer();
+      return vector.getBuffer();
     }
-
-    @Override
-    public DrillBuf buffer() { return buffer; }
   }
 
   private static class HyperVectorBufferAccessor implements BufferAccessor {
@@ -107,9 +101,6 @@ public abstract class BaseScalarReader extends AbstractScalarReader {
       BaseDataValueVector vector = vectorAccessor.vector();
       return vector.getBuffer();
     }
-
-    @Override
-    public void rebind() { }
   }
 
   protected ColumnMetadata schema;
@@ -168,7 +159,6 @@ public abstract class BaseScalarReader extends AbstractScalarReader {
 
   @Override
   public void bindBuffer() {
-    bufferAccessor.rebind();
     nullStateReader.bindBuffer();
   }
 


### PR DESCRIPTION
# [DRILL-7986](https://issues.apache.org/jira/browse/DRILL-7986): Drill crashes when using the streaming connection with arrays

## Description
When copying data from incoming batch to row set, `SingleVectorBufferAccessor` was holding outdated byte buffer that belonged to value vector from the previous batch. It caused JVM crashes when Drill tried to access the data from the outdated buffer.

Existing API assumed to call `BufferAccessor.rebind()` method every time buffer from one vector to another one was exchanged but exchange process cannot be controlled by row set API, and since we already hold `VectorAccessor` that has value vector with actual byte buffer, this method became excessive.

## Documentation
NA

## Testing
Checked manually, no unit test is added since the issue is reproduced coincidentally for and for a specific set of conditions.
