### PR TITLE
Fixed Broken Link for Kafka Plugin Documentation

### DIFF
--- a/contrib/storage-kafka/README.md
+++ b/contrib/storage-kafka/README.md
@@ -214,8 +214,7 @@ Note:
 - Custom record reader can be implemented by extending org.apache.drill.exec.store.kafka.decoders.MessageReader and setting store.kafka.record.reader accordingly
 
 
-In case of JSON message format, following system / session options can be used accordingly. More details can be found in [Drill Json Model](https://drill.apache.org/docs/json-data
--model/) and in [Drill system options configurations](https://drill.apache.org/docs/configuration-options-introduction/)
+In case of JSON message format, following system / session options can be used accordingly. More details can be found in [Drill Json Model](https://drill.apache.org/docs/json-data-model/) and in [Drill system options configurations](https://drill.apache.org/docs/configuration-options-introduction/)
 
 <ul>
   <li>ALTER SESSION SET `store.kafka.record.reader` = 'org.apache.drill.exec.store.kafka.decoders.JsonMessageReader';</li>


### PR DESCRIPTION
# [DRILL-XXXX](https://issues.apache.org/jira/browse/DRILL-XXXX) Fix Broken Link for Kafka Plugin Documentation

## Description

The [link to JSON data model on apache drill website](https://drill.apache.org/docs/json-data-model/) was incorrectly linked in the README.md file. I fixed it.


## Testing
The link works and it is visible in my fork
