### PR TITLE
LGTM Code Cleanup-Fixed Javadoc param tags and type conversions

### DIFF
--- a/common/src/main/java/org/apache/drill/common/HistoricalLog.java
+++ b/common/src/main/java/org/apache/drill/common/HistoricalLog.java
@@ -119,16 +119,10 @@ public class HistoricalLog {
    * events with their stack traces.
    *
    * @param sb {@link StringBuilder} to write to
-   * @param additional an extra string that will be written between the identifying
-   *     information and the history; often used for a current piece of state
-   */
-
-  /**
-   *
-   * @param sb
-   * @param indexLevel
+   * @param indent
    * @param includeStackTrace
    */
+
   public synchronized void buildHistory(final StringBuilder sb, int indent, boolean includeStackTrace) {
     final char[] indentation = new char[indent];
     final char[] innerIndentation = new char[indent + 2];

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
@@ -377,7 +377,11 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
     int totalColNum = STAR_COLS;
     PluginCost pluginCostModel = formatPlugin.getPluginCostModel();
     final int avgColumnSize = pluginCostModel.getAverageColumnSize(this);
-    boolean filterPushed = (scanSpec.getSerializedFilter() != null);
+    boolean filterPushed;
+    if (scanSpec == null) {
+      filterPushed=false;
+    }
+    filterPushed = (scanSpec.getSerializedFilter() != null);
     if (scanSpec != null && scanSpec.getIndexDesc() != null) {
       totalColNum = scanSpec.getIndexDesc().getIncludedFields().size()
           + scanSpec.getIndexDesc().getIndexedFields().size() + 1;
@@ -490,7 +494,7 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
   /**
    * Get the estimated average rowsize. DO NOT call this API directly.
    * Call the stats API instead which modifies the counts based on preference options.
-   * @param index, to use for generating the estimate
+   * @param index to use for generating the estimate
    * @return row count post filtering
    */
   public MapRDBStatisticsPayload getAverageRowSizeStats(IndexDescriptor index) {
@@ -524,8 +528,9 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
   /**
    * Get the estimated statistics after applying the {@link RexNode} condition. DO NOT call this API directly.
    * Call the stats API instead which modifies the counts based on preference options.
-   * @param condition, filter to apply
-   * @param index, to use for generating the estimate
+   * @param condition filter to apply
+   * @param index to use for generating the estimate
+   * @param scanRel
    * @return row count post filtering
    */
   public MapRDBStatisticsPayload getFirstKeyEstimatedStats(QueryCondition condition, IndexDescriptor index, RelNode scanRel) {
@@ -538,8 +543,9 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
 
   /**
    * Get the estimated statistics after applying the {@link QueryCondition} condition
-   * @param condition, filter to apply
-   * @param index, to use for generating the estimate
+   * @param condition filter to apply
+   * @param index to use for generating the estimate
+   * @param scanRel
    * @return {@link MapRDBStatisticsPayload} statistics
    */
   private MapRDBStatisticsPayload getFirstKeyEstimatedStatsInternal(QueryCondition condition, IndexDesc index, RelNode scanRel) {
@@ -630,7 +636,8 @@ public class JsonTableGroupScan extends MapRDBGroupScan implements IndexGroupSca
 
   /**
    * Get the row count after applying the {@link RexNode} condition
-   * @param condition, filter to apply
+   * @param condition filter to apply
+   * @param scanRel
    * @return row count post filtering
    */
   @Override

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/DrillControllerFactory.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/DrillControllerFactory.java
@@ -185,7 +185,7 @@ public class DrillControllerFactory implements ControllerFactory {
    * This class is very Linux-specific. The usual adjustments must be made to
    * adapt it to Windows.
    *
-   * @param config
+   * @param resources
    * @return
    * @throws DoyConfigException
    */

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/client/StopCommand.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/client/StopCommand.java
@@ -174,7 +174,7 @@ public class StopCommand extends ClientCommand {
    * Include the master key with the request to differentiate this request from
    * accidental uses of the stop REST API.
    *
-   * @param report
+   * @param baseUrl
    * @return
    */
 

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/core/DfsFacade.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/core/DfsFacade.java
@@ -291,12 +291,12 @@ public class DfsFacade {
    * <p>
    * Resources are made public.
    *
-   * @param conf
-   *          Configuration created from the Hadoop config files, in this case,
-   *          identifies the target file system.
-   * @param resourcePath
+   * @param dfsPath
    *          the path (relative or absolute) to the file on the configured file
    *          system (usually HDFS).
+   * @param dfsFileStatus
+   * @param type
+   * @param visibility
    * @return a YARN local resource records that contains information about path,
    *         size, type, resource and so on that YARN requires.
    * @throws IOException

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/core/DrillOnYarnConfig.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/core/DrillOnYarnConfig.java
@@ -786,7 +786,6 @@ public class DrillOnYarnConfig {
    * root and/or cluster ID (just not the same combination), so the file name
    * contains both parts.
    *
-   * @param clusterId
    * @return
    */
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/DbGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/DbGroupScan.java
@@ -58,8 +58,8 @@ public interface DbGroupScan extends GroupScan {
   /**
    * Get the row count after applying the {@link RexNode} condition
    *
-   * @param condition, filter to apply
-   * @param scanRel, the current scan rel
+   * @param condition filter to apply
+   * @param scanRel the current scan rel
    * @return row count post filtering
    */
   @JsonIgnore

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/IndexGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/IndexGroupScan.java
@@ -51,7 +51,8 @@ public interface IndexGroupScan extends GroupScan {
 
   /**
    * Get the row count after applying the {@link RexNode} condition
-   * @param condition, filter to apply
+   * @param condition filter to apply
+   * @param scanRel
    * @return row count post filtering
    */
   @JsonIgnore

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/rangepartitioner/RangePartitionRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/rangepartitioner/RangePartitionRecordBatch.java
@@ -97,7 +97,6 @@ public class RangePartitionRecordBatch extends AbstractSingleRecordBatch<RangePa
    * Sets up projection that will transfer all of the columns in batch, and also setup
    * the partition column based on which partition a record falls into
    *
-   * @param batch
    * @throws SchemaChangeException
    * @return True if the new schema differs from old schema, False otherwise
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
@@ -143,7 +143,6 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
    * both the table and scan operator. Returns the result set loader to be used
    * by the reader to write to the table's value vectors.
    *
-   * @param schemaNegotiator builder given to the reader to provide it's
    * schema information
    * @return the result set loader to be used by the reader
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ConstantColumnLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ConstantColumnLoader.java
@@ -87,8 +87,7 @@ public class ConstantColumnLoader extends StaticColumnLoader {
   /**
    * Populate static vectors with the defined static values.
    *
-   * @param rowCount number of rows to generate. Must match the
-   * row count in the batch returned by the reader
+   * @param writer
    */
 
   private void loadRow(TupleWriter writer) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ExplicitSchemaProjection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ExplicitSchemaProjection.java
@@ -296,7 +296,8 @@ public class ExplicitSchemaProjection extends ReaderLevelProjection {
    * A child column of a map is not projected. Recurse to determine the full
    * set of nullable child columns.
    *
-   * @param projectedColumn the map column which was projected
+   * @param outputTuple
+   * @param col the map column which was projected
    * @return a list of null markers for the requested children
    */
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ScanLevelProjection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ScanLevelProjection.java
@@ -233,7 +233,7 @@ public class ScanLevelProjection {
      * comes from the query planner, assumes that the planner has checked
      * the list for syntax and uniqueness.
      *
-     * @param queryCols list of columns in the SELECT list in SELECT list order
+     * @param projectionList list of columns in the SELECT list in SELECT list order
      * @return this builder
      */
     public Builder projection(List<SchemaPath> projectionList) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/SchemaNegotiatorImpl.java
@@ -141,8 +141,6 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
    * both the table and scan operator. Returns the result set loader to be used
    * by the reader to write to the table's value vectors.
    *
-   * @param schemaNegotiator builder given to the reader to provide it's
-   * schema information
    * @return the result set loader to be used by the reader
    */
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/BuildFromSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/BuildFromSchema.java
@@ -264,7 +264,7 @@ public class BuildFromSchema {
    * it may have may layers of other repeated lists before we get to the element
    * (inner-most) array.
    *
-   * @param writer tuple writer for the tuple that holds the array
+   * @param parent tuple writer for the tuple that holds the array
    * @param colSchema schema definition of the array
    */
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
@@ -123,7 +123,7 @@ public class ColumnBuilder {
    * and manages the column.
    *
    * @param parent schema of the new primitive column
-   * @param colProj implied projection type for the column
+   * @param columnSchema implied projection type for the column
    * @return column state for the new column
    */
   private ColumnState buildPrimitive(ContainerState parent, ColumnMetadata columnSchema) {
@@ -189,7 +189,7 @@ public class ColumnBuilder {
    * map vector (or vector container) until harvest time.
    *
    * @param parent description of the map column
-   * @param colProj implied projection type for the column
+   * @param columnSchema implied projection type for the column
    * @return column state for the map column
    */
   private ColumnState buildMap(ContainerState parent, ColumnMetadata columnSchema) {
@@ -310,7 +310,7 @@ public class ColumnBuilder {
    * does so. Unions are fully tested in the row set writer mechanism.
    *
    * @param parent container
-   * @param colProj column schema
+   * @param columnSchema column schema
    * @return column
    */
   private ColumnState buildUnion(ContainerState parent, ColumnMetadata columnSchema) {
@@ -368,7 +368,7 @@ public class ColumnBuilder {
    * not support the {@code ListVector</tt> type.
    *
    * @param parent the parent (tuple, union or list) that holds this list
-   * @param colProj metadata description of the list which must contain
+   * @param columnSchema metadata description of the list which must contain
    * exactly one subtype
    * @return the column state for the list
    */
@@ -418,7 +418,7 @@ public class ColumnBuilder {
    * not support the {@code ListVector} type.
    *
    * @param parent the parent (tuple, union or list) that holds this list
-   * @param colProj metadata description of the list (must be empty of
+   * @param columnSchema description of the list (must be empty of
    * subtypes)
    * @return the column state for the list
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetOptionBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetOptionBuilder.java
@@ -96,7 +96,7 @@ public class ResultSetOptionBuilder {
    * operation. Leave this method unset to start with an empty schema.</li>
    * <li>A combination of the above.</li>
    * </ul>
-   * @param schema the initial schema for the loader
+   * @param readerSchema the initial schema for the loader
    * @return this builder
    */
   public ResultSetOptionBuilder readerSchema(TupleMetadata readerSchema) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/SingleVectorState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/SingleVectorState.java
@@ -258,10 +258,12 @@ public abstract class SingleVectorState implements VectorState {
    * row, or for some previous row, depending on exactly when and where the
    * overflow occurs.
    *
-   * @param sourceStartIndex the index of the row that caused the overflow, the
+   * sourceStartIndex: the index of the row that caused the overflow, the
    * values of which should be copied to a new "look-ahead" vector. If the
    * vector is an array, then the overflowIndex is the position of the first
    * element to be moved, and multiple elements may need to move
+   *
+   * @param cardinality
    */
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
@@ -380,9 +380,9 @@ public abstract class DrillRelOptUtil {
 
   /**
    * Given a list of rexnodes it transforms the rexnodes by changing the expr to use new index mapped to the old index.
-   * @param builder : RexBuilder from the planner.
-   * @param exprs: RexNodes to be transformed.
-   * @param corrMap: Mapping between old index to new index.
+   * @param builder RexBuilder from the planner.
+   * @param exprs RexNodes to be transformed.
+   * @param corrMap Mapping between old index to new index.
    * @return
    */
   public static List<RexNode> transformExprs(RexBuilder builder, List<RexNode> exprs, Map<Integer, Integer> corrMap) {
@@ -396,9 +396,9 @@ public abstract class DrillRelOptUtil {
 
   /**
    * Given a of rexnode it transforms the rexnode by changing the expr to use new index mapped to the old index.
-   * @param builder : RexBuilder from the planner.
-   * @param expr: RexNode to be transformed.
-   * @param corrMap: Mapping between old index to new index.
+   * @param builder RexBuilder from the planner.
+   * @param expr RexNode to be transformed.
+   * @param corrMap Mapping between old index to new index.
    * @return
    */
   public static RexNode transformExpr(RexBuilder builder, RexNode expr, Map<Integer, Integer> corrMap) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/IndexPlanUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/IndexPlanUtils.java
@@ -73,7 +73,7 @@ public class IndexPlanUtils {
   /**
    * Check if any of the fields of the index are present in a list of LogicalExpressions supplied
    * as part of IndexableExprMarker
-   * @param exprMarker, the marker that has analyzed original index condition on top of original scan
+   * @param exprMarker the marker that has analyzed original index condition on top of original scan
    * @param indexDesc
    * @return ConditionIndexed.FULL, PARTIAL or NONE depending on whether all, some or no columns
    * of the indexDesc are present in the list of LogicalExpressions supplied as part of exprMarker

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ClassicConnectorLocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ClassicConnectorLocator.java
@@ -234,7 +234,6 @@ public class ClassicConnectorLocator implements ConnectorLocator {
    * {@link ExecConstants#BOOTSTRAP_FORMAT_PLUGINS_FILE} files for the first
    * fresh install of Drill.
    *
-   * @param lpPersistence deserialization mapper provider
    * @return bootstrap storage plugins
    * @throws IOException if a read error occurs
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/PluginHandle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/PluginHandle.java
@@ -129,7 +129,6 @@ public class PluginHandle {
    * time if the plugin creates a connection to another system, especially if that system
    * suffers timeouts.
    *
-   * @param context the context to use for creating a new instance, if needed
    * @return the initialized storage plugin
    * @throws UserException if the storage plugin creation failed due to class errors
    * (unlikely) or external system errors (more likely)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/SystemPluginLocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/SystemPluginLocator.java
@@ -55,10 +55,6 @@ public class SystemPluginLocator implements ConnectorLocator {
    * Will skip plugin initialization if no matching constructor, incorrect
    * class implementation, name absence are detected.
    *
-   * @param classpathScan
-   *          classpath scan result
-   * @param context
-   *          drillbit context
    * @return map with system plugins stored by name
    */
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownListener.java
@@ -43,7 +43,7 @@ import org.apache.drill.exec.store.base.filter.ExprNode.AndNode;
  * <dl>
  * <p>
  * In both cases, the conditions are in the form of a
- * {@link ColRelOpConst} in which one side refers to a column in the scan
+ * {@link  } in which one side refers to a column in the scan
  * and the other is a constant expression. The "driver" will ensure
  * the rel op is of the correct form; this class ensures that the
  * column is valid for the scan and the type of the value matches the
@@ -100,10 +100,6 @@ public interface FilterPushDownListener {
      * If so, return an equivalent RelOp with the value normalized to what
      * the plugin needs. The returned value may be the same as the original
      * one if the value is already normalized.
-     *
-     * @param groupScan the scan element. Use {@code scan.getGroupScan()}
-     * to get the group scan
-     * @param relOp the description of the relational operator expression
      * @return a normalized RelOp if this relop can be transformed into a filter
      * push-down, @{code null} if not and thus the relop should remain in
      * the Drill plan
@@ -126,13 +122,7 @@ public interface FilterPushDownListener {
      * to leave in the query. Those terms can be the ones passed in, or
      * new terms to handle special needs.
      *
-     * @param groupScan the scan node
-     * @param andTerms a list of the CNF (AND) terms, in which each is given
-     * by the Calcite AND node and the derived RelOp expression.
-     * @param orTerm the DNF (OR) term, if any, that includes the Calcite
-     * node for that term and the set of OR terms. Only provided if the OR
-     * term represents a simple list of values (all OR clauses are on the
-     * same column). The OR term itself is AND'ed with the CNF terms.
+     * @param expr
      * @return a pair of elements: a new scan (that represents the pushed filters),
      * and the original or new expression to appear in the WHERE clause
      * joined by AND with any non-candidate expressions. That is, if analysis

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -101,7 +101,6 @@ public class JSONRecordReader extends AbstractRecordReader {
   /**
    * Create a JSON Record Reader that uses an InputStream directly
    * @param fragmentContext The Drill Fragmement
-   * @param inputStream The inputStream from which data will be received
    * @param columns  pathnames of columns/subfields to read
    * @throws OutOfMemoryException
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ObjectParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ObjectParser.java
@@ -158,7 +158,8 @@ public abstract class ObjectParser extends AbstractElementParser {
    * <li>{@code foo: []}</li>
    * </ul>
    *
-   * @param field description of the field, including the field name
+   * @param key
+   * @param tokenizer
    * @return a parser for the newly-created field
    */
   protected abstract ElementParser onField(String key, TokenIterator tokenizer);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/CompliantTextBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/CompliantTextBatchReader.java
@@ -86,8 +86,7 @@ public class CompliantTextBatchReader implements ManagedReader<ColumnsSchemaNego
    * Performs the initial setup required for the record reader.
    * Initializes the input stream, handling of the output record batch
    * and the actual reader to be used.
-   * @param errorContext  operator context from which buffer's will be allocated and managed
-   * @param outputMutator  Used to create the schema in the output record batch
+   * @param schemaNegotiator Used to create the schema in the output record batch
    */
   @Override
   public boolean open(ColumnsSchemaNegotiator schemaNegotiator) {
@@ -128,7 +127,6 @@ public class CompliantTextBatchReader implements ManagedReader<ColumnsSchemaNego
    * Extract header and use that to define the reader schema.
    *
    * @param schemaNegotiator used to define the reader schema
-   * @param providedHeaders "artificial" headers created from a
    * provided schema, if any. Used when using a provided schema
    * with a text file that contains no headers; ignored for
    * text file with headers

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FooterGatherer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FooterGatherer.java
@@ -128,7 +128,7 @@ public class FooterGatherer {
   /**
    * An updated footer reader that tries to read the entire footer without knowing the length.
    * This should reduce the amount of seek/read roundtrips in most workloads.
-   * @param fs
+   * @param config
    * @param status
    * @return
    * @throws IOException

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
@@ -159,8 +159,8 @@ public abstract class ColumnReader<V extends ValueVector> {
     try {
       readField(recordsToRead);
 
-      valuesReadInCurrentPass += recordsReadInThisIteration;
-      pageReader.valuesRead += recordsReadInThisIteration;
+      valuesReadInCurrentPass += (int)recordsReadInThisIteration;
+      pageReader.valuesRead += (int)recordsReadInThisIteration;
       pageReader.readPosInBytes = readStartInBytes + readLength;
     } catch (Exception e) {
       UserException ex = UserException.dataReadError(e)
@@ -181,7 +181,6 @@ public abstract class ColumnReader<V extends ValueVector> {
    * Return value indicates if we have finished a row group and should stop reading
    *
    * @param recordsReadInCurrentPass
-   * @param lengthVarFieldsInCurrentRecord
    * @return - true if we should stop reading
    * @throws IOException
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenAbstractEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenAbstractEntryReader.java
@@ -35,9 +35,8 @@ abstract class VarLenAbstractEntryReader {
   /**
    * CTOR.
    * @param buffer byte buffer for data buffering (within CPU cache)
-   * @param pageInfo page being processed information
-   * @param columnPrecInfo column precision information
    * @param entry reusable bulk entry object
+   * @param containerCallback
    */
   VarLenAbstractEntryReader(ByteBuffer buffer,
     VarLenColumnBulkEntry entry,
@@ -49,7 +48,7 @@ abstract class VarLenAbstractEntryReader {
   }
 
   /**
-   * @param valuesToRead maximum values to read within the current page
+   * @param valsToReadWithinPage maximum values to read within the current page
    * @return a bulk entry object
    */
   abstract VarLenColumnBulkEntry getEntry(int valsToReadWithinPage);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkInput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkInput.java
@@ -75,7 +75,7 @@ public final class VarLenColumnBulkInput<V extends ValueVector> implements VarLe
    * CTOR.
    * @param parentInst parent object instance
    * @param recordsToRead number of records to read
-   * @param columnPrecInfo column precision information
+   * @param bulkReaderState
    * @throws IOException runtime exception in case of processing error
    */
   VarLenColumnBulkInput(VarLengthValuesColumn<V> parentInst,
@@ -720,8 +720,7 @@ public final class VarLenColumnBulkInput<V extends ValueVector> implements VarLe
     /**
      * Set the {@link PageReader#dictionaryValueReader} object; if a null value is passed, then it is understood
      * the current page doesn't use dictionary encoding
-     * @param valuesReader {@link ValuesReader} object
-     * @param numValues total number of values that can be read from the stream
+     * @param _rawReader {@link ValuesReader} object
      */
     void set(ValuesReader _rawReader) {
       this.valuesReader    = _rawReader;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenOverflowReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenOverflowReader.java
@@ -39,8 +39,8 @@ public final class VarLenOverflowReader extends VarLenAbstractEntryReader {
   /**
    * CTOR.
    * @param buffer byte buffer for data buffering (within CPU cache)
-   * @param pageInfo page being processed information
-   * @param columnPrecInfo column precision information
+   * @param containerCallback
+   * @param fieldOverflowContainer
    * @param entry reusable bulk entry object
    */
   VarLenOverflowReader(ByteBuffer buffer,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/batchsizing/BatchSizingMemoryUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/batchsizing/BatchSizingMemoryUtil.java
@@ -91,9 +91,9 @@ public final class BatchSizingMemoryUtil {
   /**
    * Load memory usage information for a variable length value vector
    *
-   * @param vector source value vector
+   * @param sourceVector source value vector
    * @param currValueCount current value count
-   * @param vectorMemory result object which contains source vector memory usage information
+   * @param vectorMemoryUsage result object which contains source vector memory usage information
    */
   public static void getMemoryUsage(ValueVector sourceVector,
     int currValueCount,
@@ -223,7 +223,7 @@ public final class BatchSizingMemoryUtil {
   }
 
   /**
-   * @param fixed column's metadata
+   * @param column column's metadata
    * @param valueCount number of column values
    * @return memory size required to store "valueCount" within a value vector
    */
@@ -243,7 +243,7 @@ public final class BatchSizingMemoryUtil {
   }
 
   /**
-   * @param variable length column's metadata
+   * @param column length column's metadata
    * @param averagePrecision VL column average precision
    * @param valueCount number of column values
    * @return memory size required to store "valueCount" within a value vector

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/record/RecordBatchStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/record/RecordBatchStats.java
@@ -49,7 +49,8 @@ public final class RecordBatchStats {
     private final String contextOperatorId;
 
     /**
-     * @param options options manager
+     * @param context
+     * @param oContext
      */
     public RecordBatchStatsContext(FragmentContext context, OperatorContext oContext) {
       final boolean operatorEnabledForStatsLogging = isBatchStatsEnabledForOperator(context, oContext);
@@ -300,7 +301,7 @@ public final class RecordBatchStats {
   /**
    * Constructs record batch statistics for the input record batch
    *
-   * @param stats instance identifier
+   * @param statsId instance identifier
    * @param ioType whether a record batch is an input or/and output
    * @param sourceId optional source identifier for scanners
    * @param batchSizer contains batch sizing information

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/filter/BloomFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/filter/BloomFilter.java
@@ -156,8 +156,8 @@ public class BloomFilter {
    * Calculate optimal size according to the number of distinct values and false positive probability.
    * See http://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives for the formula.
    *
-   * @param ndv: The number of distinct values.
-   * @param fpp: The false positive probability.
+   * @param ndv The number of distinct values.
+   * @param fpp The false positive probability.
    * @return optimal number of bytes of given ndv and fpp.
    */
   public static int optimalNumOfBytes(long ndv, double fpp) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/QueryQueue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/QueryQueue.java
@@ -42,8 +42,6 @@ public interface QueryQueue {
     /**
      * Release a query lease obtained from {@link #queue(QueryId, double))}.
      * Should be called by the per-query resource manager.
-     *
-     * @param lease the lease to be released.
      */
 
     void release();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/QueryResourceAllocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/QueryResourceAllocator.java
@@ -48,7 +48,6 @@ public interface QueryResourceAllocator {
    * Provide the manager with the physical plan and node assignments
    * for the query to be run. This class will plan memory for the query.
    *
-   * @param plan
    * @param work
    */
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/NullableVectorDefinitionSetter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/NullableVectorDefinitionSetter.java
@@ -28,7 +28,7 @@ public interface NullableVectorDefinitionSetter {
   /**
    * Set a contiguous set of values starting at position "index" to be defined.
    * @param index value position
-   * @param number of contiguous values
+   * @param numValues of contiguous values
    */
   public void setIndexDefined(int index, int numValues);
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/VarLenBulkInput.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/VarLenBulkInput.java
@@ -33,7 +33,6 @@ public interface VarLenBulkInput<T extends VarLenBulkEntry> extends Iterator<T> 
    * Indicates we're done processing (processor might stop processing when memory buffers
    * are depleted); this allows caller to re-submit any unprocessed data.
    *
-   * @param numCommitted number of processed entries
    */
   void done();
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/UnionWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/UnionWriterImpl.java
@@ -232,7 +232,7 @@ public class UnionWriterImpl implements VariantWriter, WriterEvents {
    * The corresponding metadata must already have been added to the schema.
    * Called by the shim's <tt>addMember</tt> to do writer-level tasks.
    *
-   * @param colWriter the column writer to add
+   * @param writer the column writer to add
    */
 
   protected void addMember(AbstractObjectWriter writer) {

--- a/logical/src/main/java/org/apache/drill/common/graph/GraphAlgos.java
+++ b/logical/src/main/java/org/apache/drill/common/graph/GraphAlgos.java
@@ -69,8 +69,7 @@ public class GraphAlgos {
      *
      * @param graph
      *          The adjacency list for the DAG.
-     * @param sourceNodes
-     *          List of nodes that
+     * @param reverse
      * @return
      */
     static <V extends GraphValue<V>> List<AdjacencyList<V>.Node> sortInternal(AdjacencyList<V> graph, boolean reverse) {


### PR DESCRIPTION
# DRILL-7993 (https://issues.apache.org/jira/browse/DRILL-7993): LGTM Code Cleanup-Fixed @param tags and type conversion

## Description

Fixed invalid param tags in Javadoc comments. Also fixed some type conversion errors.

## Documentation
NA

## Testing
NA
