### PR TITLE
DRILL-8004: Splunk Sends Newlines in INT Fields, Causing Exceptions

### DIFF
--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
@@ -370,7 +370,17 @@ public class SplunkBatchReader implements ManagedReader<SchemaNegotiator> {
     @Override
     public void load(String[] record) {
       if (record[columnIndex] != null) {
-        int value = Integer.parseInt(record[columnIndex]);
+        // Splunk may include extra garbage such as newlines or other whitespace in INT fields.
+        String stringValue = record[columnIndex];
+        stringValue = stringValue.replaceAll("\\s","");
+
+        int value;
+        try {
+          value = Integer.parseInt(stringValue);
+        } catch (NumberFormatException e) {
+          // If we still can't parse the INT field, for whatever reason, set value to -1
+          value = -1;
+        }
         columnWriter.setInt(value);
       } else {
         columnWriter.setNull();

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
@@ -372,7 +372,7 @@ public class SplunkBatchReader implements ManagedReader<SchemaNegotiator> {
       if (record[columnIndex] != null) {
         // Splunk may include extra garbage such as newlines or other whitespace in INT fields.
         String stringValue = record[columnIndex];
-        stringValue = stringValue.replaceAll("\\s","");
+        stringValue = stringValue.replaceAll("\\s", "");
 
         int value;
         try {


### PR DESCRIPTION
# [DRILL-8004](https://issues.apache.org/jira/browse/DRILL-8004): DRILL-8004: Splunk Sends Newlines in INT Fields, Causing Exceptions

## Description
Splunk occasionally sends extra white space in `INT` fields.  This was discovered by a user, and when Drill tries to parse the response, it causes `NumberFormatExceptions`.  This PR removes white space in known `INT` fields.  If an exception is thrown, it replaces the value with `-1`.   

Note that all the known `INT` fields are fields derived from time stamps, so in theory they should never be negative.

## Documentation
N/A

## Testing
Manually tested.