### PR TITLE
DRILL-7990: Unable to disable requireTail in HTTP storage plugin API

### DIFF
--- a/common/src/main/java/org/apache/drill/common/map/CaseInsensitiveMap.java
+++ b/common/src/main/java/org/apache/drill/common/map/CaseInsensitiveMap.java
@@ -173,4 +173,8 @@ public class CaseInsensitiveMap<VALUE> implements Map<String, VALUE> {
     return Objects.equals(underlyingMap, that.underlyingMap);
   }
 
+  @Override
+  public String toString() {
+    return underlyingMap.toString();
+  }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
@@ -64,6 +64,7 @@ public class HttpApiConfig {
    * API represents a table (the URL is complete except for
    * parameters specified in the WHERE clause.)
    */
+  @JsonInclude
   @JsonProperty
   private final boolean requireTail;
 
@@ -100,7 +101,7 @@ public class HttpApiConfig {
   private final int xmlDataLevel;
   @JsonProperty
   private final boolean errorOn400;
-  @JsonProperty
+  @Getter(AccessLevel.NONE)
   private final CredentialsProvider credentialsProvider;
   @Getter(AccessLevel.NONE)
   protected boolean directCredentials;
@@ -150,10 +151,9 @@ public class HttpApiConfig {
     this.dataPath = StringUtils.defaultIfEmpty(builder.dataPath, null);
 
     // Default to true for backward compatibility with first PR.
-    this.requireTail = builder.requireTail == null || builder.requireTail;
+    this.requireTail = builder.requireTail;
 
-    this.inputType = builder.inputType == null
-      ? DEFAULT_INPUT_FORMAT : builder.inputType.trim().toLowerCase();
+    this.inputType = builder.inputType.trim().toLowerCase();
 
     this.xmlDataLevel = Math.max(1, builder.xmlDataLevel);
     this.errorOn400 = builder.errorOn400;
@@ -161,6 +161,7 @@ public class HttpApiConfig {
     this.directCredentials = builder.credentialsProvider == null;
   }
 
+  @JsonProperty
   public String userName() {
     if (directCredentials) {
       return getUsernamePasswordCredentials().getUsername();
@@ -168,6 +169,7 @@ public class HttpApiConfig {
     return null;
   }
 
+  @JsonProperty
   public String password() {
     if (directCredentials) {
       return getUsernamePasswordCredentials().getPassword();
@@ -185,6 +187,7 @@ public class HttpApiConfig {
     return new UsernamePasswordCredentials(credentialsProvider);
   }
 
+  @JsonProperty
   public CredentialsProvider credentialsProvider() {
     if (directCredentials) {
       return null;
@@ -204,7 +207,11 @@ public class HttpApiConfig {
 
     @Getter
     @Setter
-    private Boolean requireTail;
+    private boolean requireTail = true;
+
+    @Getter
+    @Setter
+    private String inputType = DEFAULT_INPUT_FORMAT;
 
     public HttpApiConfig build() {
       return new HttpApiConfig(this);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -380,6 +380,17 @@ public class TestHttpPlugin extends ClusterTest {
   }
 
   @Test
+  public void testApiConfigRequiresTailSerDe() throws Exception {
+    String sql = "SELECT * FROM local.mocktable";
+
+    queryBuilder()
+      .sql(sql)
+      .detailedPlanMatcher()
+      .include("requireTail=false")
+      .match();
+  }
+
+  @Test
   public void simpleTestWithMockServer() throws Exception {
     String sql = "SELECT * FROM local.sunrise.`?lat=36.7201600&lng=-4.4203400&date=2019-10-02`";
     doSimpleTestWithMockServer(sql);


### PR DESCRIPTION
# [DRILL-7990](https://issues.apache.org/jira/browse/DRILL-7990): Unable to disable requireTail in HTTP storage plugin API

## Description
This issue is caused by the conflict of `@JsonInclude(JsonInclude.Include.NON_DEFAULT)` annotation and default behavior of `HttpApiConfig` to set `requireTail` to `true` when value is `null` (or absent). 
Fixed by including the `requireTail` field explicitly. Fixed backward compatibility for the credentials provider.

## Documentation
NA

## Testing
Added UT, checked manually.
