### PR TITLE
[MINOR-UPDATE] Removed password from debug logging in Python script

### DIFF
--- a/tools/drill-patch-review.py
+++ b/tools/drill-patch-review.py
@@ -65,6 +65,7 @@ def main():
   p.close()
 
   rb_command="post-review --publish --tracking-branch " + opt.branch + " --target-groups=drill-git --bugs-closed=" + opt.jira
+  rb_command_for_debug=rb_command + " --username " + opt.reviewboard_user + " --password XXXX"
   rb_command=rb_command + " --username " + opt.reviewboard_user + " --password " + opt.reviewboard_password
 
   if opt.debug:
@@ -80,7 +81,7 @@ def main():
   if opt.testing:
     rb_command=rb_command + " --testing-done=" + opt.testing
   if opt.debug:
-    print(rb_command)
+    print(rb_command_for_debug)
   p=os.popen(rb_command)
   rb_url=""
   for line in p:


### PR DESCRIPTION
This minor fix fixed an LGTM alert where credentials are logged in a debug statement in a python script.   Functionality is not affected except to remove the password from the log output. 