### PR TITLE
DRILL-8001: Replace JRE docker images with JDK counterparts.

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -18,14 +18,14 @@
 
 docker build \
 	--build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-8 \
-	--build-arg BASE_IMAGE=openjdk:8-jre \
+	--build-arg BASE_IMAGE=openjdk:8 \
 	-t apache/drill:$DOCKER_TAG-openjdk-8 \
 	-t apache/drill:$DOCKER_TAG \
 	.
 
 docker build \
 	--build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-11 \
-	--build-arg BASE_IMAGE=openjdk:11-jre \
+	--build-arg BASE_IMAGE=openjdk:11 \
 	-t apache/drill:$DOCKER_TAG-openjdk-11 \
 	.
 


### PR DESCRIPTION
# [DRILL-8001](https://issues.apache.org/jira/browse/DRILL-8001): Replace JRE docker images with JDK counterparts.

## Description

Drill requires the Java compiler from the full JDK at runtime so we need to change the base OpenJDK images used accordingly.

## Documentation
N/A

## Testing

I rented a VM for testing this time and tested each image from building from a clean clone through to running a SQL query in Drill.

```
podman build \
        --build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-8 \
        --build-arg BASE_IMAGE=openjdk:8 \
        -t apache/drill-openjdk-8 .

podman run --rm -it localhost/apache/drill-openjdk-8

select * from cp.`employee.json`;

podman build \
        --build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-11 \
        --build-arg BASE_IMAGE=openjdk:11 \
        -t apache/drill-openjdk-11 .

podman run --rm -it localhost/apache/drill-openjdk-11

select * from cp.`employee.json`;

podman build \
        --build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-11 \
        --build-arg BASE_IMAGE=openjdk:14 \
        -t apache/drill-openjdk-14.

podman run --rm -it localhost/apache/drill-openjdk-14

select * from cp.`employee.json`;
```