### PR TITLE
DRILL-8014: Bump Calcite to 1.21.0r5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       avoid_bad_dependencies plugin found in the file.
     -->
     <calcite.groupId>com.github.vvysotskyi.drill-calcite</calcite.groupId>
-    <calcite.version>1.21.0-drill-r4</calcite.version>
+    <calcite.version>1.21.0-drill-r5</calcite.version>
     <avatica.version>1.17.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.9.0</sqlline.version>


### PR DESCRIPTION
# [DRILL-8014](https://issues.apache.org/jira/browse/DRILL-8014): Bump Calcite to 1.21.0r5

## Description
Bump Calcite to 1.21.0 r5.  Includes some minor bug fixes.

## Documentation
N/A

## Testing
Ran unit tests.