### PR TITLE
DRILL-8009: DrillConnectionImpl#isValid() doesn't correspond JDBC API

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillHandler.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillHandler.java
@@ -30,8 +30,6 @@ public class DrillHandler implements Handler {
 
   @Override
   public void onConnectionClose(AvaticaConnection c) throws RuntimeException {
-    DrillConnectionImpl connection = (DrillConnectionImpl) c;
-    connection.cleanup();
   }
 
   @Override

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2489CallsAfterCloseThrowExceptionsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2489CallsAfterCloseThrowExceptionsTest.java
@@ -294,9 +294,14 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
      * Reports whether it's okay if given method didn't throw any exception.
      */
     protected boolean isOkayNonthrowingMethod(Method method) {
-       return
-           "isClosed".equals(method.getName())
-           || "close".equals(method.getName());
+       switch (method.getName()) {
+         case "isClosed":
+         case "close":
+         case "isValid":
+           return true;
+         default:
+           return false;
+       }
     }
 
     /**

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.rpc;
 
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import com.google.protobuf.Internal.EnumLite;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
@@ -26,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -34,30 +34,34 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.GeneralRPCProtos.RpcMode;
 import org.apache.drill.exec.rpc.security.AuthenticationOutcomeListener;
 import org.apache.drill.exec.rpc.security.AuthenticatorFactory;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 /**
- *
- * @param <T> handshake rpc type
+ * @param <T>  handshake rpc type
  * @param <CC> Client connection type
  * @param <HS> Handshake send type
  * @param <HR> Handshake receive type
  */
 public abstract class BasicClient<T extends EnumLite, CC extends ClientConnection,
-                                  HS extends MessageLite, HR extends MessageLite>
-    extends RpcBus<T, CC> {
+  HS extends MessageLite, HR extends MessageLite>
+  extends RpcBus<T, CC> {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BasicClient.class);
 
   // The percentage of time that should pass before sending a ping message to ensure server doesn't time us out. For
@@ -71,7 +75,7 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
   private final Class<HR> responseClass;
   private final Parser<HR> handshakeParser;
 
-  private final IdlePingHandler pingHandler;
+  private HeartBeatHandler heartBeatHandler;
   private ConnectionMultiListener.SSLHandshakeListener sslHandshakeListener = null;
 
   // Determines if authentication is completed between client and server
@@ -83,48 +87,48 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
     this.responseClass = responseClass;
     this.handshakeType = handshakeType;
     this.handshakeParser = handshakeParser;
-    final long timeoutInMillis = rpcMapping.hasTimeout() ?
-        (long) (rpcMapping.getTimeout() * 1000.0 * PERCENT_TIMEOUT_BEFORE_SENDING_PING) :
-        -1;
-    this.pingHandler = rpcMapping.hasTimeout() ? new IdlePingHandler(timeoutInMillis) : null;
+    final int readIdleSec = rpcMapping.hasTimeout() ?
+            (int) (rpcMapping.getTimeout() * PERCENT_TIMEOUT_BEFORE_SENDING_PING) : -1;
+    IdleStateHandler idleStateHandler = rpcMapping.hasTimeout() ? new IdleStateHandler(readIdleSec, 0, 0) : null;
+
+    final int heartbeatWaitSec = rpcMapping.hasTimeout() ? rpcMapping.getTimeout() - readIdleSec : -1;
+    HeartBeatHandler heartBeatHandler = this.heartBeatHandler = new HeartBeatHandler(heartbeatWaitSec);
 
     b = new Bootstrap() //
-        .group(eventLoopGroup) //
-        .channel(TransportCheck.getClientSocketChannel()) //
-        .option(ChannelOption.ALLOCATOR, alloc) //
-        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30 * 1000)
-        .option(ChannelOption.SO_REUSEADDR, true)
-        .option(ChannelOption.SO_RCVBUF, 1 << 17) //
-        .option(ChannelOption.SO_SNDBUF, 1 << 17) //
-        .option(ChannelOption.TCP_NODELAY, true)
-        .handler(new ChannelInitializer<SocketChannel>() {
+      .group(eventLoopGroup) //
+      .channel(TransportCheck.getClientSocketChannel()) //
+      .option(ChannelOption.ALLOCATOR, alloc) //
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30 * 1000)
+      .option(ChannelOption.SO_REUSEADDR, true)
+      .option(ChannelOption.SO_RCVBUF, 1 << 17) //
+      .option(ChannelOption.SO_SNDBUF, 1 << 17) //
+      .option(ChannelOption.TCP_NODELAY, true)
+      .handler(new ChannelInitializer<SocketChannel>() {
 
-          @Override
-          protected void initChannel(SocketChannel ch) throws Exception {
-            // logger.debug("initializing client connection.");
-            connection = initRemoteConnection(ch);
+        @Override
+        protected void initChannel(SocketChannel ch) throws Exception {
+          // logger.debug("initializing client connection.");
+          connection = initRemoteConnection(ch);
 
-            ch.closeFuture().addListener(getCloseHandler(ch, connection));
+          ch.closeFuture().addListener(getCloseHandler(ch, connection));
 
-            final ChannelPipeline pipe = ch.pipeline();
-            // Make sure that the SSL handler is the first handler in the pipeline so everything is encrypted
-            if (isSslEnabled()) {
-              setupSSL(pipe, sslHandshakeListener);
-            }
-
-            pipe.addLast(RpcConstants.PROTOCOL_DECODER, getDecoder(connection.getAllocator()));
-            pipe.addLast(RpcConstants.MESSAGE_DECODER, new RpcDecoder("c-" + rpcConfig.getName()));
-            pipe.addLast(RpcConstants.PROTOCOL_ENCODER, new RpcEncoder("c-" + rpcConfig.getName()));
-            pipe.addLast(RpcConstants.HANDSHAKE_HANDLER, new ClientHandshakeHandler(connection));
-
-            if(pingHandler != null){
-              pipe.addLast(RpcConstants.IDLE_STATE_HANDLER, pingHandler);
-            }
-
-            pipe.addLast(RpcConstants.MESSAGE_HANDLER, new InboundHandler(connection));
-            pipe.addLast(RpcConstants.EXCEPTION_HANDLER, new RpcExceptionHandler<>(connection));
+          final ChannelPipeline pipe = ch.pipeline();
+          // Make sure that the SSL handler is the first handler in the pipeline so everything is encrypted
+          if (isSslEnabled()) {
+            setupSSL(pipe, sslHandshakeListener);
           }
-        }); //
+          if (idleStateHandler != null) {
+            pipe.addLast(RpcConstants.IDLE_STATE_HANDLER, idleStateHandler);
+          }
+          pipe.addLast(RpcConstants.PROTOCOL_DECODER, getDecoder(connection.getAllocator()));
+          pipe.addLast(RpcConstants.MESSAGE_DECODER, new RpcDecoder("c-" + rpcConfig.getName()));
+          pipe.addLast(RpcConstants.PROTOCOL_ENCODER, new RpcEncoder("c-" + rpcConfig.getName()));
+          pipe.addLast(RpcConstants.HANDSHAKE_HANDLER, new ClientHandshakeHandler(connection));
+          pipe.addLast(RpcConstants.MESSAGE_HANDLER, new InboundHandler(connection));
+          pipe.addLast(RpcConstants.HEARTBEAT_HANDLER, heartBeatHandler);
+          pipe.addLast(RpcConstants.EXCEPTION_HANDLER, new RpcExceptionHandler<>(connection));
+        }
+      }); //
 
     // if(TransportCheck.SUPPORTS_EPOLL){
     // b.option(EpollChannelOption.SO_REUSEPORT, true); //
@@ -143,6 +147,7 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
 
   /**
    * Set's the state for authentication complete.
+   *
    * @param authComplete - state to set. True means authentication between client and server is completed, false
    *                     means authentication is in progress.
    */
@@ -160,38 +165,125 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
   }
 
   @Override
