### PR TITLE
DRILL-7863: Add Storage Plugin for Apache Phoenix

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -54,6 +54,7 @@
     <module>format-xml</module>
     <module>format-image</module>
     <module>format-pcapng</module>
+    <module>storage-phoenix</module>
     <module>storage-hive</module>
     <module>storage-mongo</module>
     <module>storage-jdbc</module>

--- a/contrib/storage-phoenix/README.md
+++ b/contrib/storage-phoenix/README.md
@@ -1,0 +1,153 @@
+# [DRILL-7863](https://issues.apache.org/jira/browse/DRILL-7863): Add Storage Plugin for Apache Phoenix
+
+## Description
+
+ Phoenix say : "We put the SQL back in NoSQL",<br/>
+ Drill call : "We use the SQL to cross almost all the file systems and storage engines",<br/>
+ "Cheers !", users said.
+
+## Documentation
+
+Features :
+
+ - Full support for Enhanced Vector Framework.
+ 
+ - Tested in phoenix 4.14 and 5.1.2.
+ 
+ - Support the array data type.
+ 
+ - Support the pushdown (Project, Limit, Filter, Aggregate, Join, CrossJoin, Join_Filter, GroupBy, Distinct and more).
+ 
+ - Use the PQS client (6.0).
+
+Related Information :
+
+ 1. PHOENIX-6398: Returns uniform SQL dialect in calcite for the PQS
+
+ 2. PHOENIX-6582: Bump default HBase version to 2.3.7 and 2.4.8
+
+ 3. PHOENIX-6605, PHOENIX-6606 and PHOENIX-6607.
+
+ 4. DRILL-8060, DRILL-8061 and DRILL-8062.
+
+ 5. [QueryServer 6.0.0-drill-r1](https://github.com/luocooong/phoenix-queryserver/releases/tag/6.0.0-drill-r1)
+
+## Configuration
+
+ To connect Drill to Phoenix, create a new storage plugin with the following configuration :
+
+Option 1 (Use the host and port) :
+
+```json
+{
+  "type": "phoenix",
+  "host": "the.queryserver.hostname",
+  "port": 8765,
+  "enabled": true
+}
+```
+
+Option 2 (Use the jdbcURL) :
+
+```json
+{
+  "type": "phoenix",
+  "jdbcURL": "jdbc:phoenix:thin:url=http://the.queryserver.hostname:8765;serialization=PROTOBUF",
+  "enabled": true
+}
+```
+
+Use the connection properties :
+
+```json
+{
+  "type": "phoenix",
+  "host": "the.queryserver.hostname",
+  "port": 8765,
+  "props": {
+    "phoenix.query.timeoutMs": 60000
+  },
+  "enabled": true
+}
+```
+
+Tips :
+ * More connection properties, see also [PQS Configuration](http://phoenix.apache.org/server.html).
+ * If you provide the `jdbcURL`, the connection will ignore the value of `host` and `port`.
+ * If you extended the authentication of QueryServer, you can also pass the `userName` and `password`.
+
+```json
+{
+  "type": "phoenix",
+  "host": "the.queryserver.hostname",
+  "port": 8765,
+  "userName": "my_user",
+  "password": "my_pass",
+  "enabled": true
+}
+```
+
+## Testing
+
+ The test framework of phoenix queryserver required the Hadoop 3, but exist `PHOENIX-5993` and `HBASE-22394` :
+
+```
+" The HBase PMC does not release multiple artifacts for both Hadoop2 and Hadoop3 support at the current time.
+Current HBase2 releases still compile against Hadoop2 by default, and using Hadoop 3 against HBase2
+requires a recompilation of HBase because of incompatible changes between Hadoop2 and Hadoop3. "
+```
+
+### Recommended Practices
+
+ 1. Download HBase 2.4.2 sources and rebuild with Hadoop 3.
+
+ 2. Remove the `Ignore` annotation in `PhoenixTestSuite.java`.
+
+ 3. Go to the phoenix root folder and run test.
+
+### To Add Features
+
+ - Don't forget to add a test function to the test class.
+ 
+ - If a new test class is added, please declare it in the `PhoenixTestSuite` class.
+
+### Play in CLI
+
+```
+apache drill> use phoenix123.v1;
++------+-------------------------------------------+
+|  ok  |                  summary                  |
++------+-------------------------------------------+
+| true | Default schema changed to [phoenix123.v1] |
++------+-------------------------------------------+
+1 row selected (0.308 seconds)
+apache drill (phoenix123.v1)> select n_regionkey, max(n_nationkey) from nation group by n_regionkey having max(n_nationkey) > 20;
++-------------+--------+
+| n_regionkey | EXPR$1 |
++-------------+--------+
+| 1           | 24     |
+| 2           | 21     |
+| 3           | 23     |
++-------------+--------+
+3 rows selected (0.734 seconds)
+apache drill (phoenix123.v1)> select a.n_name, b.r_name from nation a join region b on a.n_regionkey = b.r_regionkey where b.r_name = 'ASIA';
++-----------+--------+
+|  n_name   | r_name |
++-----------+--------+
+| INDIA     | ASIA   |
+| INDONESIA | ASIA   |
+| JAPAN     | ASIA   |
+| CHINA     | ASIA   |
+| VIETNAM   | ASIA   |
++-----------+--------+
+5 rows selected (1.199 seconds)
+apache drill (phoenix123.v1)> select n_name, n_regionkey from nation limit 3 offset 10;
++--------+-------------+
+| n_name | n_regionkey |
++--------+-------------+
+| IRAN   | 4           |
+| IRAQ   | 4           |
+| JAPAN  | 2           |
++--------+-------------+
+3 rows selected (0.77 seconds)
+```

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.drill.contrib</groupId>
+    <artifactId>drill-contrib-parent</artifactId>
+    <version>1.20.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>drill-storage-phoenix</artifactId>
+  <name>Drill : Contrib : Storage : Phoenix</name>
+  
+  <properties>
+    <phoenix.queryserver.version>6.0.0</phoenix.queryserver.version>
+    <phoenix.version>5.1.2</phoenix.version>
+    <!-- Keep the 2.4.2 to reduce dependency conflict -->
+    <hbase.minicluster.version>2.4.2</hbase.minicluster.version>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.drill.exec</groupId>
+      <artifactId>drill-java-exec</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.drill.exec</groupId>
+      <artifactId>drill-java-exec</artifactId>
+      <classifier>tests</classifier>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.drill</groupId>
+      <artifactId>drill-common</artifactId>
+      <classifier>tests</classifier>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+	<dependency>
+	  <groupId>org.apache.phoenix</groupId>
+	  <artifactId>phoenix-queryserver-client</artifactId>
+	  <version>${phoenix.queryserver.version}</version>
+	</dependency>
+ 
+    <!-- Test Dependency versions -->
+    <dependency>
+      <!-- PHOENIX-6605 -->
+      <groupId>com.github.luocooong.phoenix-queryserver</groupId>
+      <artifactId>phoenix-queryserver</artifactId>
+      <version>6.0.0-drill-r1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-core</artifactId>
+      <version>${phoenix.version}</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+         <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-core</artifactId>
+      <version>${phoenix.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-hbase-compat-2.4.0</artifactId>
+      <version>${phoenix.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-it</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-protocol-shaded</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-hadoop-compat</artifactId>
+      <version>${hbase.minicluster.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.univocity</groupId>
+      <artifactId>univocity-parsers</artifactId>
+      <version>${univocity-parsers.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-java-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/org/apache/drill/exec/store/phoenix</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/java/org/apache/drill/exec/store/phoenix</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/PhoenixTestSuite.class</include>
+          </includes>
+          <excludes>
+            <exclude>**/*Test.java</exclude>
+          </excludes>
+          <argLine>-Xms2048m -Xmx2048m</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixBatchReader.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixBatchReader.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayBigintDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayBooleanDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayDoubleDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayIntegerDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArraySmallintDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayTinyintDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ArrayVarcharDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.ColumnDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.GenericDateDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.GenericDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.GenericTimeDefn;
+import org.apache.drill.exec.store.phoenix.PhoenixReader.GenericTimestampDefn;
+import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
+import org.slf4j.LoggerFactory;
+
+public class PhoenixBatchReader implements ManagedReader<SchemaNegotiator> {
+
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(PhoenixBatchReader.class);
+
+  private final PhoenixSubScan subScan;
+  private CustomErrorContext errorContext;
+  private PhoenixReader reader;
+  private Connection conn;
+  private PreparedStatement pstmt;
+  private ResultSet results;
+  private ResultSetMetaData meta;
+  private ColumnDefn[] columns;
+  private Stopwatch watch;
+
+  public PhoenixBatchReader(PhoenixSubScan subScan) {
+    this.subScan = subScan;
+  }
+
+  @Override
+  public boolean open(SchemaNegotiator negotiator) {
+    try {
+      errorContext = negotiator.parentErrorContext();
+      conn = subScan.getPlugin().getDataSource().getConnection();
+      pstmt = conn.prepareStatement(subScan.getSql());
+      results = pstmt.executeQuery();
+      meta = pstmt.getMetaData();
+    } catch (SQLException e) {
+      throw UserException
+              .dataReadError(e)
+              .message("Failed to execute the phoenix sql query. " + e.getMessage())
+              .addContext(errorContext)
+              .build(logger);
+    }
+    try {
+      negotiator.tableSchema(defineMetadata(), true);
+      reader = new PhoenixReader(negotiator.build(), columns, results);
+      bindColumns(reader.getStorage());
+    } catch (SQLException e) {
+      throw UserException
+              .dataReadError(e)
+              .message("Failed to get type of columns from metadata. " + e.getMessage())
+              .addContext(errorContext)
+              .build(logger);
+    }
+    watch = Stopwatch.createStarted();
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+    try {
+      while(!reader.getStorage().isFull()) {
+        if (!reader.processRow()) { // return true if one row is processed.
+          watch.stop();
+          logger.debug("Phoenix fetch total record numbers : {}", reader.getRowCount());
+          return false; // the EOF is reached.
+        }
+      }
+      return true; // batch full but not reached the EOF.
+    } catch (SQLException e) {
+      throw UserException
+              .dataReadError(e)
+              .message("Failed to get the data from the result set. " + e.getMessage())
+              .addContext(errorContext)
+              .build(logger);
+    }
+  }
+
+  @Override
+  public void close() {
+    logger.debug("Phoenix fetch batch size : {}, took {} ms. ", reader.getBatchCount(), watch.elapsed(TimeUnit.MILLISECONDS));
+    AutoCloseables.closeSilently(results, pstmt, conn);
+  }
+
+  private TupleMetadata defineMetadata() throws SQLException {
+    List<SchemaPath> cols = subScan.getColumns();
+    columns = new ColumnDefn[cols.size()];
+    SchemaBuilder builder = new SchemaBuilder();
+    for (int index = 0; index < cols.size(); index++) {
+      int columnIndex = index + 1; // column the first column is 1
+      int sqlType = meta.getColumnType(columnIndex);
+      String columnName = cols.get(index).rootName();
+      columns[index] = makeColumn(columnName, sqlType, meta.getColumnTypeName(columnIndex), columnIndex);
+      columns[index].define(builder);
+    }
+    return builder.buildSchema();
+  }
+
+  private ColumnDefn makeColumn(String name, int sqlType, String baseType, int index) {
+    if (sqlType == Types.ARRAY) { // supports the array data type
+      if (baseType.equals(ArrayDefn.VARCHAR) || baseType.equals(ArrayDefn.CHAR)) {
+        return new ArrayVarcharDefn(name, index, sqlType, baseType);
+      } else if (baseType.equals(ArrayDefn.BIGINT)) {
+        return new ArrayBigintDefn(name, index, sqlType, baseType);
+      } else if (baseType.equals(ArrayDefn.INTEGER)) {
+        return new ArrayIntegerDefn(name, index, sqlType, baseType);
+      } else if (baseType.equals(ArrayDefn.SMALLINT)) {
+        return new ArraySmallintDefn(name, index, sqlType, baseType);
+      } else if (baseType.equals(ArrayDefn.TINYINT)) {
+        return new ArrayTinyintDefn(name, index, sqlType, baseType);
+      } else if (baseType.equals(ArrayDefn.DOUBLE) || baseType.equals(ArrayDefn.FLOAT)) {
+        return new ArrayDoubleDefn(name, index, sqlType, baseType);
+      } else if (baseType.equals(ArrayDefn.BOOLEAN)) {
+        return new ArrayBooleanDefn(name, index, sqlType, baseType);
+      } else {
+        throw UserException.dataReadError()
+        .message("The Phoenix reader does not support this data type : " + baseType)
+        .addContext(errorContext)
+        .build(logger);
+      }
+    }
+    // supports the generic data type
+    if (sqlType == Types.DATE) {
+      return new GenericDateDefn(name, index, sqlType);
+    } else if (sqlType == Types.TIME) {
+      return new GenericTimeDefn(name, index, sqlType);
+    } else if (sqlType == Types.TIMESTAMP) {
+      return new GenericTimestampDefn(name, index, sqlType);
+    } else if (sqlType == Types.VARCHAR
+        || sqlType == Types.CHAR
+        || sqlType == Types.BIGINT
+        || sqlType == Types.INTEGER
+        || sqlType == Types.SMALLINT
+        || sqlType == Types.TINYINT
+        || sqlType == Types.DOUBLE
+        || sqlType == Types.FLOAT
+        || sqlType == Types.DECIMAL
+        || sqlType == Types.BINARY
+        || sqlType == Types.VARBINARY
+        || sqlType == Types.BOOLEAN) {
+      return new GenericDefn(name, index, sqlType);
+    } else {
+      throw UserException.dataReadError()
+      .message("The Phoenix reader does not support this data type : java.sql.Types : " + sqlType)
+      .addContext(errorContext)
+      .build(logger);
+    }
+  }
+
+  private void bindColumns(RowSetLoader loader) {
+    for (int i = 0; i < columns.length; i++) {
+      columns[i].bind(loader);
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixDataSource.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixDataSource.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+/**
+ * Phoenix’s Connection objects are different from most other JDBC Connections
+ * due to the underlying HBase connection. The Phoenix Connection object
+ * is designed to be a thin object that is inexpensive to create.
+ *
+ * If Phoenix Connections are reused, it is possible that the underlying HBase connection
+ * is not always left in a healthy state by the previous user. It is better to
+ * create new Phoenix Connections to ensure that you avoid any potential issues.
+ */
+public class PhoenixDataSource implements DataSource {
+
+  private static final String DEFAULT_URL_HEADER = "jdbc:phoenix:thin:url=http://";
+  private static final String DEFAULT_SERIALIZATION = "serialization=PROTOBUF";
+
+  private String url;
+  private Map<String, Object> connectionProperties;
+  private boolean isFatClient; // Is a fat client
+
+  public PhoenixDataSource(String url) {
+    Preconditions.checkNotNull(url);
+    this.url = url;
+  }
+
+  public PhoenixDataSource(String host, int port) {
+    Preconditions.checkNotNull(host);
+    Preconditions.checkArgument(port > 0, "Please set the correct port.");
+    this.url = new StringBuilder()
+        .append(DEFAULT_URL_HEADER)
+        .append(host)
+        .append(":")
+        .append(port)
+        .append(";")
+        .append(DEFAULT_SERIALIZATION)
+        .toString();
+  }
+
+  public PhoenixDataSource(String url, Map<String, Object> connectionProperties) {
+    this(url);
+    Preconditions.checkNotNull(connectionProperties);
+    connectionProperties.forEach((k, v)
+        -> Preconditions.checkArgument(v != null, String.format("does not accept null values : %s", k)));
+    this.connectionProperties = connectionProperties;
+  }
+
+  public PhoenixDataSource(String host, int port, Map<String, Object> connectionProperties) {
+    this(host, port);
+    Preconditions.checkNotNull(connectionProperties);
+    connectionProperties.forEach((k, v)
+        -> Preconditions.checkArgument(v != null, String.format("does not accept null values : %s", k)));
+    this.connectionProperties = connectionProperties;
+  }
+
+  public Map<String, Object> getConnectionProperties() {
+    return connectionProperties;
+  }
+
+  public void setConnectionProperties(Map<String, Object> connectionProperties) {
+    this.connectionProperties = connectionProperties;
+  }
+
+  @Override
+  public PrintWriter getLogWriter() throws SQLException {
+    throw new UnsupportedOperationException("getLogWriter");
+  }
+
+  @Override
+  public void setLogWriter(PrintWriter out) throws SQLException {
+    throw new UnsupportedOperationException("setLogWriter");
+  }
+
+  @Override
+  public void setLoginTimeout(int seconds) throws SQLException {
+    throw new UnsupportedOperationException("setLoginTimeout");
+  }
+
+  @Override
+  public int getLoginTimeout() throws SQLException {
+    return 0;
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    throw new UnsupportedOperationException("getParentLogger");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return (T) this;
+    }
+    throw new SQLException("DataSource of type [" + getClass().getName() +
+        "] cannot be unwrapped as [" + iface.getName() + "]");
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return iface.isInstance(this);
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    useDriverClass();
+    Connection conn = DriverManager.getConnection(url, useConfProperties());
+    return conn;
+  }
+
+  @Override
+  public Connection getConnection(String username, String password) throws SQLException {
+    useDriverClass();
+    Connection conn = DriverManager.getConnection(url, username, password);
+    return conn;
+  }
+
+  /**
+   * The thin-client is lightweight and better compatibility.
+   * Only thin-client is currently supported.
+   *
+   * @throws SQLException
+   */
+  private void useDriverClass() throws SQLException {
+    try {
+      if (!isFatClient) {
+        Class.forName(PhoenixStoragePluginConfig.THIN_DRIVER_CLASS);
+      } else {
+        Class.forName(PhoenixStoragePluginConfig.FAT_DRIVER_CLASS);
+      }
+    } catch (ClassNotFoundException e) {
+      throw new SQLException("Cause by : " + e.getMessage());
+    }
+  }
+
+  /**
+   * Override these parameters at any time using the storage configuration.
+   *
+   * @return the final connection properties
+   */
+  private Properties useConfProperties() {
+    Properties props = new Properties();
+    props.put("phoenix.trace.frequency", "never");
+    props.put("phoenix.query.timeoutMs", 30000);
+    props.put("phoenix.query.keepAliveMs", 120000);
+    if (getConnectionProperties() != null) {
+      props.putAll(getConnectionProperties());
+    }
+    return props;
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixGroupScan.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixGroupScan.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
+import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.SubScan;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("phoenix-scan")
+public class PhoenixGroupScan extends AbstractGroupScan {
+
+  private final String sql;
+  private final List<SchemaPath> columns;
+  private final PhoenixScanSpec scanSpec;
+  private final PhoenixStoragePlugin plugin;
+
+  private int hashCode;
+
+  @JsonCreator
+  public PhoenixGroupScan(
+      @JsonProperty("sql") String sql,
+      @JsonProperty("columns") List<SchemaPath> columns,
+      @JsonProperty("scanSpec") PhoenixScanSpec scanSpec,
+      @JsonProperty("config") PhoenixStoragePluginConfig config,
+      @JacksonInject StoragePluginRegistry plugins) {
+    super("no-user");
+    this.sql = sql;
+    this.columns = columns;
+    this.scanSpec = scanSpec;
+    this.plugin = plugins.resolve(config, PhoenixStoragePlugin.class);
+  }
+
+  public PhoenixGroupScan(PhoenixScanSpec scanSpec, PhoenixStoragePlugin plugin) {
+    super("no-user");
+    this.sql = scanSpec.getSql();
+    this.columns = ALL_COLUMNS;
+    this.scanSpec = scanSpec;
+    this.plugin = plugin;
+  }
+
+  public PhoenixGroupScan(PhoenixGroupScan scan) {
+    super(scan);
+    this.sql = scan.sql;
+    this.columns = scan.columns;
+    this.scanSpec = scan.scanSpec;
+    this.plugin = scan.plugin;
+  }
+
+  public PhoenixGroupScan(PhoenixGroupScan scan, List<SchemaPath> columns) {
+    super(scan);
+    this.sql = scan.sql;
+    this.columns = columns;
+    this.scanSpec = scan.scanSpec;
+    this.plugin = scan.plugin;
+  }
+
+  public PhoenixGroupScan(String sql, List<SchemaPath> columns, PhoenixScanSpec scanSpec, PhoenixStoragePlugin plugin) {
+    super("no-user");
+    this.sql = sql;
+    this.columns = columns;
+    this.scanSpec = scanSpec;
+    this.plugin = plugin;
+  }
+
+  @JsonProperty("sql")
+  public String sql() {
+    return sql;
+  }
+
+  @JsonProperty("columns")
+  public List<SchemaPath> columns() {
+    return columns;
+  }
+
+  @JsonProperty("scanSpec")
+  public PhoenixScanSpec scanSpec() {
+    return scanSpec;
+  }
+
+  @JsonIgnore
+  public PhoenixStoragePlugin plugin() {
+    return plugin;
+  }
+
+  @JsonProperty("config")
+  public StoragePluginConfig config() {
+    return plugin.getConfig();
+  }
+
+  @Override
+  public void applyAssignments(List<DrillbitEndpoint> endpoints) throws PhysicalOperatorSetupException {  }
+
+  @Override
+  public SubScan getSpecificScan(int minorFragmentId) throws ExecutionSetupException {
+    return new PhoenixSubScan(sql, columns, scanSpec, plugin);
+  }
+
+  @Override
+  public int getMaxParallelizationWidth() {
+    return 1;
+  }
+
+  @Override
+  public String getDigest() {
+    return toString();
+  }
+
+  @Override
+  public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) throws ExecutionSetupException {
+    return new PhoenixGroupScan(this);
+  }
+
+  @Override
+  public GroupScan clone(List<SchemaPath> columns) {
+    return new PhoenixGroupScan(this, columns);
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashCode == 0) {
+      hashCode = Objects.hash(sql, columns, scanSpec, plugin.getConfig());
+    }
+    return hashCode;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    PhoenixGroupScan groupScan = (PhoenixGroupScan) obj;
+    return Objects.equals(sql, groupScan.sql())
+        && Objects.equals(columns, groupScan.columns())
+        && Objects.equals(scanSpec, groupScan.scanSpec())
+        && Objects.equals(plugin.getConfig(), groupScan.config());
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+      .field("sql", sql)
+      .field("columns", columns)
+      .field("scanSpec", scanSpec)
+      .field("config", plugin.getConfig())
+      .toString();
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixReader.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixReader.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.sql.Array;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.vector.accessor.ColumnWriter;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.writer.ScalarArrayWriter;
+import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+
+public class PhoenixReader {
+
+  private final RowSetLoader writer;
+  private final ColumnDefn[] columns;
+  private final ResultSet results;
+
+  public PhoenixReader(ResultSetLoader loader, ColumnDefn[] columns, ResultSet results) {
+    this.writer = loader.writer();
+    this.columns = columns;
+    this.results = results;
+  }
+
+  public RowSetLoader getStorage() {
+    return writer;
+  }
+
+  public long getRowCount() {
+    return writer.loader().totalRowCount();
+  }
+
+  public int getBatchCount() {
+    return writer.loader().batchCount();
+  }
+
+  /**
+   * Fetch and process one row.
+   * @return return true if one row is processed, return false if there is no next row.
+   * @throws SQLException
+   */
+  public boolean processRow() throws SQLException {
+    if (results.next()) {
+      writer.start();
+      for (ColumnDefn columnDefn : columns) {
+        columnDefn.load(results);
+      }
+      writer.save();
+      return true;
+    }
+    return false;
+  }
+
+  protected static final Map<Integer, MinorType> COLUMN_TYPE_MAP = Maps.newHashMap();
+
+  static {
+    // text
+    COLUMN_TYPE_MAP.put(Types.VARCHAR, MinorType.VARCHAR);
+    COLUMN_TYPE_MAP.put(Types.CHAR, MinorType.VARCHAR);
+    // numbers
+    COLUMN_TYPE_MAP.put(Types.BIGINT, MinorType.BIGINT);
+    COLUMN_TYPE_MAP.put(Types.INTEGER, MinorType.INT);
+    COLUMN_TYPE_MAP.put(Types.SMALLINT, MinorType.INT);
+    COLUMN_TYPE_MAP.put(Types.TINYINT, MinorType.INT);
+    COLUMN_TYPE_MAP.put(Types.DOUBLE, MinorType.FLOAT8);
+    COLUMN_TYPE_MAP.put(Types.FLOAT, MinorType.FLOAT4);
+    COLUMN_TYPE_MAP.put(Types.DECIMAL, MinorType.VARDECIMAL);
+    // time
+    COLUMN_TYPE_MAP.put(Types.DATE, MinorType.DATE);
+    COLUMN_TYPE_MAP.put(Types.TIME, MinorType.TIME);
+    COLUMN_TYPE_MAP.put(Types.TIMESTAMP, MinorType.TIMESTAMP);
+    // binary
+    COLUMN_TYPE_MAP.put(Types.BINARY, MinorType.VARBINARY); // Raw fixed length byte array. Mapped to byte[].
+    COLUMN_TYPE_MAP.put(Types.VARBINARY, MinorType.VARBINARY); // Raw variable length byte array.
+    // boolean
+    COLUMN_TYPE_MAP.put(Types.BOOLEAN, MinorType.BIT);
+  }
+
+  protected abstract static class ColumnDefn {
+
+    final String name;
+    final int index;
+    final int sqlType;
+    ColumnWriter writer;
+
+    public String getName() {
+      return name;
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public int getSqlType() {
+      return sqlType;
+    }
+
+    public ColumnDefn(String name, int index, int sqlType) {
+      this.name = name;
+      this.index = index;
+      this.sqlType = sqlType;
+    }
+
+    public void define(SchemaBuilder builder) {
+      builder.addNullable(getName(), COLUMN_TYPE_MAP.get(getSqlType()));
+    }
+
+    public void bind(RowSetLoader loader) {
+      writer = loader.scalar(getName());
+    }
+
+    public abstract void load(ResultSet row) throws SQLException;
+  }
+
+  protected static class GenericDefn extends ColumnDefn {
+
+    public GenericDefn(String name, int index, int sqlType) {
+      super(name, index, sqlType);
+    }
+
+    @Override
+    public void load(ResultSet row) throws SQLException {
+      Object value = row.getObject(index);
+      if (value != null) {
+        writer.setObject(value);
+      }
+    }
+  }
+
+  protected static class GenericDateDefn extends GenericDefn {
+
+    public GenericDateDefn(String name, int index, int sqlType) {
+      super(name, index, sqlType);
+    }
+
+    @Override
+    public void load(ResultSet row) throws SQLException {
+      Object value = row.getObject(index);
+      if (value != null) {
+        LocalDate date = ((Date) value).toLocalDate(); // java.sql.Date
+        ((ScalarWriter) writer).setDate(date);
+      }
+    }
+  }
+
+  protected static class GenericTimeDefn extends GenericDefn {
+
+    public GenericTimeDefn(String name, int index, int sqlType) {
+      super(name, index, sqlType);
+    }
+
+    @Override
+    public void load(ResultSet row) throws SQLException {
+      Object value = row.getObject(index);
+      if (value != null) {
+        LocalTime time = ((Time) value).toLocalTime(); // java.sql.Time
+        ((ScalarWriter) writer).setTime(time);
+      }
+    }
+  }
+
+  protected static class GenericTimestampDefn extends GenericDefn {
+
+    public GenericTimestampDefn(String name, int index, int sqlType) {
+      super(name, index, sqlType);
+    }
+
+    @Override
+    public void load(ResultSet row) throws SQLException {
+      Object value = row.getObject(index);
+      if (value != null) {
+        Instant ts = ((Timestamp) value).toInstant(); // java.sql.Timestamp
+        ((ScalarWriter) writer).setTimestamp(ts);
+      }
+    }
+  }
+
+  protected static abstract class ArrayDefn extends ColumnDefn {
+
+    static final String VARCHAR = "VARCHAR ARRAY";
+    static final String CHAR = "CHAR ARRAY";
+    static final String BIGINT = "BIGINT ARRAY";
+    static final String INTEGER = "INTEGER ARRAY";
+    static final String DOUBLE = "DOUBLE ARRAY";
+    static final String FLOAT = "FLOAT ARRAY";
+    static final String SMALLINT = "SMALLINT ARRAY";
+    static final String TINYINT = "TINYINT ARRAY";
+    static final String BOOLEAN = "BOOLEAN ARRAY";
+
+    final String baseType;
+
+    public ArrayDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType);
+      this.baseType = baseType;
+    }
+
+    @Override
+    public void bind(RowSetLoader loader) {
+      writer = loader.array(getName());
+    }
+
+    @Override
+    public void load(ResultSet row) throws SQLException {
+      Array array = row.getArray(index);
+      if (array != null && array.getArray() != null) {
+        Object[] values = (Object[]) array.getArray();
+        ((ScalarArrayWriter) writer).setObjectArray(values);
+      }
+    }
+  }
+
+  protected static class ArrayVarcharDefn extends ArrayDefn {
+
+    public ArrayVarcharDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.VARCHAR);
+    }
+  }
+
+  protected static class ArrayBigintDefn extends ArrayDefn {
+
+    public ArrayBigintDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.BIGINT);
+    }
+  }
+
+  protected static class ArrayIntegerDefn extends ArrayDefn {
+
+    public ArrayIntegerDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.INT);
+    }
+  }
+
+  protected static class ArraySmallintDefn extends ArrayDefn {
+
+    public ArraySmallintDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.SMALLINT);
+    }
+  }
+
+  protected static class ArrayTinyintDefn extends ArrayDefn {
+
+    public ArrayTinyintDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.TINYINT);
+    }
+  }
+
+  protected static class ArrayDoubleDefn extends ArrayDefn {
+
+    public ArrayDoubleDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.FLOAT8);
+    }
+  }
+
+  protected static class ArrayBooleanDefn extends ArrayDefn {
+
+    public ArrayBooleanDefn(String name, int index, int sqlType, String baseType) {
+      super(name, index, sqlType, baseType);
+    }
+
+    @Override
+    public void define(SchemaBuilder builder) {
+      builder.addArray(getName(), MinorType.BIT);
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixScanBatchCreator.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixScanBatchCreator.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.util.List;
+
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.server.options.OptionManager;
+
+public class PhoenixScanBatchCreator implements BatchCreator<PhoenixSubScan> {
+
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context, PhoenixSubScan subScan, List<RecordBatch> children) throws ExecutionSetupException {
+    try {
+      ScanFrameworkBuilder builder = createBuilder(context.getOptions(), subScan);
+      return builder.buildScanOperator(context, subScan);
+    } catch (UserException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new ExecutionSetupException(e);
+    }
+  }
+
+  private ScanFrameworkBuilder createBuilder(OptionManager options, PhoenixSubScan subScan) {
+    ScanFrameworkBuilder builder = new ScanFrameworkBuilder();
+    builder.projection(subScan.getColumns());
+    builder.setUserName(subScan.getUserName());
+    // Phoenix reader
+    ReaderFactory readerFactory = new PhoenixReaderFactory(subScan);
+    builder.setReaderFactory(readerFactory);
+    builder.nullType(Types.optional(MinorType.VARCHAR));
+    // Add custom error context
+    builder.errorContext(new ChildErrorContext(builder.errorContext()) {
+      @Override
+      public void addContext(UserException.Builder builder) {
+        builder.addContext("sql : ", subScan.getScanSpec().getSql());
+        builder.addContext("columns : ", subScan.getScanSpec().getColumns().toString());
+        builder.addContext("estimate row count : ", subScan.getScanSpec().getEstimateRows());
+      }
+    });
+
+    return builder;
+  }
+
+  private static class PhoenixReaderFactory implements ReaderFactory {
+
+    private final PhoenixSubScan subScan;
+    private int count;
+
+    public PhoenixReaderFactory(PhoenixSubScan subScan) {
+      this.subScan = subScan;
+    }
+
+    @Override
+    public void bind(ManagedScanFramework framework) {  }
+
+    @Override
+    public ManagedReader<? extends SchemaNegotiator> next() {
+      // Only a single scan
+      if (count++ == 0) {
+        return new PhoenixBatchReader(subScan);
+      }
+      return null;
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixScanSpec.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixScanSpec.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.util.List;
+
+import org.apache.drill.common.PlanStringBuilder;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("phoenix-scan-spec")
+public class PhoenixScanSpec {
+
+  private final String sql;
+  private final List<String> columns;
+  private final double estimateRows;
+
+  @JsonCreator
+  public PhoenixScanSpec(
+      @JsonProperty("sql") String sql,
+      @JsonProperty("columns") List<String> columns,
+      @JsonProperty("estimateRows") double estimateRows) {
+    this.sql = sql;
+    this.columns = columns;
+    this.estimateRows = estimateRows;
+  }
+
+  @JsonProperty("sql")
+  public String getSql() {
+    return sql;
+  }
+
+  @JsonProperty("columns")
+  public List<String> getColumns() {
+    return columns;
+  }
+
+  @JsonProperty("estimateRows")
+  public double getEstimateRows() {
+    return estimateRows;
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+        .field("sql", sql)
+        .field("columns", columns)
+        .field("estimateRows", estimateRows)
+        .toString();
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixSchemaFactory.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixSchemaFactory.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.common.map.CaseInsensitiveMap;
+import org.apache.drill.exec.store.AbstractSchema;
+import org.apache.drill.exec.store.AbstractSchemaFactory;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+
+public class PhoenixSchemaFactory extends AbstractSchemaFactory {
+
+  private final PhoenixStoragePlugin plugin;
+  private final Map<String, PhoenixSchema> schemaMap;
+  private PhoenixSchema rootSchema;
+
+  public PhoenixSchemaFactory(PhoenixStoragePlugin plugin) {
+    super(plugin.getName());
+    this.plugin = plugin;
+    this.schemaMap = Maps.newHashMap();
+  }
+
+  @Override
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
+    rootSchema = new PhoenixSchema(plugin, Collections.emptyList(), plugin.getName());
+    locateSchemas();
+    parent.add(getName(), rootSchema); // resolve the top-level schema.
+    for (String schemaName : rootSchema.getSubSchemaNames()) {
+      PhoenixSchema schema = (PhoenixSchema) rootSchema.getSubSchema(schemaName);
+      parent.add(schemaName, schema); // provide all available schemas for calcite.
+    }
+  }
+
+  private void locateSchemas() {
+    DataSource ds = plugin.getDataSource();
+    try (Connection conn = ds.getConnection();
+          ResultSet rs = ds.getConnection().getMetaData().getSchemas()) {
+      while (rs.next()) {
+        final String schemaName = rs.getString(1); // lookup the schema (or called database).
+        PhoenixSchema schema = new PhoenixSchema(plugin, Arrays.asList(getName()), schemaName);
+        schemaMap.put(schemaName, schema);
+      }
+      rootSchema.addSchemas(schemaMap);
+    } catch (SQLException e) {
+      throw new DrillRuntimeException(e.getMessage(), e);
+    }
+  }
+
+  protected static class PhoenixSchema extends AbstractSchema {
+
+    private final JdbcSchema jdbcSchema;
+    private final Map<String, PhoenixSchema> schemaMap = CaseInsensitiveMap.newHashMap();
+
+    public PhoenixSchema(PhoenixStoragePlugin plugin, List<String> parentSchemaPath, String schemaName) {
+      super(parentSchemaPath, schemaName);
+      this.jdbcSchema = new JdbcSchema(plugin.getDataSource(), plugin.getDialect(), plugin.getConvention(), null, schemaName);
+    }
+
+    @Override
+    public Schema getSubSchema(String name) {
+      return schemaMap.get(name);
+    }
+
+    @Override
+    public Set<String> getSubSchemaNames() {
+      return schemaMap.keySet();
+    }
+
+    @Override
+    public Table getTable(String name) {
+      Table table = jdbcSchema.getTable(StringUtils.upperCase(name));
+      return table;
+    }
+
+    @Override
+    public Set<String> getTableNames() {
+      Set<String> tables = jdbcSchema.getTableNames();
+      return tables;
+    }
+
+    @Override
+    public String getTypeName() {
+      return PhoenixStoragePluginConfig.NAME;
+    }
+
+    public void addSchemas(Map<String, PhoenixSchema> schemas) {
+      schemaMap.putAll(schemas);
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePlugin.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePlugin.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlDialectFactoryImpl;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.JSONOptions;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.store.AbstractStoragePlugin;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.phoenix.rules.PhoenixConvention;
+import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class PhoenixStoragePlugin extends AbstractStoragePlugin {
+
+  private final PhoenixStoragePluginConfig config;
+  private final DataSource dataSource;
+  private final SqlDialect dialect;
+  private final PhoenixConvention convention;
+  private final PhoenixSchemaFactory schemaFactory;
+
+  public PhoenixStoragePlugin(PhoenixStoragePluginConfig config, DrillbitContext context, String name) {
+    super(context, name);
+    this.config = config;
+    this.dataSource = initNoPoolingDataSource(config);
+    this.dialect = JdbcSchema.createDialect(SqlDialectFactoryImpl.INSTANCE, dataSource);
+    this.convention = new PhoenixConvention(dialect, name, this);
+    this.schemaFactory = new PhoenixSchemaFactory(this);
+  }
+
+  @Override
+  public StoragePluginConfig getConfig() {
+    return config;
+  }
+
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
+  public SqlDialect getDialect() {
+    return dialect;
+  }
+
+  public PhoenixConvention getConvention() {
+    return convention;
+  }
+
+  @Override
+  public boolean supportsRead() {
+    return true;
+  }
+
+  @Override
+  public Set<? extends RelOptRule> getPhysicalOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
+    return convention.getRules();
+  }
+
+  @Override
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
+    schemaFactory.registerSchemas(schemaConfig, parent);
+  }
+
+  @Override
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection) throws IOException {
+    PhoenixScanSpec scanSpec = selection.getListWith(context.getLpPersistence().getMapper(), new TypeReference<PhoenixScanSpec>() {});
+    return new PhoenixGroupScan(scanSpec, this);
+  }
+
+  private static DataSource initNoPoolingDataSource(PhoenixStoragePluginConfig config) {
+    // Don't use the pool with the connection
+    PhoenixDataSource dataSource = null;
+    if (StringUtils.isNotBlank(config.getJdbcURL())) {
+      dataSource = new PhoenixDataSource(config.getJdbcURL(), config.getProps()); // the props is initiated.
+    } else {
+      dataSource = new PhoenixDataSource(config.getHost(), config.getPort(), config.getProps());
+    }
+    if (config.getUsername() != null && config.getPassword() != null) {
+      if (dataSource.getConnectionProperties() == null) {
+        dataSource.setConnectionProperties(Maps.newHashMap());
+      }
+      dataSource.getConnectionProperties().put("user", config.getUsername());
+      dataSource.getConnectionProperties().put("password", config.getPassword());
+    }
+    return dataSource;
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePluginConfig.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePluginConfig.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.common.logical.AbstractSecuredStoragePluginConfig;
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.exec.store.security.CredentialProviderUtils;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName(PhoenixStoragePluginConfig.NAME)
+public class PhoenixStoragePluginConfig extends AbstractSecuredStoragePluginConfig {
+
+  public static final String NAME = "phoenix";
+  public static final String THIN_DRIVER_CLASS = "org.apache.phoenix.queryserver.client.Driver";
+  public static final String FAT_DRIVER_CLASS = "org.apache.phoenix.jdbc.PhoenixDriver";
+
+  private final String host;
+  private final int port;
+  private final String jdbcURL; // (options) Equal to host + port
+  private final Map<String, Object> props; // (options) See also http://phoenix.apache.org/tuning.html
+
+  @JsonCreator
+  public PhoenixStoragePluginConfig(
+      @JsonProperty("host") String host,
+      @JsonProperty("port") int port,
+      @JsonProperty("userName") String userName,
+      @JsonProperty("password") String password,
+      @JsonProperty("jdbcURL") String jdbcURL,
+      @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider,
+      @JsonProperty("props") Map<String, Object> props) {
+    super(CredentialProviderUtils.getCredentialsProvider(userName, password, credentialsProvider), credentialsProvider == null);
+    this.host = host;
+    this.port = port == 0 ? 8765 : port;
+    this.jdbcURL = jdbcURL;
+    this.props = props == null ? Collections.emptyMap() : props;
+  }
+
+  @JsonIgnore
+  public UsernamePasswordCredentials getUsernamePasswordCredentials() {
+    return new UsernamePasswordCredentials(credentialsProvider);
+  }
+
+  @JsonProperty("host")
+  public String getHost() {
+    return host;
+  }
+
+  @JsonProperty("port")
+  public int getPort() {
+    return port;
+  }
+
+  @JsonProperty("userName")
+  public String getUsername() {
+    if (directCredentials) {
+      return getUsernamePasswordCredentials().getUsername();
+    }
+    return null;
+  }
+
+  @JsonIgnore
+  @JsonProperty("password")
+  public String getPassword() {
+    if (directCredentials) {
+      return getUsernamePasswordCredentials().getPassword();
+    }
+    return null;
+  }
+
+  @JsonProperty("jdbcURL")
+  public String getJdbcURL() {
+    return jdbcURL;
+  }
+
+  @JsonProperty("props")
+  public Map<String, Object> getProps() {
+    return props;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || !(o instanceof PhoenixStoragePluginConfig)) {
+      return false;
+    }
+    PhoenixStoragePluginConfig config = (PhoenixStoragePluginConfig) o;
+    // URL first
+    if (StringUtils.isNotBlank(config.getJdbcURL())) {
+      return Objects.equals(this.jdbcURL, config.getJdbcURL());
+    }
+    // Then the host and port
+    return Objects.equals(this.host, config.getHost()) && Objects.equals(this.port, config.getPort());
+  }
+
+  @Override
+  public int hashCode() {
+    if (StringUtils.isNotBlank(jdbcURL)) {
+     return Objects.hash(jdbcURL);
+    }
+    return Objects.hash(host, port);
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(PhoenixStoragePluginConfig.NAME)
+        .field("driverName", THIN_DRIVER_CLASS)
+        .field("host", host)
+        .field("port", port)
+        .field("userName", getUsername())
+        .maskedField("password", getPassword()) // will set to "*******"
+        .field("jdbcURL", jdbcURL)
+        .field("props", props)
+        .toString();
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixSubScan.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixSubScan.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.physical.base.AbstractBase;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.PhysicalVisitor;
+import org.apache.drill.exec.physical.base.SubScan;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("phoenix-sub-scan")
+public class PhoenixSubScan extends AbstractBase implements SubScan {
+
+  private final String sql;
+  private final List<SchemaPath> columns;
+  private final PhoenixScanSpec scanSpec;
+  private final PhoenixStoragePlugin plugin;
+
+  @JsonCreator
+  public PhoenixSubScan(
+      @JsonProperty("sql") String sql,
+      @JsonProperty("columns") List<SchemaPath> columns,
+      @JsonProperty("scanSpec") PhoenixScanSpec scanSpec,
+      @JsonProperty("config") StoragePluginConfig config,
+      @JacksonInject StoragePluginRegistry registry) {
+    super("no-user");
+    this.sql = sql;
+    this.columns = columns;
+    this.scanSpec = scanSpec;
+    this.plugin = registry.resolve(config, PhoenixStoragePlugin.class);
+  }
+
+  public PhoenixSubScan(String sql, List<SchemaPath> columns, PhoenixScanSpec scanSpec, PhoenixStoragePlugin plugin) {
+    super("no-user");
+    this.sql = sql;
+    this.columns = columns;
+    this.scanSpec = scanSpec;
+    this.plugin = plugin;
+  }
+
+  @JsonProperty("sql")
+  public String getSql() {
+    return sql;
+  }
+
+  @JsonProperty("columns")
+  public List<SchemaPath> getColumns() {
+    return columns;
+  }
+
+  @JsonProperty("scanSpec")
+  public PhoenixScanSpec getScanSpec() {
+    return scanSpec;
+  }
+
+  @JsonIgnore
+  public PhoenixStoragePlugin getPlugin() {
+    return plugin;
+  }
+
+  @JsonProperty("config")
+  public StoragePluginConfig getConfig() {
+    return plugin.getConfig();
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
+    return physicalVisitor.visitSubScan(this, value);
+  }
+
+  @Override
+  public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) throws ExecutionSetupException {
+    return new PhoenixSubScan(sql, columns, scanSpec, plugin);
+  }
+
+  @Override
+  public String getOperatorType() {
+    return PhoenixStoragePluginConfig.NAME.toUpperCase();
+  }
+
+  @Override
+  public Iterator<PhysicalOperator> iterator() {
+    return ImmutableSet.<PhysicalOperator>of().iterator();
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+      .field("sql", sql)
+      .field("columns", columns)
+      .field("scanSpec", scanSpec)
+      .field("config", plugin.getConfig())
+      .toString();
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixImplementor.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixImplementor.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix.rules;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.adapter.jdbc.JdbcImplementor;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+
+public class PhoenixImplementor extends JdbcImplementor {
+
+  public PhoenixImplementor(SqlDialect dialect, JavaTypeFactory typeFactory) {
+    super(dialect, typeFactory);
+  }
+
+  @Override
+  public Result result(SqlNode node, Collection<Clause> clauses, RelNode rel, Map<String, RelDataType> aliases) {
+    if (node instanceof SqlIdentifier) {
+      SqlIdentifier identifier = (SqlIdentifier) node;
+      String name = identifier.names.get(identifier.names.size() -1);
+      if (!aliasSet.contains(name)) {
+        /*
+         * phoenix does not support the 'SELECT `table_name`.`field_name`',
+         * need to force the alias name and start from `table_name0`,
+         * the result is that 'SELECT `table_name0`.`field_name`'.
+         */
+        aliasSet.add(name);
+      }
+    }
+    return super.result(node, clauses, rel, aliases);
+  }
+
+  @Override
+  public Result visit(Project e) {
+    return super.visit(e);
+  }
+
+  @Override
+  public Result visit(Filter e) {
+    final RelNode input = e.getInput();
+    Result x = visitChild(0, input);
+    parseCorrelTable(e, x);
+    if (input instanceof Aggregate) {
+      return super.visit(e);
+    } else {
+      final Builder builder = x.builder(e, Clause.WHERE);
+      builder.setWhere(builder.context.toSql(null, e.getCondition()));
+      final List<SqlNode> selectList = new ArrayList<>();
+      e.getRowType().getFieldNames().forEach(fieldName -> {
+        /*
+         * phoenix does not support the wildcard in the subqueries,
+         * expand the wildcard at this time.
+         */
+        addSelect(selectList, new SqlIdentifier(fieldName, POS), e.getRowType());
+      });
+      builder.setSelect(new SqlNodeList(selectList, POS));
+      return builder.result();
+    }
+  }
+
+  @Override
+  public Result visit(Join e) {
+    return super.visit(e);
+  }
+
+  private void parseCorrelTable(RelNode relNode, Result x) {
+    for (CorrelationId id : relNode.getVariablesSet()) {
+      correlTableMap.put(id, x.qualifiedContext());
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixIntermediatePrel.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixIntermediatePrel.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix.rules;
+
+import java.util.List;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.planner.physical.PhysicalPlanCreator;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.physical.SinglePrel;
+import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
+import org.apache.drill.exec.planner.sql.handlers.PrelFinalizable;
+import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
+
+public class PhoenixIntermediatePrel extends SinglePrel implements PrelFinalizable {
+
+  public PhoenixIntermediatePrel(RelOptCluster cluster, RelTraitSet traits, RelNode child) {
+    super(cluster, traits, child);
+  }
+
+  @Override
+  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new PhoenixIntermediatePrel(getCluster(), traitSet, getInput());
+  }
+
+  @Override
+  protected Object clone() throws CloneNotSupportedException {
+    return copy(getTraitSet(), getInputs());
+  }
+
+  @Override
+  public SelectionVectorMode getEncoding() {
+    return SelectionVectorMode.NONE;
+  }
+
+  @Override
+  public Prel finalizeRel() {
+    return new PhoenixPrel(getCluster(), getTraitSet(), this);
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PrelVisitor<T, X, E> logicalVisitor, X value) throws E {
+    throw new UnsupportedOperationException("This needs to be finalized before using a PrelVisitor.");
+  }
+
+  @Override
+  public boolean needsFinalColumnReordering() {
+    return false;
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixIntermediatePrelConverterRule.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixIntermediatePrelConverterRule.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix.rules;
+
+import java.util.function.Predicate;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.DrillRelFactories;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.store.enumerable.plan.VertexDrel;
+
+final class PhoenixIntermediatePrelConverterRule extends ConverterRule {
+
+  static final PhoenixIntermediatePrelConverterRule INSTANCE = new PhoenixIntermediatePrelConverterRule();
+
+  private PhoenixIntermediatePrelConverterRule() {
+    super(VertexDrel.class, (Predicate<RelNode>) input -> true,
+        DrillRel.DRILL_LOGICAL, Prel.DRILL_PHYSICAL, DrillRelFactories.LOGICAL_BUILDER, "Phoenix_PREL_Converter");
+  }
+
+  @Override
+  public RelNode convert(RelNode in) {
+    return new PhoenixIntermediatePrel(
+        in.getCluster(),
+        in.getTraitSet().replace(getOutTrait()),
+        in.getInput(0));
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    RelNode rel = call.rel(0);
+    if (rel.getTraitSet().contains(getInTrait())) {
+      Convention c = rel.getInput(0).getTraitSet().getTrait(ConventionTraitDef.INSTANCE);
+      /*
+       * only accept the PhoenixConvention
+       * need to avoid the NPE or ClassCastException
+       */
+      if (c != null && c instanceof PhoenixConvention) {
+        final RelNode converted = convert(rel);
+        if (converted != null) {
+          call.transformTo(converted);
+        }
+      }
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixJoinRule.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixJoinRule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.calcite.adapter.jdbc.JdbcConvention;
+import org.apache.calcite.adapter.jdbc.JdbcRules.JdbcJoin;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.rel.InvalidRelException;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.logical.LogicalJoin;
+
+public class PhoenixJoinRule extends ConverterRule {
+
+  private final JdbcConvention out;
+
+  public PhoenixJoinRule(RelTrait in, JdbcConvention out) {
+    super(LogicalJoin.class, in, out, "PhoenixJoinRule");
+    this.out = out;
+  }
+
+  @Override
+  public RelNode convert(RelNode rel) {
+    final List<RelNode> newInputs = new ArrayList<>();
+    final Join join = (Join) rel;
+    for (RelNode input : join.getInputs()) {
+      if (input.getConvention() != getOutTrait()) {
+        input = convert(input, input.getTraitSet().replace(out));
+      }
+      newInputs.add(input);
+    }
+    try {
+      JdbcJoin jdbcJoin = new JdbcJoin(
+          join.getCluster(),
+          join.getTraitSet().replace(out),
+          newInputs.get(0),
+          newInputs.get(1),
+          join.getCondition(),
+          join.getVariablesSet(),
+          join.getJoinType());
+      return jdbcJoin;
+    } catch (InvalidRelException e) {
+      return null;
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixPrel.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixPrel.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix.rules;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.adapter.jdbc.JdbcImplementor;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.planner.physical.PhysicalPlanCreator;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
+import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
+import org.apache.drill.exec.store.SubsetRemover;
+import org.apache.drill.exec.store.phoenix.PhoenixGroupScan;
+import org.apache.drill.exec.store.phoenix.PhoenixScanSpec;
+
+public class PhoenixPrel extends AbstractRelNode implements Prel {
+
+  private final String sql;
+  private final double rows;
+  private final PhoenixConvention convention;
+
+  public PhoenixPrel(RelOptCluster cluster, RelTraitSet traitSet, PhoenixIntermediatePrel prel) {
+    super(cluster, traitSet);
+    final RelNode input = prel.getInput();
+    rows = input.estimateRowCount(cluster.getMetadataQuery());
+    convention = (PhoenixConvention) input.getTraitSet().getTrait(ConventionTraitDef.INSTANCE);
+    final SqlDialect dialect = convention.getPlugin().getDialect();
+    final JdbcImplementor jdbcImplementor = new PhoenixImplementor(dialect, (JavaTypeFactory) getCluster().getTypeFactory());
+    final JdbcImplementor.Result result = jdbcImplementor.visitChild(0, input.accept(SubsetRemover.INSTANCE));
+    sql = result.asStatement().toSqlString(dialect).getSql();
+    rowType = input.getRowType();
+  }
+
+  @Override
+  public Iterator<Prel> iterator() {
+    return Collections.emptyIterator();
+  }
+
+  @Override
+  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator)
+      throws IOException {
+    List<SchemaPath> schemaPaths = new ArrayList<SchemaPath>(rowType.getFieldCount());
+    List<String> columns = new ArrayList<String>(rowType.getFieldCount());
+    for (String col : rowType.getFieldNames()) {
+      schemaPaths.add(SchemaPath.getSimplePath(col));
+      columns.add(SchemaPath.getSimplePath(col).rootName());
+    }
+    PhoenixGroupScan output = new PhoenixGroupScan(sql, schemaPaths, new PhoenixScanSpec(sql, columns, rows), convention.getPlugin());
+    return creator.addMetadata(this, output);
+  }
+
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    return super.explainTerms(pw).item("sql", stripToOneLineSql(sql));
+  }
+
+  private String stripToOneLineSql(String sql) {
+    StringBuilder sbt = new StringBuilder(sql.length());
+    String[] sqlToken = sql.split("\\n");
+    for (String sqlText : sqlToken) {
+      sbt.append(sqlText).append(' ');
+    }
+    return sbt.toString();
+  }
+
+  @Override
+  public double estimateRowCount(RelMetadataQuery mq) {
+    return rows;
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PrelVisitor<T, X, E> logicalVisitor, X value) throws E {
+    return logicalVisitor.visitPrel(this, value);
+  }
+
+  @Override
+  public SelectionVectorMode[] getSupportedEncodings() {
+    return SelectionVectorMode.DEFAULT;
+  }
+
+  @Override
+  public SelectionVectorMode getEncoding() {
+    return SelectionVectorMode.NONE;
+  }
+
+  @Override
+  public boolean needsFinalColumnReordering() {
+    return false;
+  }
+}

--- a/contrib/storage-phoenix/src/main/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-phoenix/src/main/resources/bootstrap-storage-plugins.json
@@ -1,0 +1,13 @@
+{
+  "storage": {
+    "phoenix": {
+      "type": "phoenix",
+      "host": "the.queryserver.hostname",
+      "port": 8765,
+      "props" : {
+        "phoenix.query.timeoutMs": 60000
+      },
+      "enabled": false
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/main/resources/drill-module.conf
+++ b/contrib/storage-phoenix/src/main/resources/drill-module.conf
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#  This file tells Drill to consider this module when class path scanning.
+#  This file can also include any supplementary configuration information.
+#  This file is in HOCON format, see https://github.com/typesafehub/config/blob/master/HOCON.md for more information.
+
+drill: {
+  classpath.scanning: {
+    packages += "org.apache.drill.exec.store.phoenix"
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixBaseTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixBaseTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.nio.file.Paths;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.apache.hadoop.fs.Path;
+import org.junit.BeforeClass;
+import org.slf4j.LoggerFactory;
+
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+
+public class PhoenixBaseTest extends ClusterTest {
+
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(PhoenixBaseTest.class);
+
+  private static AtomicInteger initCount = new AtomicInteger(0);
+  protected static String U_U_I_D = UUID.randomUUID().toString();
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    if (PhoenixTestSuite.isRunningSuite()) {
+      QueryServerBasicsIT.testCatalogs();
+    }
+    bootMiniCluster();
+    if (initCount.incrementAndGet() == 1) {
+      createSchema();
+      createTables();
+      createSampleData();
+    }
+  }
+
+  public static void bootMiniCluster() throws Exception {
+    ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher);
+    startCluster(builder);
+    dirTestWatcher.copyResourceToRoot(Paths.get(""));
+    Map<String, Object> props = Maps.newHashMap();
+    props.put("phoenix.query.timeoutMs", 90000);
+    props.put("phoenix.query.keepAliveMs", "30000");
+    StoragePluginRegistry registry = cluster.drillbit().getContext().getStorage();
+    PhoenixStoragePluginConfig config = new PhoenixStoragePluginConfig(null, 0, null, null, QueryServerBasicsIT.CONN_STRING, null, props);
+    config.setEnabled(true);
+    registry.put(PhoenixStoragePluginConfig.NAME + "123", config);
+  }
+
+  public static void createSchema() throws Exception {
+    try (final Connection connection = DriverManager.getConnection(QueryServerBasicsIT.CONN_STRING)) {
+      assertFalse(connection.isClosed());
+      connection.setAutoCommit(true);
+      try (final Statement stmt = connection.createStatement()) {
+        assertFalse(stmt.execute("CREATE SCHEMA IF NOT EXISTS V1"));
+      }
+    }
+  }
+
+  public static void createTables() throws Exception {
+    try (final Connection connection = DriverManager.getConnection(QueryServerBasicsIT.CONN_STRING)) {
+      assertFalse(connection.isClosed());
+      connection.setAutoCommit(true);
+      try (final Statement stmt = connection.createStatement()) {
+        String region_sql = " CREATE TABLE V1.REGION "
+            + "("
+            + "    R_REGIONKEY BIGINT not null,"
+            + "    R_NAME      VARCHAR,"
+            + "    R_COMMENT   VARCHAR"
+            + "    CONSTRAINT  REGION_PK PRIMARY KEY (R_REGIONKEY)"
+            + ")";
+        String nation_sql = " CREATE TABLE V1.NATION "
+            + "("
+            + "    N_NATIONKEY BIGINT not null primary key,"
+            + "    N_NAME      VARCHAR(100),"
+            + "    N_REGIONKEY BIGINT,"
+            + "    N_COMMENT   VARCHAR(255)"
+            + ")";
+        String datatype_sql = " CREATE TABLE V1.DATATYPE "
+            + "("
+            + "    T_UUID      VARCHAR not null primary key,"
+            + "    T_VARCHAR   VARCHAR,"
+            + "    T_CHAR      CHAR(5),"
+            + "    T_BIGINT    BIGINT,"
+            + "    T_INTEGER   INTEGER,"
+            + "    T_SMALLINT  SMALLINT,"
+            + "    T_TINYINT   TINYINT,"
+            + "    T_DOUBLE    DOUBLE,"
+            + "    T_FLOAT     FLOAT,"
+            + "    T_DECIMAL   DECIMAL(4,2),"
+            + "    T_DATE      DATE,"
+            + "    T_TIME      TIME,"
+            + "    T_TIMESTAMP TIMESTAMP,"
+            + "    T_BINARY    BINARY(10),"
+            + "    T_VARBINARY VARBINARY,"
+            + "    T_BOOLEAN   BOOLEAN"
+            + ")";
+        String arrytype_sql = " CREATE TABLE V1.ARRAYTYPE "
+            + "("
+            + "    T_UUID      VARCHAR not null primary key,"
+            + "    T_VARCHAR   VARCHAR ARRAY,"
+            + "    T_CHAR      CHAR(5) ARRAY,"
+            + "    T_BIGINT    BIGINT  ARRAY,"
+            + "    T_INTEGER   INTEGER ARRAY,"
+            + "    T_DOUBLE    DOUBLE  ARRAY,"
+            + "    T_SMALLINT  SMALLINT ARRAY,"
+            + "    T_TINYINT   TINYINT  ARRAY,"
+            + "    T_BOOLEAN   BOOLEAN  ARRAY"
+            + ")";
+        assertFalse(stmt.execute(region_sql));
+        assertFalse(stmt.execute(nation_sql));
+        assertFalse(stmt.execute(datatype_sql));
+        assertFalse(stmt.execute(arrytype_sql));
+      }
+    }
+  }
+
+  public static void createSampleData() throws Exception {
+    final String[] paths = new String[] { "data/region.tbl", "data/nation.tbl" };
+    final String[] sqls = new String[] {
+        "UPSERT INTO V1.REGION VALUES(?,?,?)",
+        "UPSERT INTO V1.NATION VALUES(?,?,?,?)",
+        "UPSERT INTO V1.DATATYPE VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        "UPSERT INTO V1.ARRAYTYPE VALUES(?,?,ARRAY['a','b','c'],?,?,?,?,?,?)",
+    };
+
+    Path region_path = new Path(dirTestWatcher.getRootDir().getAbsolutePath(), paths[0]);
+    Path nation_path = new Path(dirTestWatcher.getRootDir().getAbsolutePath(), paths[1]);
+    logger.info("Loading the .tbl file : " + Arrays.toString(paths));
+
+    List<String[]> allRows = parseTblFile(String.valueOf(region_path));
+    try (final Connection connection = DriverManager.getConnection(QueryServerBasicsIT.CONN_STRING)) {
+      assertFalse(connection.isClosed());
+      connection.setAutoCommit(false);
+      // region table
+      try (final PreparedStatement pstmt = connection.prepareStatement(sqls[0])) {
+        for (String[] row : allRows) {
+          pstmt.setLong(1, Long.valueOf(row[0]));
+          pstmt.setString(2, row[1]);
+          pstmt.setString(3, row[2]);
+          pstmt.addBatch();
+        }
+        pstmt.executeBatch();
+      }
+      connection.commit();
+      // nation table
+      allRows = parseTblFile(String.valueOf(nation_path));
+      try (final PreparedStatement pstmt = connection.prepareStatement(sqls[1])) {
+        for (String[] row : allRows) {
+          pstmt.setLong(1, Long.valueOf(row[0]));
+          pstmt.setString(2, row[1]);
+          pstmt.setLong(3, Long.valueOf(row[2]));
+          pstmt.setString(4, row[3]);
+          pstmt.addBatch();
+        }
+        pstmt.executeBatch();
+      }
+      connection.commit();
+      // datatype table
+      try (final PreparedStatement pstmt = connection.prepareStatement(sqls[2])) {
+        pstmt.setString(1, U_U_I_D);
+        pstmt.setString(2, "apache");
+        pstmt.setString(3, "drill");
+        pstmt.setLong(4, Long.MAX_VALUE);
+        pstmt.setInt(5, Integer.MAX_VALUE);
+        pstmt.setShort(6, Short.MAX_VALUE);
+        pstmt.setByte(7, Byte.MAX_VALUE);
+        pstmt.setDouble(8, Double.MAX_VALUE);
+        pstmt.setFloat(9, Float.MAX_VALUE);
+        pstmt.setBigDecimal(10, BigDecimal.valueOf(10.11));
+        pstmt.setDate(11, java.sql.Date.valueOf("2021-12-12"));
+        pstmt.setTime(12, java.sql.Time.valueOf("12:12:12"));
+        pstmt.setTimestamp(13, java.sql.Timestamp.valueOf("2021-12-12 12:12:12"));
+        pstmt.setBytes(14, "a_b_c_d_e_".getBytes());
+        pstmt.setBytes(15, "12345".getBytes());
+        pstmt.setBoolean(16, Boolean.TRUE);
+        pstmt.addBatch();
+        pstmt.executeBatch();
+      }
+      connection.commit();
+      // arraytype table
+      try (final PreparedStatement pstmt = connection.prepareStatement(sqls[3])) {
+        Array t_varchar = connection.createArrayOf("VARCHAR", new String[] { "apache", "drill", "1.20" });
+        @SuppressWarnings("unused")
+        Array t_char = connection.createArrayOf("CHAR", new String[] { "a", "b", "c" }); // PHOENIX-6607
+        Array t_bigint = connection.createArrayOf("BIGINT", new Long[] { Long.MIN_VALUE, Long.MAX_VALUE });
+        Array t_integer = connection.createArrayOf("INTEGER", new Integer[] { Integer.MIN_VALUE, Integer.MAX_VALUE });
+        Array t_double = connection.createArrayOf("DOUBLE", new Double[] { Double.MIN_VALUE, Double.MAX_VALUE });
+        @SuppressWarnings("unused")
+        Array t_float = connection.createArrayOf("FLOAT", new Float[] { Float.MIN_VALUE, Float.MAX_VALUE }); // PHOENIX-6606
+        Array t_smallint = connection.createArrayOf("SMALLINT", new Short[] { Short.MIN_VALUE, Short.MAX_VALUE });
+        Array t_tinyint = connection.createArrayOf("TINYINT", new Byte[] { Byte.MIN_VALUE, Byte.MAX_VALUE });
+        Array t_boolean = connection.createArrayOf("BOOLEAN", new Boolean[] { Boolean.TRUE, Boolean.FALSE });
+        pstmt.setString(1, U_U_I_D);
+        pstmt.setArray(2, t_varchar);
+        pstmt.setArray(3, t_bigint);
+        pstmt.setArray(4, t_integer);
+        pstmt.setArray(5, t_double);
+        pstmt.setArray(6, t_smallint);
+        pstmt.setArray(7, t_tinyint);
+        pstmt.setArray(8, t_boolean);
+        pstmt.addBatch();
+        pstmt.executeBatch();
+      }
+      connection.commit();
+      logger.info("Loaded {} rows.", allRows.size());
+    }
+  }
+
+  private static List<String[]> parseTblFile(String path) throws Exception {
+    CsvParserSettings settings = new CsvParserSettings();
+    settings.getFormat().setDelimiter("|");
+    settings.getFormat().setLineSeparator("\n");
+    CsvParser parser = new CsvParser(settings);
+
+    return parser.parseAll(getReader(path));
+  }
+
+  private static Reader getReader(String path) throws Exception {
+    return new InputStreamReader(new FileInputStream(path), "UTF-8");
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixCommandTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixCommandTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.QueryBuilder;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.JVM)
+@Category({ SlowTest.class, RowSetTests.class })
+public class PhoenixCommandTest extends PhoenixBaseTest {
+
+  @Test
+  public void testShowTablesLike() throws Exception {
+    run("USE phoenix123.v1");
+    assertEquals(1, queryBuilder().sql("SHOW TABLES LIKE '%REGION%'").run().recordCount());
+  }
+
+  @Test
+  public void testShowTables() throws Exception {
+    String sql = "SHOW TABLES FROM phoenix123.v1";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("TABLE_SCHEMA", MinorType.VARCHAR)
+        .addNullable("TABLE_NAME", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow("phoenix123.v1", "ARRAYTYPE")
+        .addRow("phoenix123.v1", "DATATYPE")
+        .addRow("phoenix123.v1", "NATION")
+        .addRow("phoenix123.v1", "REGION")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Ignore
+  @Test
+  public void testDescribe() throws Exception {
+    run("USE phoenix123.v1");
+    assertEquals(4, queryBuilder().sql("DESCRIBE NATION").run().recordCount());
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixDataTypeTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixDataTypeTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.boolArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.byteArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.doubleArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.intArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.shortArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.QueryBuilder;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.JVM)
+@Category({ SlowTest.class, RowSetTests.class })
+public class PhoenixDataTypeTest extends PhoenixBaseTest {
+
+  @Test
+  public void testDataType() throws Exception {
+    String sql = "select * from phoenix123.v1.datatype";
+    QueryBuilder builder = queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("T_UUID", MinorType.VARCHAR)
+        .addNullable("T_VARCHAR", MinorType.VARCHAR)
+        .addNullable("T_CHAR", MinorType.VARCHAR)
+        .addNullable("T_BIGINT", MinorType.BIGINT)
+        .addNullable("T_INTEGER", MinorType.INT)
+        .addNullable("T_SMALLINT", MinorType.INT)
+        .addNullable("T_TINYINT", MinorType.INT)
+        .addNullable("T_DOUBLE", MinorType.FLOAT8)
+        .addNullable("T_FLOAT", MinorType.FLOAT4)
+        .addNullable("T_DECIMAL", MinorType.VARDECIMAL)
+        .addNullable("T_DATE", MinorType.DATE)
+        .addNullable("T_TIME", MinorType.TIME)
+        .addNullable("T_TIMESTAMP", MinorType.TIMESTAMP)
+        .addNullable("T_BINARY", MinorType.VARBINARY)
+        .addNullable("T_VARBINARY", MinorType.VARBINARY)
+        .addNullable("T_BOOLEAN", MinorType.BIT)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(U_U_I_D,
+            "apache", "drill",
+            Long.MAX_VALUE,
+            Integer.MAX_VALUE,
+            Short.MAX_VALUE,
+            Byte.MAX_VALUE,
+            Double.MAX_VALUE,
+            Float.MAX_VALUE,
+            BigDecimal.valueOf(10.11),
+            LocalDate.parse("2021-12-12"),
+            LocalTime.parse("12:12:12"),
+            Instant.ofEpochMilli(1639311132000l),
+            "a_b_c_d_e_".getBytes(), "12345".getBytes(),
+            Boolean.TRUE)
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testArrayType() throws Exception {
+    String sql = "select * from phoenix123.v1.arraytype";
+
+    QueryBuilder builder = queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("T_UUID", MinorType.VARCHAR)
+        .addArray("T_VARCHAR", MinorType.VARCHAR)
+        .addArray("T_CHAR", MinorType.VARCHAR)
+        .addArray("T_BIGINT", MinorType.BIGINT)
+        .addArray("T_INTEGER", MinorType.INT)
+        .addArray("T_DOUBLE", MinorType.FLOAT8)
+        .addArray("T_SMALLINT", MinorType.SMALLINT)
+        .addArray("T_TINYINT", MinorType.TINYINT)
+        .addArray("T_BOOLEAN", MinorType.BIT)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(U_U_I_D,
+            strArray("apache", "drill", "1.20"),
+            strArray("a", "b", "c"),
+            longArray(Long.MIN_VALUE, Long.MAX_VALUE),
+            intArray(Integer.MIN_VALUE, Integer.MAX_VALUE),
+            doubleArray(Double.MIN_VALUE, Double.MAX_VALUE),
+            shortArray(Short.MIN_VALUE, Short.MAX_VALUE),
+            byteArray((int) Byte.MIN_VALUE, (int) Byte.MAX_VALUE),
+            boolArray(Boolean.TRUE, Boolean.FALSE))
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixSQLTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixSQLTest.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.QueryBuilder;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.JVM)
+@Category({ SlowTest.class, RowSetTests.class })
+public class PhoenixSQLTest extends PhoenixBaseTest {
+
+  @Test
+  public void testStarQuery() throws Exception {
+    String sql = "select * from phoenix123.v1.nation";
+    queryBuilder().sql(sql).run();
+  }
+
+  @Test
+  public void testExplicitQuery() throws Exception {
+    String sql = "select n_nationkey, n_regionkey, n_name from phoenix123.v1.nation";
+    QueryBuilder builder = queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("n_nationkey", MinorType.BIGINT)
+        .addNullable("n_regionkey", MinorType.BIGINT)
+        .addNullable("n_name", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(0, 0, "ALGERIA")
+        .addRow(1, 1, "ARGENTINA")
+        .addRow(2, 1, "BRAZIL")
+        .addRow(3, 1, "CANADA")
+        .addRow(4, 4, "EGYPT")
+        .addRow(5, 0, "ETHIOPIA")
+        .addRow(6, 3, "FRANCE")
+        .addRow(7, 3, "GERMANY")
+        .addRow(8, 2, "INDIA")
+        .addRow(9, 2, "INDONESIA")
+        .addRow(10, 4, "IRAN")
+        .addRow(11, 4, "IRAQ")
+        .addRow(12, 2, "JAPAN")
+        .addRow(13, 4, "JORDAN")
+        .addRow(14, 0, "KENYA")
+        .addRow(15, 0, "MOROCCO")
+        .addRow(16, 0, "MOZAMBIQUE")
+        .addRow(17, 1, "PERU")
+        .addRow(18, 2, "CHINA")
+        .addRow(19, 3, "ROMANIA")
+        .addRow(20, 4, "SAUDI ARABIA")
+        .addRow(21, 2, "VIETNAM")
+        .addRow(22, 3, "RUSSIA")
+        .addRow(23, 3, "UNITED KINGDOM")
+        .addRow(24, 1, "UNITED STATES")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testLimitPushdown() throws Exception {
+    String sql = "select n_name, n_regionkey from phoenix123.v1.nation limit 20 offset 10";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Limit")
+        .include("OFFSET .* ROWS FETCH NEXT .* ROWS ONLY")
+        .match();
+
+    assertEquals(15, sets.rowCount());
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("n_name", MinorType.VARCHAR)
+        .addNullable("n_regionkey", MinorType.BIGINT)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow("IRAN", 4)
+        .addRow("IRAQ", 4)
+        .addRow("JAPAN", 2)
+        .addRow("JORDAN", 4)
+        .addRow("KENYA", 0)
+        .addRow("MOROCCO", 0)
+        .addRow("MOZAMBIQUE", 0)
+        .addRow("PERU", 1)
+        .addRow("CHINA", 2)
+        .addRow("ROMANIA", 3)
+        .addRow("SAUDI ARABIA", 4)
+        .addRow("VIETNAM", 2)
+        .addRow("RUSSIA", 3)
+        .addRow("UNITED KINGDOM", 3)
+        .addRow("UNITED STATES", 1)
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testFilterPushdown() throws Exception {
+    String sql = "select * from phoenix123.v1.region where r_name = 'ASIA'";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Filter")
+        .include("WHERE .* = 'ASIA'")
+        .match();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("R_REGIONKEY", MinorType.BIGINT)
+        .addNullable("R_NAME", MinorType.VARCHAR)
+        .addNullable("R_COMMENT", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(2, "ASIA", "ges. thinly even pinto beans ca")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testSerDe() throws Exception {
+    String sql = "select count(*) as total from phoenix123.v1.nation";
+    String plan = queryBuilder().sql(sql).explainJson();
+    long cnt = queryBuilder().physical(plan).singletonLong();
+    assertEquals("Counts should match", 25, cnt);
+  }
+
+  @Test
+  public void testJoinPushdown() throws Exception {
+    String sql = "select a.n_name, b.r_name from phoenix123.v1.nation a join phoenix123.v1.region b "
+        + "on a.n_regionkey = b.r_regionkey";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Join")
+        .include("Phoenix\\(.* INNER JOIN")
+        .match();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("n_name", MinorType.VARCHAR)
+        .addNullable("r_name", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow("ALGERIA", "AFRICA")
+        .addRow("ARGENTINA", "AMERICA")
+        .addRow("BRAZIL", "AMERICA")
+        .addRow("CANADA", "AMERICA")
+        .addRow("EGYPT", "MIDDLE EAST")
+        .addRow("ETHIOPIA", "AFRICA")
+        .addRow("FRANCE", "EUROPE")
+        .addRow("GERMANY", "EUROPE")
+        .addRow("INDIA", "ASIA")
+        .addRow("INDONESIA", "ASIA")
+        .addRow("IRAN", "MIDDLE EAST")
+        .addRow("IRAQ", "MIDDLE EAST")
+        .addRow("JAPAN", "ASIA")
+        .addRow("JORDAN", "MIDDLE EAST")
+        .addRow("KENYA", "AFRICA")
+        .addRow("MOROCCO", "AFRICA")
+        .addRow("MOZAMBIQUE", "AFRICA")
+        .addRow("PERU", "AMERICA")
+        .addRow("CHINA", "ASIA")
+        .addRow("ROMANIA", "EUROPE")
+        .addRow("SAUDI ARABIA", "MIDDLE EAST")
+        .addRow("VIETNAM", "ASIA")
+        .addRow("RUSSIA", "EUROPE")
+        .addRow("UNITED KINGDOM", "EUROPE")
+        .addRow("UNITED STATES", "AMERICA")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testCrossJoin() throws Exception {
+    String sql = "select a.n_name, b.n_comment from phoenix123.v1.nation a cross join phoenix123.v1.nation b";
+    client.alterSession(PlannerSettings.NLJOIN_FOR_SCALAR.getOptionName(), false);
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher().exclude("Join").match();
+
+    assertEquals("Counts should match", 625, sets.rowCount());
+    sets.clear();
+  }
+
+  @Ignore("use the remote query server directly without minicluster")
+  @Test
+  public void testJoinWithFilterPushdown() throws Exception {
+    String sql = "select 10 as DRILL, a.n_name, b.r_name from phoenix123.v1.nation a join phoenix123.v1.region b "
+        + "on a.n_regionkey = b.r_regionkey where b.r_name = 'ASIA'";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Join")
+        .exclude("Filter")
+        .include("Phoenix\\(.* INNER JOIN .* WHERE")
+        .match();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("DRILL", MinorType.INT)
+        .addNullable("n_name", MinorType.VARCHAR)
+        .addNullable("r_name", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(10, "INDIA", "ASIA")
+        .addRow(10, "INDONESIA", "ASIA")
+        .addRow(10, "JAPAN", "ASIA")
+        .addRow(10, "CHINA", "ASIA")
+        .addRow(10, "VIETNAM", "ASIA")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testGroupByPushdown() throws Exception {
+    String sql = "select n_regionkey, count(1) as total from phoenix123.v1.nation group by n_regionkey";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Aggregate")
+        .include("Phoenix\\(.* GROUP BY")
+        .match();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("n_regionkey", MinorType.BIGINT)
+        .addNullable("total", MinorType.BIGINT)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(0, 5)
+        .addRow(1, 5)
+        .addRow(2, 5)
+        .addRow(3, 5)
+        .addRow(4, 5)
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testDistinctPushdown() throws Exception {
+    String sql = "select distinct n_name from phoenix123.v1.nation"; // auto convert to group-by
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Aggregate")
+        .include("Phoenix\\(.* GROUP BY \"N_NAME")
+        .match();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("n_name", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow("ALGERIA")
+        .addRow("ARGENTINA")
+        .addRow("BRAZIL")
+        .addRow("CANADA")
+        .addRow("CHINA")
+        .addRow("EGYPT")
+        .addRow("ETHIOPIA")
+        .addRow("FRANCE")
+        .addRow("GERMANY")
+        .addRow("INDIA")
+        .addRow("INDONESIA")
+        .addRow("IRAN")
+        .addRow("IRAQ")
+        .addRow("JAPAN")
+        .addRow("JORDAN")
+        .addRow("KENYA")
+        .addRow("MOROCCO")
+        .addRow("MOZAMBIQUE")
+        .addRow("PERU")
+        .addRow("ROMANIA")
+        .addRow("RUSSIA")
+        .addRow("SAUDI ARABIA")
+        .addRow("UNITED KINGDOM")
+        .addRow("UNITED STATES")
+        .addRow("VIETNAM")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+
+  @Test
+  public void testHavingPushdown() throws Exception {
+    String sql = "select n_regionkey, max(n_nationkey) from phoenix123.v1.nation group by n_regionkey having max(n_nationkey) > 20";
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    builder.planMatcher()
+        .exclude("Aggregate")
+        .include("Phoenix\\(.* GROUP BY .* HAVING MAX")
+        .match();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("n_regionkey", MinorType.BIGINT)
+        .addNullable("EXPR$1", MinorType.BIGINT)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow(1, 24)
+        .addRow(2, 21)
+        .addRow(3, 23)
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixTestSuite.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixTestSuite.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.test.ClusterTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Suite.class)
+@SuiteClasses ({
+   PhoenixDataTypeTest.class,
+   PhoenixSQLTest.class,
+   PhoenixCommandTest.class
+})
+@Ignore
+@Category({ SlowTest.class })
+public class PhoenixTestSuite extends ClusterTest {
+
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(PhoenixTestSuite.class);
+
+  private static volatile boolean runningSuite = false;
+  private static AtomicInteger initCount = new AtomicInteger(0);
+
+  @BeforeClass
+  public static void initPhoenixQueryServer() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    synchronized (PhoenixTestSuite.class) {
+      if (initCount.get() == 0) {
+        logger.info("Boot the test cluster...");
+        QueryServerBasicsIT.doSetup();
+      }
+      initCount.incrementAndGet();
+      runningSuite = true;
+    }
+  }
+
+  @AfterClass
+  public static void tearDownCluster() throws Exception {
+    synchronized (PhoenixTestSuite.class) {
+      if (initCount.decrementAndGet() == 0) {
+        logger.info("Shutdown all instances of test cluster.");
+        QueryServerBasicsIT.afterClass();
+        shutdown();
+      }
+    }
+  }
+
+  public static boolean isRunningSuite() {
+    return runningSuite;
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/QueryServerBasicsIT.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/QueryServerBasicsIT.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_CAT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.queryserver.QueryServerProperties;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.apache.phoenix.util.ThinClientUtil;
+import org.slf4j.LoggerFactory;
+
+public class QueryServerBasicsIT extends BaseTest {
+
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(QueryServerBasicsIT.class);
+
+  private static QueryServerThread AVATICA_SERVER;
+  private static Configuration CONF;
+  protected static String CONN_STRING;
+
+  public static synchronized void doSetup() throws Exception {
+      setUpTestDriver(ReadOnlyProps.EMPTY_PROPS);
+
+      CONF = config;
+      if(System.getProperty("do.not.randomize.pqs.port") == null) {
+        CONF.setInt(QueryServerProperties.QUERY_SERVER_HTTP_PORT_ATTRIB, 0);
+      }
+      String url = getUrl();
+      AVATICA_SERVER = new QueryServerThread(new String[] { url }, CONF, QueryServerBasicsIT.class.getName());
+      AVATICA_SERVER.start();
+      AVATICA_SERVER.getQueryServer().awaitRunning();
+      final int port = AVATICA_SERVER.getQueryServer().getPort();
+      logger.info("Avatica server started on port " + port);
+      CONN_STRING = ThinClientUtil.getConnectionUrl("localhost", port);
+      logger.info("JDBC connection string is " + CONN_STRING);
+  }
+
+  public static void testCatalogs() throws Exception {
+    try (final Connection connection = DriverManager.getConnection(CONN_STRING)) {
+      assertFalse(connection.isClosed());
+      try (final ResultSet resultSet = connection.getMetaData().getCatalogs()) {
+        final ResultSetMetaData metaData = resultSet.getMetaData();
+        assertFalse("unexpected populated resultSet", resultSet.next());
+        assertEquals(1, metaData.getColumnCount());
+        assertEquals(TABLE_CAT, metaData.getColumnName(1));
+      }
+    }
+  }
+
+  public static synchronized void afterClass() throws Exception {
+    if (AVATICA_SERVER != null) {
+      AVATICA_SERVER.join(TimeUnit.SECONDS.toSeconds(3));
+      Throwable t = AVATICA_SERVER.getQueryServer().getThrowable();
+      if (t != null) {
+        fail("query server threw. " + t.getMessage());
+      }
+      assertEquals("query server didn't exit cleanly", 0, AVATICA_SERVER.getQueryServer().getRetCode());
+    }
+  }
+}

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/QueryServerThread.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/QueryServerThread.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.phoenix;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.queryserver.server.QueryServer;
+
+/** Wraps up the query server for tests. */
+public class QueryServerThread extends Thread {
+
+  private final QueryServer main;
+
+  public QueryServerThread(String[] argv, Configuration conf) {
+    this(argv, conf, null);
+  }
+
+  public QueryServerThread(String[] argv, Configuration conf, String name) {
+    this(new QueryServer(argv, conf), name);
+  }
+
+  private QueryServerThread(QueryServer m, String name) {
+    super(m, "query server" + (name == null ? "" : (" - " + name)));
+    this.main = m;
+    setDaemon(true);
+  }
+
+  public QueryServer getQueryServer() {
+    return main;
+  }
+}

--- a/contrib/storage-phoenix/src/test/resources/data/nation.tbl
+++ b/contrib/storage-phoenix/src/test/resources/data/nation.tbl
@@ -1,0 +1,25 @@
+0|ALGERIA|0| haggle. carefully final deposits detect slyly agai|
+1|ARGENTINA|1|al foxes promise slyly according to the regular accounts. bold requests alon|
+2|BRAZIL|1|y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special |
+3|CANADA|1|eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold|
+4|EGYPT|4|y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d|
+5|ETHIOPIA|0|ven packages wake quickly. regu|
+6|FRANCE|3|refully final requests. regular, ironi|
+7|GERMANY|3|l platelets. regular accounts x-ray: unusual, regular acco|
+8|INDIA|2|ss excuses cajole slyly across the packages. deposits print aroun|
+9|INDONESIA|2| slyly express asymptotes. regular deposits haggle slyly. carefully ironic hockey players sleep blithely. carefull|
+10|IRAN|4|efully alongside of the slyly final dependencies. |
+11|IRAQ|4|nic deposits boost atop the quickly final requests? quickly regula|
+12|JAPAN|2|ously. final, express gifts cajole a|
+13|JORDAN|4|ic deposits are blithely about the carefully regular pa|
+14|KENYA|0| pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t|
+15|MOROCCO|0|rns. blithely bold courts among the closely regular packages use furiously bold platelets?|
+16|MOZAMBIQUE|0|s. ironic, unusual asymptotes wake blithely r|
+17|PERU|1|platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun|
+18|CHINA|2|c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos|
+19|ROMANIA|3|ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account|
+20|SAUDI ARABIA|4|ts. silent requests haggle. closely express packages sleep across the blithely|
+21|VIETNAM|2|hely enticingly express accounts. even, final |
+22|RUSSIA|3| requests against the platelets use never according to the quickly regular pint|
+23|UNITED KINGDOM|3|eans boost carefully special requests. accounts are. carefull|
+24|UNITED STATES|1|y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be|

--- a/contrib/storage-phoenix/src/test/resources/data/region.tbl
+++ b/contrib/storage-phoenix/src/test/resources/data/region.tbl
@@ -1,0 +1,5 @@
+0|AFRICA|lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to |
+1|AMERICA|hs use ironic, even requests. s|
+2|ASIA|ges. thinly even pinto beans ca|
+3|EUROPE|ly final courts cajole furiously final excuse|
+4|MIDDLE EAST|uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl|

--- a/contrib/storage-phoenix/src/test/resources/hbase-site.xml
+++ b/contrib/storage-phoenix/src/test/resources/hbase-site.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+  <property>
+    <name>hbase.master.start.timeout.localHBaseCluster</name>
+    <value>60000</value>
+  </property>
+  <property>
+    <name>phoenix.schema.isNamespaceMappingEnabled</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -374,6 +374,11 @@
         </dependency>
         <dependency>
           <groupId>org.apache.drill.contrib</groupId>
+          <artifactId>drill-storage-phoenix</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.drill.contrib</groupId>
           <artifactId>drill-udfs</artifactId>
           <version>${project.version}</version>
         </dependency>

--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -55,6 +55,7 @@
         <include>org.apache.drill.contrib:drill-format-sas:jar</include>
         <include>org.apache.drill.contrib:drill-jdbc-storage:jar</include>
         <include>org.apache.drill.contrib:drill-kudu-storage:jar</include>
+        <include>org.apache.drill.contrib:drill-storage-phoenix:jar</include>
         <include>org.apache.drill.contrib:drill-storage-splunk:jar</include>
         <include>org.apache.drill.contrib:drill-storage-kafka:jar</include>
         <include>org.apache.drill.contrib:drill-storage-elasticsearch:jar</include>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>com.univocity</groupId>
       <artifactId>univocity-parsers</artifactId>
-      <version>2.8.3</version>
+      <version>${univocity-parsers.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.jdbc;
+package org.apache.drill.exec.store.enumerable.plan;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -39,13 +39,14 @@ import org.apache.drill.shaded.guava.com.google.common.cache.CacheLoader;
 import org.apache.drill.shaded.guava.com.google.common.cache.LoadingCache;
 import org.apache.drill.exec.planner.logical.DrillRelFactories;
 
-abstract class DrillJdbcRuleBase extends ConverterRule {
+public abstract class DrillJdbcRuleBase extends ConverterRule {
 
   protected final LoadingCache<RexNode, Boolean> checkedExpressions = CacheBuilder.newBuilder()
       .maximumSize(1000)
       .expireAfterWrite(10, TimeUnit.MINUTES)
       .build(
           new CacheLoader<RexNode, Boolean>() {
+            @Override
             public Boolean load(RexNode expr) {
               return JdbcExpressionCheck.isOnlyStandardExpressions(expr);
             }
@@ -58,12 +59,13 @@ abstract class DrillJdbcRuleBase extends ConverterRule {
     this.out = out;
   }
 
-  static class DrillJdbcProjectRule extends DrillJdbcRuleBase {
+  public static class DrillJdbcProjectRule extends DrillJdbcRuleBase {
 
-    DrillJdbcProjectRule(RelTrait in, JdbcConvention out) {
+    public DrillJdbcProjectRule(RelTrait in, JdbcConvention out) {
       super(LogicalProject.class, in, out, "DrillJdbcProjectRule");
     }
 
+    @Override
     public RelNode convert(RelNode rel) {
       LogicalProject project = (LogicalProject) rel;
       return new JdbcRules.JdbcProject(rel.getCluster(), rel.getTraitSet().replace(this.out), convert(
@@ -89,12 +91,13 @@ abstract class DrillJdbcRuleBase extends ConverterRule {
     }
   }
 
-  static class DrillJdbcFilterRule extends DrillJdbcRuleBase {
+  public static class DrillJdbcFilterRule extends DrillJdbcRuleBase {
 
-    DrillJdbcFilterRule(RelTrait in, JdbcConvention out) {
+    public DrillJdbcFilterRule(RelTrait in, JdbcConvention out) {
       super(LogicalFilter.class, in, out, "DrillJdbcFilterRule");
     }
 
+    @Override
     public RelNode convert(RelNode rel) {
       LogicalFilter filter = (LogicalFilter) rel;
 
@@ -120,9 +123,9 @@ abstract class DrillJdbcRuleBase extends ConverterRule {
     }
   }
 
-  static class DrillJdbcSortRule extends DrillJdbcRuleBase {
+  public static class DrillJdbcSortRule extends DrillJdbcRuleBase {
 
-    DrillJdbcSortRule(RelTrait in, JdbcConvention out) {
+    public DrillJdbcSortRule(RelTrait in, JdbcConvention out) {
       super(Sort.class, in, out, "DrillJdbcSortRule");
     }
 
@@ -136,9 +139,9 @@ abstract class DrillJdbcRuleBase extends ConverterRule {
     }
   }
 
-  static class DrillJdbcLimitRule extends DrillJdbcRuleBase {
+  public static class DrillJdbcLimitRule extends DrillJdbcRuleBase {
 
-    DrillJdbcLimitRule(RelTrait in, JdbcConvention out) {
+    public DrillJdbcLimitRule(RelTrait in, JdbcConvention out) {
       super(DrillLimitRelBase.class, in, out, "DrillJdbcLimitRule");
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcSort.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcSort.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.jdbc;
+package org.apache.drill.exec.store.enumerable.plan;
 
 import org.apache.calcite.adapter.jdbc.JdbcRules;
 import org.apache.calcite.plan.RelOptCluster;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/JdbcExpressionCheck.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/JdbcExpressionCheck.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.jdbc;
+package org.apache.drill.exec.store.enumerable.plan;
 
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderProtocol.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderProtocol.java
@@ -17,6 +17,13 @@
  */
 package org.apache.drill.exec.physical.resultSet.impl;
 
+import static org.apache.drill.test.rowSet.RowSetUtilities.boolArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.byteArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.doubleArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.floatArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.intArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.shortArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +41,9 @@ import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -42,9 +52,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.TupleWriter.UndefinedColumnException;
 import org.apache.drill.test.SubOperatorTest;
-import org.apache.drill.exec.physical.rowSet.RowSet;
-import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.exec.physical.rowSet.RowSetReader;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -441,15 +448,115 @@ public class TestResultSetLoaderProtocol extends SubOperatorTest {
     assertEquals(4, schema.index("e"));
     assertEquals(4, schema.index("E"));
     rootWriter.array(4).setObject(strArray("e1", "e2", "e3"));
+
+    MaterializedField col6 = SchemaBuilder.columnSchema("f", MinorType.BIGINT, DataMode.REPEATED);
+    rootWriter.addColumn(col6);
+    assertEquals(6, rsLoader.schemaVersion());
+    assertTrue(col6.isEquivalent(schema.column(5)));
+    ColumnMetadata col6Metadata = schema.metadata(5);
+    assertSame(col6Metadata, schema.metadata("f"));
+    assertSame(col6Metadata, schema.metadata("F"));
+    assertEquals(6, schema.size());
+    assertEquals(5, schema.index("f"));
+    assertEquals(5, schema.index("F"));
+    rootWriter.array(5).setObject(new Long[] { Long.MIN_VALUE, Long.MAX_VALUE });
+
+    MaterializedField col7 = SchemaBuilder.columnSchema("g", MinorType.INT, DataMode.REPEATED);
+    rootWriter.addColumn(col7);
+    assertEquals(7, rsLoader.schemaVersion());
+    assertTrue(col7.isEquivalent(schema.column(6)));
+    ColumnMetadata col7Metadata = schema.metadata(6);
+    assertSame(col7Metadata, schema.metadata("g"));
+    assertSame(col7Metadata, schema.metadata("G"));
+    assertEquals(7, schema.size());
+    assertEquals(6, schema.index("g"));
+    assertEquals(6, schema.index("G"));
+    rootWriter.array(6).setObject(new Integer[] { Integer.MIN_VALUE, Integer.MAX_VALUE });
+
+    MaterializedField col8 = SchemaBuilder.columnSchema("h", MinorType.INT, DataMode.REPEATED);
+    rootWriter.addColumn(col8);
+    assertEquals(8, rsLoader.schemaVersion());
+    assertTrue(col8.isEquivalent(schema.column(7)));
+    ColumnMetadata col8Metadata = schema.metadata(7);
+    assertSame(col8Metadata, schema.metadata("h"));
+    assertSame(col8Metadata, schema.metadata("H"));
+    assertEquals(8, schema.size());
+    assertEquals(7, schema.index("h"));
+    assertEquals(7, schema.index("H"));
+    rootWriter.array(7).setObject(new Short[] { Short.MIN_VALUE, Short.MAX_VALUE });
+
+    MaterializedField col9 = SchemaBuilder.columnSchema("i", MinorType.INT, DataMode.REPEATED);
+    rootWriter.addColumn(col9);
+    assertEquals(9, rsLoader.schemaVersion());
+    assertTrue(col9.isEquivalent(schema.column(8)));
+    ColumnMetadata col9Metadata = schema.metadata(8);
+    assertSame(col9Metadata, schema.metadata("i"));
+    assertSame(col9Metadata, schema.metadata("I"));
+    assertEquals(9, schema.size());
+    assertEquals(8, schema.index("i"));
+    assertEquals(8, schema.index("I"));
+    rootWriter.array(8).setObject(new Byte[] { Byte.MIN_VALUE, Byte.MAX_VALUE });
+
+    MaterializedField col10 = SchemaBuilder.columnSchema("j", MinorType.FLOAT8, DataMode.REPEATED);
+    rootWriter.addColumn(col10);
+    assertEquals(10, rsLoader.schemaVersion());
+    assertTrue(col10.isEquivalent(schema.column(9)));
+    ColumnMetadata col10Metadata = schema.metadata(9);
+    assertSame(col10Metadata, schema.metadata("j"));
+    assertSame(col10Metadata, schema.metadata("J"));
+    assertEquals(10, schema.size());
+    assertEquals(9, schema.index("j"));
+    assertEquals(9, schema.index("J"));
+    rootWriter.array(9).setObject(new Double[] { Double.MIN_VALUE, Double.MAX_VALUE });
+
+    MaterializedField col11 = SchemaBuilder.columnSchema("k", MinorType.FLOAT4, DataMode.REPEATED);
+    rootWriter.addColumn(col11);
+    assertEquals(11, rsLoader.schemaVersion());
+    assertTrue(col11.isEquivalent(schema.column(10)));
+    ColumnMetadata col11Metadata = schema.metadata(10);
+    assertSame(col11Metadata, schema.metadata("k"));
+    assertSame(col11Metadata, schema.metadata("K"));
+    assertEquals(11, schema.size());
+    assertEquals(10, schema.index("k"));
+    assertEquals(10, schema.index("K"));
+    rootWriter.array(10).setObject(new Float[] { Float.MIN_VALUE, Float.MAX_VALUE });
+
+    MaterializedField col12 = SchemaBuilder.columnSchema("l", MinorType.BIT, DataMode.REPEATED);
+    rootWriter.addColumn(col12);
+    assertEquals(12, rsLoader.schemaVersion());
+    assertTrue(col12.isEquivalent(schema.column(11)));
+    ColumnMetadata col12Metadata = schema.metadata(11);
+    assertSame(col12Metadata, schema.metadata("l"));
+    assertSame(col12Metadata, schema.metadata("L"));
+    assertEquals(12, schema.size());
+    assertEquals(11, schema.index("l"));
+    assertEquals(11, schema.index("L"));
+    rootWriter.array(11).setObject(new Boolean[] { Boolean.TRUE, Boolean.FALSE });
     rootWriter.save();
 
     // Verify. No reason to expect problems, but might as well check.
 
     RowSet result = fixture.wrap(rsLoader.harvest());
-    assertEquals(5, rsLoader.schemaVersion());
+    assertEquals(12, rsLoader.schemaVersion());
     SingleRowSet expected = fixture.rowSetBuilder(result.batchSchema())
-        .addRow("foo", "second", "",    null,  strArray())
-        .addRow("bar", "",       "c.2", "d.2", strArray("e1", "e2", "e3"))
+        .addRow("foo", "second", "", null,
+            strArray(),
+            longArray(),
+            intArray(),
+            shortArray(),
+            byteArray(),
+            doubleArray(),
+            floatArray(),
+            boolArray())
+        .addRow("bar", "", "c.2", "d.2",
+            strArray("e1", "e2", "e3"),
+            longArray(Long.MIN_VALUE, Long.MAX_VALUE),
+            intArray(Integer.MIN_VALUE, Integer.MAX_VALUE),
+            shortArray(Short.MIN_VALUE, Short.MAX_VALUE),
+            byteArray((int) Byte.MIN_VALUE, (int) Byte.MAX_VALUE),
+            doubleArray(Double.MIN_VALUE, Double.MAX_VALUE),
+            floatArray(Float.MIN_VALUE, Float.MAX_VALUE),
+            boolArray(Boolean.TRUE, Boolean.FALSE))
         .build();
     RowSetUtilities.verify(expected, result);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
@@ -219,6 +219,14 @@ public class RowSetUtilities {
     return array;
   }
 
+  public static float[] floatArray(Float... elements) {
+    float[] array = new float[elements.length];
+    for (int i = 0; i < elements.length; i++) {
+      array[i] = elements[i];
+    }
+    return array;
+  }
+
   public static boolean[] boolArray(Boolean... elements) {
     boolean[] array = new boolean[elements.length];
     for (int i = 0; i < elements.length; i++) {
@@ -241,6 +249,14 @@ public class RowSetUtilities {
 
   public static int[] intArray(Integer... elements) {
     int[] array = new int[elements.length];
+    for (int i = 0; i < elements.length; i++) {
+      array[i] = elements[i];
+    }
+    return array;
+  }
+
+  public static short[] shortArray(Short... elements) {
+    short[] array = new short[elements.length];
     for (int i = 0; i < elements.length; i++) {
       array[i] = elements[i];
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ScalarArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ScalarArrayWriter.java
@@ -174,6 +174,14 @@ public class ScalarArrayWriter extends BaseArrayWriter {
         setLongObjectArray((Long[]) array);
       } else if (memberClassName.equals(Double.class.getName())) {
         setDoubleObjectArray((Double[]) array);
+      } else if (memberClassName.equals(Float.class.getName())) {
+        setFloatObjectArray((Float[]) array);
+      } else if (memberClassName.equals(Short.class.getName())) {
+        setShortObjectArray((Short[]) array);
+      } else if (memberClassName.equals(Byte.class.getName())) {
+        setByteObjectArray((Byte[]) array);
+      } else if (memberClassName.equals(Boolean.class.getName())) {
+        setBooleanObjectArray((Boolean[]) array);
       } else {
         throw new IllegalArgumentException( "Unknown Java array type: " + memberClassName );
       }
@@ -183,9 +191,27 @@ public class ScalarArrayWriter extends BaseArrayWriter {
     }
   }
 
+  public void setObjectArray(Object[] value) {
+    for (int i = 0; i < value.length; i++) {
+      final Object element = value[i];
+      if (element != null) {
+        elementWriter.setObject(element);
+      }
+    }
+  }
+
   public void setBooleanArray(boolean[] value) {
     for (int i = 0; i < value.length; i++) {
       elementWriter.setInt(value[i] ? 1 : 0);
+    }
+  }
+
+  public void setBooleanObjectArray(Boolean[] value) {
+    for (int i = 0; i < value.length; i++) {
+      final Boolean element = value[i];
+      if (element != null) {
+        elementWriter.setBoolean(element);
+      }
     }
   }
 
@@ -201,9 +227,27 @@ public class ScalarArrayWriter extends BaseArrayWriter {
     }
   }
 
+  public void setByteObjectArray(Byte[] value) {
+    for (int i = 0; i < value.length; i++) {
+      final Byte element = value[i];
+      if (element != null) {
+        elementWriter.setInt(element);
+      }
+    }
+  }
+
   public void setShortArray(short[] value) {
     for (int i = 0; i < value.length; i++) {
       elementWriter.setInt(value[i]);
+    }
+  }
+
+  public void setShortObjectArray(Short[] value) {
+    for (int i = 0; i < value.length; i++) {
+      final Short element = value[i];
+      if (element != null) {
+        elementWriter.setInt(element);
+      }
     }
   }
 
@@ -216,9 +260,7 @@ public class ScalarArrayWriter extends BaseArrayWriter {
   public void setIntObjectArray(Integer[] value) {
     for (int i = 0; i < value.length; i++) {
       final Integer element = value[i];
-      if (element == null) {
-        elementWriter.setNull();
-      } else {
+      if (element != null) {
         elementWriter.setInt(element);
       }
     }
@@ -233,9 +275,7 @@ public class ScalarArrayWriter extends BaseArrayWriter {
   public void setLongObjectArray(Long[] value) {
     for (int i = 0; i < value.length; i++) {
       final Long element = value[i];
-      if (element == null) {
-        elementWriter.setNull();
-      } else {
+      if (element != null) {
         elementWriter.setLong(element);
       }
     }
@@ -244,6 +284,15 @@ public class ScalarArrayWriter extends BaseArrayWriter {
   public void setFloatArray(float[] value) {
     for (int i = 0; i < value.length; i++) {
       elementWriter.setDouble(value[i]);
+    }
+  }
+
+  public void setFloatObjectArray(Float[] value) {
+    for (int i = 0; i < value.length; i++) {
+      final Float element = value[i];
+      if (element != null) {
+        elementWriter.setDouble(element);
+      }
     }
   }
 
@@ -256,9 +305,7 @@ public class ScalarArrayWriter extends BaseArrayWriter {
   public void setDoubleObjectArray(Double[] value) {
     for (int i = 0; i < value.length; i++) {
       final Double element = value[i];
-      if (element == null) {
-        elementWriter.setNull();
-      } else {
+      if (element != null) {
         elementWriter.setDouble(element);
       }
     }
@@ -266,19 +313,28 @@ public class ScalarArrayWriter extends BaseArrayWriter {
 
   public void setStringArray(String[] value) {
     for (int i = 0; i < value.length; i++) {
-      elementWriter.setString(value[i]);
+      final String element = value[i];
+      if (element != null) {
+        elementWriter.setString(element);
+      }
     }
   }
 
   public void setPeriodArray(Period[] value) {
     for (int i = 0; i < value.length; i++) {
-      elementWriter.setPeriod(value[i]);
+      final Period element = value[i];
+      if (element != null) {
+        elementWriter.setPeriod(element);
+      }
     }
   }
 
   public void setBigDecimalArray(BigDecimal[] value) {
     for (int i = 0; i < value.length; i++) {
-      elementWriter.setDecimal(value[i]);
+      final BigDecimal element = value[i];
+      if (element != null) {
+        elementWriter.setDecimal(element);
+      }
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <aircompressor.version>0.20</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>
+    <univocity-parsers.version>2.8.3</univocity-parsers.version>
     <junit.args/>
   </properties>
 


### PR DESCRIPTION
# [DRILL-7863](https://issues.apache.org/jira/browse/DRILL-7863): Add Storage Plugin for Apache Phoenix

## Description
Phoenix say : "We put the SQL back in NoSQL",
Drill call : "We use the SQL to cross almost all the file systems and storage engines",
"Cheers !", users said.

## Documentation
Features :
 - Full support for Enhanced Vector Framework.
 - Tested in phoenix 4.14 and 5.1.2.
 - Support the array data type.
 - Support the pushdown (Project, Limit, Filter, Aggregate, Join, CrossJoin, Join_Filter, GroupBy, Distinct and more).
 - Use the PQS client (6.0).

Related Information :
1. PHOENIX-6398: Returns uniform SQL dialect in calcite for the PQS
2. PHOENIX-6582: Bump default HBase version to 2.3.7 and 2.4.8
3. PHOENIX-6605, PHOENIX-6606 and PHOENIX-6607.
4. DRILL-8060, 
5. DRILL-8061: Add User Impersonation to Phoenix Plugin  (https://issues.apache.org/jira/browse/DRILL-8061)
6. DRILL-8062:  Add Testcontainer Support to Phoenix Plugin (https://issues.apache.org/jira/browse/DRILL-8062)
5. [QueryServer 6.0.0-drill-r1](https://github.com/luocooong/phoenix-queryserver/releases/tag/6.0.0-drill-r1)

## Testing
  The test framework of phoenix queryserver required the Hadoop 3, but exist `PHOENIX-5993` and `HBASE-22394` :
```
" The HBase PMC does not release multiple artifacts for both Hadoop2 and Hadoop3 support at the current time.
Current HBase2 releases still compile against Hadoop2 by default, and using Hadoop 3 against HBase2
requires a recompilation of HBase because of incompatible changes between Hadoop2 and Hadoop3. "
```

### Recommended Practices
1. Download HBase 2.4.2 sources and rebuild with Hadoop 3.
```
mvn clean install -DskipTests -Dhadoop.profile=3.0 -Dhadoop-three.version=3.2.2
```
2. Remove the `Ignore` annotation in `PhoenixTestSuite.java`.
```java
@Ignore
@Category({ SlowTest.class })
public class PhoenixTestSuite extends ClusterTest {
```
3. Go to the phoenix root folder and run test.
```bash
cd contrib/storage-phoenix/
mvn test
```

### To Add Features
 - Don't forget to add a test function to the test class.
 - If a new test class is added, please declare it in the `PhoenixTestSuite` class.

### Play in CLI
```sql
apache drill> use phoenix123.v1;
+------+-------------------------------------------+
|  ok  |                  summary                  |
+------+-------------------------------------------+
| true | Default schema changed to [phoenix123.v1] |
+------+-------------------------------------------+
1 row selected (0.308 seconds)
apache drill (phoenix123.v1)> select n_regionkey, max(n_nationkey) from nation group by n_regionkey having max(n_nationkey) > 20;
+-------------+--------+
| n_regionkey | EXPR$1 |
+-------------+--------+
| 1           | 24     |
| 2           | 21     |
| 3           | 23     |
+-------------+--------+
3 rows selected (0.734 seconds)
apache drill (phoenix123.v1)> select a.n_name, b.r_name from nation a join region b on a.n_regionkey = b.r_regionkey where b.r_name = 'ASIA';
+-----------+--------+
|  n_name   | r_name |
+-----------+--------+
| INDIA     | ASIA   |
| INDONESIA | ASIA   |
| JAPAN     | ASIA   |
| CHINA     | ASIA   |
| VIETNAM   | ASIA   |
+-----------+--------+
5 rows selected (1.199 seconds)
apache drill (phoenix123.v1)> select n_name, n_regionkey from nation limit 3 offset 10;
+--------+-------------+
| n_name | n_regionkey |
+--------+-------------+
| IRAN   | 4           |
| IRAQ   | 4           |
| JAPAN  | 2           |
+--------+-------------+
3 rows selected (0.77 seconds)
```