### PR TITLE
[MINOR FIX]: Fix API Config Variable. 

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
@@ -159,7 +159,7 @@ public class HttpApiConfig {
     this.requireTail = builder.requireTail;
 
     // Default to true for backward compatibility, and better security practices
-    this.verifySSLCert = builder().verifySSLCert();
+    this.verifySSLCert = builder.verifySSLCert;
 
     this.inputType = builder.inputType.trim().toLowerCase();
 


### PR DESCRIPTION
## Description
This is a minor fix.  The lombok builder prevented a user from changing the `verifySSLCert` parameter in the REST API Storage Plugin. 

## Testing
Manually Tested