-  protected CC initRemoteConnection(SocketChannel channel){
-    local=channel.localAddress();
-    remote=channel.remoteAddress();
+  protected CC initRemoteConnection(SocketChannel channel) {
+    local = channel.localAddress();
+    remote = channel.remoteAddress();
     return null;
   }
 
-  private static final OutboundRpcMessage PING_MESSAGE = new OutboundRpcMessage(RpcMode.PING, 0, 0, Acks.OK);
-
   /**
-   * Handler that watches for situations where we haven't read from the socket in a certain timeout. If we exceed this
-   * timeout, we send a PING message to the server to state that we are still alive.
+   * Handler watches for {@link IdleState#READER_IDLE IdleState.READER_IDLE} user event and sends message with
+   * {@link RpcMode#PING RpcMode.PING} to the server and waits for the {@link RpcMode#PONG RpcMode.PONG} answer.
+   * The handler watches for {@link RpcMode#PONG RpcMode.PONG} user event from
+   * {@link org.apache.drill.exec.rpc.RpcBus.InboundHandler} as a signal that the answer is received. If it is not received
+   * until answerWaitSec timeout, than the handler closes the connection.
    */
-  private class IdlePingHandler extends IdleStateHandler {
+  private class HeartBeatHandler extends ChannelInboundHandlerAdapter {
+    private final OutboundRpcMessage PING_MESSAGE = new OutboundRpcMessage(RpcMode.PING, 0, 0, Acks.OK);
+    private final int answerWaitSec;
+    private final Queue<Pair<Promise<Boolean>, ScheduledFuture>> pongFutures = new LinkedList<>();
+    private ChannelHandlerContext ctx;
 
-    private GenericFutureListener<Future<? super Void>> pingFailedHandler = new GenericFutureListener<Future<? super Void>>() {
-      public void operationComplete(Future<? super Void> future) throws Exception {
-        if (!future.isSuccess()) {
-          logger.error("Unable to maintain connection {}.  Closing connection.", connection.getName());
-          connection.close();
-        }
-      }
-    };
-
-    IdlePingHandler(long idleWaitInMillis) {
-      super(0, idleWaitInMillis, 0, TimeUnit.MILLISECONDS);
+    /**
+     * @param answerWaitSec timeout in seconds to wait an answer from the server
+     */
+    public HeartBeatHandler(int answerWaitSec) {
+      this.answerWaitSec = answerWaitSec;
     }
 
     @Override
-    protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
-      if (evt.state() == IdleState.WRITER_IDLE) {
-        ctx.writeAndFlush(PING_MESSAGE).addListener(pingFailedHandler);
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+      this.ctx = ctx;
+      super.handlerAdded(ctx);
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+      if (evt instanceof IdleStateEvent) {
+        IdleStateEvent idleState = (IdleStateEvent) evt;
+        if (idleState.state() == IdleState.READER_IDLE) {
+          idleEvent();
+        }
+      } else if (evt instanceof RpcMode) {
+        RpcMode rpcMode = (RpcMode) evt;
+        if (rpcMode == RpcMode.PONG) {
+          pongReceived();
+        }
       }
+      ctx.fireUserEventTriggered(evt);
+    }
+
+    private void idleEvent() {
+      EventExecutor executor = ctx.executor();
+
+      Promise<Boolean> pongReceived = executor.newPromise();
+      ScheduledFuture<?> pongTimeoutChecker = null;
+
+      if (answerWaitSec > 0) {
+        pongTimeoutChecker = executor.schedule(() -> {
+          if (!pongReceived.isSuccess()) {
+            logger.error("Unable to get an answer from the server. Timeout: {} seconds. Connection: {}.  " +
+              "Closing connection.", answerWaitSec, connection.getName());
+            connection.close();
+          }
+        }, answerWaitSec, TimeUnit.SECONDS);
+      }
+      pongFutures.add(Pair.of(pongReceived, pongTimeoutChecker));
+
+      sendPing();
+    }
+
+    private void sendPing() {
+      ctx.channel().writeAndFlush(PING_MESSAGE).addListener(future -> {
+        if (!future.isSuccess()) {
+          logger.error("Unable to maintain connection {}.  Closing connection.", connection.getName());
+          close();
+        }
+      });
+    }
+
+    private void pongReceived() {
+      Pair<Promise<Boolean>, ScheduledFuture> pongFuture = pongFutures.poll();
+      if (pongFuture != null) {
+        Promise<Boolean> pongReceived = pongFuture.getLeft();
+        pongReceived.setSuccess(true);
+        ScheduledFuture pongTimeoutChecker = pongFuture.getRight();
+        if (pongTimeoutChecker != null) {
+          pongTimeoutChecker.cancel(false);
+        }
+      }
+    }
+
+    public Promise<Boolean> demandHeartbeat() {
+      EventExecutor executor = this.ctx.executor();
+      Promise<Boolean> pongReceived = executor.newPromise();
+      pongFutures.add(Pair.of(pongReceived, null));
+      sendPing();
+      return pongReceived;
+    }
+  }
+
+  /**
+   * Sends request and waits for answer to verify connection.
+   *
+   * @param timeoutSec time in seconds to wait message receiving. If 0 then won't wait.
+   * @return true if answer received until timeout, false otherwise
+   */
+  public boolean hasPing(long timeoutSec) {
+    if (timeoutSec < 0) {
+      timeoutSec = 0;
+    }
+    try {
+      return heartBeatHandler.demandHeartbeat().await(timeoutSec, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      logger.warn("Heartbeat wait was interrupted.");
+
+      // Preserve evidence that the interruption occurred so that code higher up
+      // on the call stack can learn of the
+      // interruption and respond to it if it wants to.
+      Thread.currentThread().interrupt();
+
+      return false;
     }
   }
 
@@ -206,7 +298,8 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
   /**
    * Creates various instances needed to start the SASL handshake. This is called from
    * {@link BasicClient#validateHandshake(MessageLite)} if authentication is required from server side.
-   * @param connectionHandler - Connection handler used by client's to know about success/failure conditions.
+   *
+   * @param connectionHandler    - Connection handler used by client's to know about success/failure conditions.
    * @param serverAuthMechanisms - List of auth mechanisms configured on server side
    */
   protected abstract void prepareSaslHandshake(final RpcConnectionHandler<CC> connectionHandler,
@@ -217,11 +310,12 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
    * after regular RPC handshake that authentication is required by server side. Once authentication is completed
    * then only the underlying channel is made available to clients to send other RPC messages. Success and failure
    * events are notified to the connection handler on which client waits.
+   *
    * @param connectionHandler - Connection handler used by client's to know about success/failure conditions.
-   * @param saslProperties - SASL related properties needed to create SASL client.
-   * @param ugi - UserGroupInformation with logged in client side user
-   * @param authFactory - Authentication factory to use for this SASL handshake.
-   * @param rpcType - SASL_MESSAGE rpc type.
+   * @param saslProperties    - SASL related properties needed to create SASL client.
+   * @param ugi               - UserGroupInformation with logged in client side user
+   * @param authFactory       - Authentication factory to use for this SASL handshake.
+   * @param rpcType           - SASL_MESSAGE rpc type.
    */
   protected void startSaslHandshake(final RpcConnectionHandler<CC> connectionHandler,
                                     Map<String, ?> saslProperties, UserGroupInformation ugi,
@@ -245,22 +339,22 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
     logger.debug("Initiating SASL exchange.");
     new AuthenticationOutcomeListener<>(this, connection, rpcType, ugi,
       new RpcOutcomeListener<Void>() {
-      @Override
-      public void failed(RpcException ex) {
-        connectionHandler.connectionFailed(RpcConnectionHandler.FailureType.AUTHENTICATION, ex);
-      }
+        @Override
+        public void failed(RpcException ex) {
+          connectionHandler.connectionFailed(RpcConnectionHandler.FailureType.AUTHENTICATION, ex);
+        }
 
-      @Override
-      public void success(Void value, ByteBuf buffer) {
-        authComplete = true;
-        connectionHandler.connectionSucceeded(connection);
-      }
+        @Override
+        public void success(Void value, ByteBuf buffer) {
+          authComplete = true;
+          connectionHandler.connectionSucceeded(connection);
+        }
 
-      @Override
-      public void interrupted(InterruptedException ex) {
-        connectionHandler.connectionFailed(RpcConnectionHandler.FailureType.AUTHENTICATION, ex);
-      }
-    }).initiate(mechanismName);
+        @Override
+        public void interrupted(InterruptedException ex) {
+          connectionHandler.connectionFailed(RpcConnectionHandler.FailureType.AUTHENTICATION, ex);
+        }
+      }).initiate(mechanismName);
   }
 
   protected void finalizeConnection(HR handshake, CC connection) {
@@ -280,16 +374,16 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
 
   public <SEND extends MessageLite, RECEIVE extends MessageLite>
   void send(RpcOutcomeListener<RECEIVE> listener, SEND protobufBody, boolean allowInEventLoop,
-      ByteBuf... dataBodies) {
+            ByteBuf... dataBodies) {
     super.send(listener, connection, handshakeType, protobufBody, (Class<RECEIVE>) responseClass,
-        allowInEventLoop, dataBodies);
+      allowInEventLoop, dataBodies);
   }
 
   protected void connectAsClient(RpcConnectionHandler<CC> connectionListener, HS handshakeValue,
                                  String host, int port) {
     ConnectionMultiListener<T, CC, HS, HR, BasicClient<T, CC, HS, HR>> cml;
-    ConnectionMultiListener.Builder<T, CC, HS, HR, BasicClient<T, CC, HS, HR> > builder =
-        ConnectionMultiListener.newBuilder(connectionListener, handshakeValue, this);
+    ConnectionMultiListener.Builder<T, CC, HS, HR, BasicClient<T, CC, HS, HR>> builder =
+      ConnectionMultiListener.newBuilder(connectionListener, handshakeValue, this);
     if (isSslEnabled()) {
       cml = builder.enableSSL().build();
       sslHandshakeListener = new ConnectionMultiListener.SSLHandshakeListener();
@@ -314,7 +408,7 @@ public abstract class BasicClient<T extends EnumLite, CC extends ClientConnectio
     protected final void consumeHandshake(ChannelHandlerContext ctx, HR msg) throws Exception {
       // remove the handshake information from the queue so it doesn't sit there forever.
       final RpcOutcome<HR> response =
-          connection.getAndRemoveRpcOutcome(handshakeType.getNumber(), coordinationId, responseClass);
+        connection.getAndRemoveRpcOutcome(handshakeType.getNumber(), coordinationId, responseClass);
       response.set(msg, null);
     }
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.exec.rpc;
 
+import com.google.protobuf.Internal.EnumLite;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Parser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.Channel;
@@ -26,6 +30,11 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.proto.GeneralRPCProtos.RpcMode;
+import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
@@ -33,17 +42,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.proto.GeneralRPCProtos.RpcMode;
-import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
-
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
-import com.google.protobuf.Internal.EnumLite;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.MessageLite;
-import com.google.protobuf.Parser;
 
 /**
  * The Rpc Bus deals with incoming and outgoing communication and is used on both the server and the client side of a
@@ -252,7 +250,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
 
     @Override
     protected void decode(final ChannelHandlerContext ctx, final InboundRpcMessage msg, final List<Object> output)
-        throws Exception {
+            throws Exception {
       if (!ctx.channel().isOpen()) {
         return;
       }
@@ -318,7 +316,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
           break;
 
         case PONG:
-          // noop.
+          ctx.fireUserEventTriggered(RpcMode.PONG);
           break;
 
         default:

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcConstants.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcConstants.java
@@ -34,6 +34,7 @@ public class RpcConstants {
   public static final String MESSAGE_HANDLER = "message-handler";
   public static final String EXCEPTION_HANDLER = "exception-handler";
   public static final String IDLE_STATE_HANDLER = "idle-state-handler";
+  public static final String HEARTBEAT_HANDLER = "heartbeat-handler";
   public static final String SASL_DECRYPTION_HANDLER = "sasl-decryption-handler";
   public static final String SASL_ENCRYPTION_HANDLER = "sasl-encryption-handler";
   public static final String LENGTH_DECODER_HANDLER = "length-decoder";


### PR DESCRIPTION
# [DRILL-8009](https://issues.apache.org/jira/browse/DRILL-8009): DrillConnectionImpl#isValid() doesn't correspond JDBC API

## Description

I've add ping function which send message with [RpcMode.PING](http://drill.apache.org/apidocs/org/apache/drill/exec/proto/GeneralRPCProtos.RpcMode.html#PING) to drillbit and after that waits for a response message with [RpcMode.PONG](drill.apache.org/apidocs/org/apache/drill/exec/proto/GeneralRPCProtos.RpcMode.html#PONG). This method is used to validate connection. I add this verification to [DrillConnectionImpl#isValid(int timeout)](https://github.com/apache/drill/blob/5f5ae89392471d237605c0b5e1a337e5bc0e10ff/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillConnectionImpl.java#L522) as it is required by JDBC API [documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Connection.html#isValid(int)) and gives opportunity accurately validate connection:

>  The driver shall submit a query on the connection or use some other mechanism that positively verifies the connection is still valid when this method is called

Also, I've add to [DrillConnectionImpl#isValid(int timeout)](https://github.com/apache/drill/blob/5f5ae89392471d237605c0b5e1a337e5bc0e10ff/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillConnectionImpl.java#L522) simple check for [channel#isActive()](https://netty.io/4.1/api/io/netty/channel/Channel.html#isActive--).

[Previously, in Drill](https://github.com/apache/drill/commit/960f876a1945eee4eeb0d6a98c5c58dfe2eea1a9) were add `PING` and `PONG` RpcMode's, but they was primarily used for "hearbeat" function — to let drillbit know, that connection with client is still alive and now I also used it for client verification of connection to drillbit.

I've used listener pattern for checking whether client got `PONG` answer or not. If you think, that this realization is not best, I have ideas how it can be implemented in other, more "netty's" way.

## Documentation
No doc impact

## Testing
Manual tests with cases:
* server (drillbit) closes connection
* server (drillbit) shut down
* server (drillbit) process has been killed
* client (jdbc) lost network connection
* client (jdbc) temporary lost connection and restored it until JDBC's ping timeout has been elapsed. 
