### PR TITLE
DRILL-7999 Base Docker image on maven:3.8.2-jdk-11 and openjdk-11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.dockerignore
+Dockerfile
+
+# Excluding the .git directory would be a meaningful saving but the build
+# makes use of the git-commit-id plugin and that wants the git repo to be
+# present. 
+# .git
+
+# The top-level Dockerfile does its own Maven build so we don't want
+# **/target.  See distribution/Dockerfile for a Dockerfile that
+# builds an image using binaries copied from distribution/target.
+
+**/target

--- a/hooks/README
+++ b/hooks/README
@@ -1,0 +1,9 @@
+This directory exists for Docker Hub's automatic image building. The hooks 
+here override the default build, test and push commands used by Docker Hub
+to build the published Docker images of Drill.  The reason they are overridden
+is so that we can produce Docker images based on multiple OpenJDK base images,
+all using a single Dockerfile.  Also see
+
+../Dockerfile
+https://docs.docker.com/docker-hub/builds/advanced/
+

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build \
+	--build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-8 \
+	--build-arg BASE_IMAGE=openjdk:8-jre \
+	-t apache/drill:$DOCKER_TAG-openjdk-8 \
+	-t apache/drill:$DOCKER_TAG \
+	.
+
+docker build \
+	--build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-11 \
+	--build-arg BASE_IMAGE=openjdk:11-jre \
+	-t apache/drill:$DOCKER_TAG-openjdk-11 \
+	.
+
+# Maven images in Docker Hub jump from OpenJDK 11 to OpenJDK 16 so we build
+# with OpenJDK 11 for the OpenJDK 14-based container.
+
+docker build \
+	--build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-11 \
+	--build-arg BASE_IMAGE=openjdk:14 \
+	-t apache/drill:$DOCKER_TAG-openjdk-14 \
+	.

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker push apache/drill:$DOCKER_TAG
+docker push apache/drill:$DOCKER_TAG-openjdk-8
+docker push apache/drill:$DOCKER_TAG-openjdk-11
+docker push apache/drill:$DOCKER_TAG-openjdk-14
+


### PR DESCRIPTION
# [DRILL-7999](https://issues.apache.org/jira/browse/DRILL-7999): Base Docker image on maven:3.8.2-jdk-11 and openjdk-11

## Description

Our Docker container builds on OpenJDK 8u232 (released late in 2019), while the current LTS series of OpenJDK is 11.  Update our Dockerfile to OpenJDK 11.

## Documentation

Unchanged except that I do address the following docs issues pointed out by a user, not related to this JDK version change.

> 1. Drill documentation referrs to $DRILL_HOME environment variable which is not set in the Docker Image. Additionally in the doucmenation says it can be found in /etc/drill/conf while in the Docker image Drill has been installed into /opt/drill/conf
> 2. Add information how to add (mount) custom configuration files into the Docker image or even better, just make sure there is a Docker section in Drill's documentation whereever appropriate

## Testing
- Test Drill built from master branch (1.20-SNAPSHOT) with OpenJDK 11 outside of Docker.
- Test Drill built from master branch (1.20-SNAPSHOT) with OpenJDK 11 inside of Docker by building a Docker image from the updated Dockerfile.
- Test a downloaded build of Drill 1.19 inside a Docker container based on OpenJDK 11 (published [here](https://hub.docker.com/repository/docker/dzamo2/drill)).
