### PR TITLE
[MINOR UPDATE] Run Drill in Docker using a new non-root "drilluser" account

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -17,16 +17,25 @@
 #
 
 # This Dockerfile may be used during development. It adds built binaries from distribution/target folder
-# into the target image based on openjdk:8u232-jdk image.
+# into the target image based on openjdk:8 image.  If you've built Drill using a JDK version greater than
+# the one in the FROM command in this Dockerfile then you should bump this one up to match or exceed that.
 
-FROM openjdk:8u232-jdk
+FROM openjdk:8
 
 # Project version defined in pom.xml is passed as an argument
 ARG VERSION
 
+ENV DRILL_HOME=/opt/drill DRILL_USER=drilluser
+
 RUN mkdir /opt/drill
 
 COPY target/apache-drill-$VERSION/apache-drill-$VERSION /opt/drill
+
+RUN groupadd -g 999 $DRILL_USER \
+ && useradd -r -u 999 -g $DRILL_USER $DRILL_USER -m -d /var/lib/drill \
+ && chown -R $DRILL_USER: $DRILL_HOME
+
+USER $DRILL_USER
 
 # Starts Drill in embedded mode and connects to Sqlline
 ENTRYPOINT /opt/drill/bin/drill-embedded


### PR DESCRIPTION
# [MINOR UPDATE] Run Drill in Docker using a new non-root "drilluser" account

## Description

While containers are sandboxed, it is still best practice to run proceses within them using non-root accounts.  This adds a non-root "drilluser" to both Dockerfiles and fixes an incorrect default JDK base image version number at the same time (it's not used in our CI Docker build process but it was wrong nonethless, referring to a JRE base image).

## Documentation
No change to the user docs for running inside Docker.

## Testing
Build and run containers from both Dockerfiles.  Run queries in sqlline to CTAS a temp table and then query it.  Shell into a running container to look at files and perms in the home directory of the new system account (/var/lib/drill).
