### PR TITLE
DRILL-7988: Add credentials provider support for API connections in HTTP plugin

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -78,11 +78,13 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     negotiator.setErrorContext(errorContext);
 
     // Http client setup
-    SimpleHttp http = new SimpleHttp(
-        subScan, url,
-        new File(tempDirPath),
-        proxySettings(negotiator.drillConfig(), url),
-        errorContext);
+    SimpleHttp http = SimpleHttp.builder()
+      .scanDefn(subScan)
+      .url(url)
+      .tempDir(new File(tempDirPath))
+      .proxyConfig(proxySettings(negotiator.drillConfig(), url))
+      .errorContext(errorContext)
+      .build();
 
     // JSON loader setup
     ResultSetLoader loader = negotiator.build();

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
@@ -81,7 +81,13 @@ public class HttpCSVBatchReader extends HttpBatchReader {
     negotiator.setErrorContext(errorContext);
 
     // Http client setup
-    SimpleHttp http = new SimpleHttp(subScan, url, new File(tempDirPath), proxySettings(negotiator.drillConfig(), url), errorContext);
+    SimpleHttp http = SimpleHttp.builder()
+      .scanDefn(subScan)
+      .url(url)
+      .tempDir(new File(tempDirPath))
+      .proxyConfig(proxySettings(negotiator.drillConfig(), url))
+      .errorContext(errorContext)
+      .build();
 
     // CSV loader setup
     inStream = http.getInputStream();

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+lombok.log.fieldName = logger

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <httpdlog-parser.version>5.7</httpdlog-parser.version>
     <yauaa.version>5.20</yauaa.version>
+    <lombok.version>1.18.20</lombok.version>
   </properties>
 
   <scm>
@@ -1090,6 +1091,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test Dependencies -->


### PR DESCRIPTION
# [DRILL-7988](https://issues.apache.org/jira/browse/DRILL-7988): Add credentials provider support for API connections in HTTP plugin

## Description
See Jira ticket for details.

## Documentation
Yes.

## Testing
Updated one of the existing test configs to use credential provider.
