### PR TITLE
DRILL-8017: Fix LGTM Issues Relating to Equals and HashCode Functions

### DIFF
--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPluginConfig.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/TableFormatPluginConfig.java
@@ -20,7 +20,7 @@ package org.apache.drill.exec.store.mapr;
 import org.apache.drill.common.logical.FormatPluginConfig;
 
 public abstract class TableFormatPluginConfig implements FormatPluginConfig {
-
+  //lgtm [java/inconsistent-equals-and-hashcode]
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPluginConfig.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPluginConfig.java
@@ -54,6 +54,36 @@ public class MapRDBFormatPluginConfig extends TableFormatPluginConfig {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    MapRDBFormatPluginConfig other = (MapRDBFormatPluginConfig) obj;
+    if (readAllNumbersAsDouble != other.readAllNumbersAsDouble) {
+      return false;
+    } else if (allTextMode != other.allTextMode) {
+      return false;
+    } else if (ignoreSchemaChange != other.ignoreSchemaChange) {
+      return false;
+    } else if (enablePushdown != other.enablePushdown) {
+      return false;
+    } else if (disableCountOptimization != other.disableCountOptimization) {
+      return false;
+    } else if (nonExistentFieldSupport != other.nonExistentFieldSupport) {
+      return false;
+    } else if (!index.equals(other.index)) {
+      return false;
+    } else if (readTimestampWithZoneOffset != other.readTimestampWithZoneOffset) {
+      return false;
+    }
+    return true;
+  }
+
+
+  @Override
   protected boolean impEquals(Object obj) {
     MapRDBFormatPluginConfig other = (MapRDBFormatPluginConfig) obj;
     if (readAllNumbersAsDouble != other.readAllNumbersAsDouble) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableRangePartitionFunction.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableRangePartitionFunction.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.mapr.db.json;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.exec.planner.physical.AbstractRangePartitionFunction;
@@ -104,6 +105,11 @@ public class JsonTableRangePartitionFunction extends AbstractRangePartitionFunct
     partitionKeyVector = v.getValueVector();
 
     Preconditions.checkArgument(partitionKeyVector != null, "Found null partitionKeVector.");
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refList, tableName, userName, partitionKeyVector, startKeys, stopKeys);
   }
 
   @Override

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/streams/StreamsFormatPluginConfig.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/streams/StreamsFormatPluginConfig.java
@@ -32,6 +32,16 @@ public class StreamsFormatPluginConfig extends TableFormatPluginConfig {
   }
 
   @Override
+  public boolean equals(Object that) {
+    if (this == that) {
+      return true;
+    } else if (that == null || getClass() != that.getClass()) {
+      return false;
+    }
+    return impEquals(that);
+  }
+
+  @Override
   protected boolean impEquals(Object obj) {
     return true; // TODO: compare custom properties once added
   }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java
@@ -21,6 +21,9 @@ import org.apache.drill.common.FunctionNames;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.drill.common.PlanStringBuilder;
+
+import java.util.Objects;
 
 public class KafkaPartitionScanSpec {
   private final String topicName;
@@ -91,9 +94,18 @@ public class KafkaPartitionScanSpec {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(topicName, partitionId, startOffset, endOffset);
+  }
+
+  @Override
   public String toString() {
-    return "KafkaPartitionScanSpec [topicName=" + topicName + ", partitionId=" + partitionId + ", startOffset="
-               + startOffset + ", endOffset=" + endOffset + "]";
+    return new PlanStringBuilder(this)
+      .field("topicName", topicName)
+      .field("partitionId", partitionId)
+      .field("startOffset", startOffset)
+      .field("endOffset", endOffset)
+      .toString();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillCostBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillCostBase.java
@@ -19,7 +19,8 @@ package org.apache.drill.exec.planner.cost;
 
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptUtil;
-import org.apache.calcite.runtime.Utilities;
+
+import java.util.Objects;
 
 /**
  * Implementation of the DrillRelOptCost, modeled similar to VolcanoCost
@@ -159,8 +160,21 @@ public class DrillCostBase implements DrillRelOptCost {
 
   @Override
   public int hashCode() {
-    return Utilities.hashCode(rowCount) + Utilities.hashCode(cpu)
-        + Utilities.hashCode(io) + Utilities.hashCode(network);
+    return Objects.hash(rowCount, cpu, io, network);
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (this == that) {
+      return true;
+    } else if (that == null || getClass() != that.getClass()) {
+      return false;
+    }
+    DrillCostBase thatConfig = (DrillCostBase) that;
+    return Objects.equals(rowCount, thatConfig.rowCount) &&
+      Objects.equals(cpu, thatConfig.cpu) &&
+      Objects.equals(io, thatConfig.io) &&
+      Objects.equals(network, thatConfig.network);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/DrillIndexDefinition.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/DrillIndexDefinition.java
@@ -198,10 +198,10 @@ public class DrillIndexDefinition implements IndexDefinition {
   public boolean equals(Object o) {
     if (this == o) {
       return true;
-    }
-    if (o == null) {
+    }  else if (o == null || getClass() != o.getClass()) {
       return false;
     }
+
     DrillIndexDefinition index1 = (DrillIndexDefinition) o;
     return tableName.equals(index1.tableName)
         && indexName.equals(index1.indexName)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/StoragePlugins.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/StoragePlugins.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -88,6 +89,11 @@ public class StoragePlugins implements Iterable<Map.Entry<String, StoragePluginC
       return false;
     }
     return storage.equals(((StoragePlugins) obj).getStorage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(storage);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/DeadBuf.java
@@ -917,7 +917,7 @@ public class DeadBuf extends ByteBuf {
   }
 
   @Override
-  public boolean equals(Object arg0) {
+  public boolean equals(Object arg0) { //lgtm [java/unchecked-cast-in-equals]
     return false;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/schema/Field.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/schema/Field.java
@@ -22,6 +22,8 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.shaded.guava.com.google.common.base.MoreObjects;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 
+import java.util.Objects;
+
 public abstract class Field {
   final String prefixFieldName;
   MajorType fieldType;
@@ -89,6 +91,17 @@ public abstract class Field {
 
   public void setFieldType(MajorType fieldType) {
     this.fieldType = fieldType;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (this == that) {
+      return true;
+    } else if (that == null || getClass() != that.getClass()) {
+      return false;
+    }
+    Field thatField = (Field)that;
+    return Objects.equals(getFullFieldName(), thatField.getFullFieldName());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatField.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatField.java
@@ -80,4 +80,9 @@ public class LogFormatField {
            Objects.equals(fieldType, other.fieldType) &&
            Objects.equals(format, other.format);
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fieldName, fieldType, format);
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractPropertied.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractPropertied.java
@@ -120,7 +120,7 @@ public class AbstractPropertied implements Propertied {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(Object o) { //lgtm [java/unchecked-cast-in-equals]
     if (o == this) {
       return true;
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
@@ -24,10 +24,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.drill.exec.record.MaterializedField;
 
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -170,6 +172,11 @@ public class TupleSchema extends AbstractPropertied implements TupleMetadata {
       return false;
     }
     return isEquivalent((TupleMetadata) o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(parentMap, nameSpace);
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringArrayList.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringArrayList.java
@@ -19,12 +19,11 @@ package org.apache.drill.exec.util;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonStringArrayList<E> extends ArrayList<E> {
-
+//lgtm [java/inconsistent-equals-and-hashcode]
   private static ObjectMapper mapper;
 
   static {

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringHashMap.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringHashMap.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
  * toString() method of the HashMap class to produce a JSON string instead
  */
 public class JsonStringHashMap<K, V> extends LinkedHashMap<K, V> {
-
+  // lgtm [java/inconsistent-equals-and-hashcode]
   private static final ObjectMapper mapper = new ObjectMapper()
       .registerModule(SerializationModule.getModule())
       .registerModule(new JodaModule());

--- a/logical/src/main/java/org/apache/drill/common/graph/AdjacencyList.java
+++ b/logical/src/main/java/org/apache/drill/common/graph/AdjacencyList.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.common.graph;
 
+import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimaps;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,11 +28,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
-import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
-import org.apache.drill.shaded.guava.com.google.common.collect.Multimaps;
 
 class AdjacencyList<V extends GraphValue<V>> {
   private Set<Node> allNodes = new HashSet<Node>();
@@ -165,6 +167,16 @@ class AdjacencyList<V extends GraphValue<V>> {
     @Override
     public int hashCode() {
       return nodeValue.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (this == that) {
+        return true;
+      } else if (that == null || getClass() != that.getClass()) {
+        return false;
+      }
+      return Objects.equals(nodeValue, ((Node) that).getNodeValue());
     }
 
     public V getNodeValue() {

--- a/logical/src/main/java/org/apache/drill/common/logical/data/LogicalOperatorBase.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/LogicalOperatorBase.java
@@ -41,6 +41,11 @@ public abstract class LogicalOperatorBase implements LogicalOperator{
   }
 
   @Override
+  public boolean equals(Object obj) {
+    return super.equals(obj);
+  }
+
+  @Override
   public void setupAndValidate(List<LogicalOperator> operators, Collection<ValidationError> errors) {
     // TODO: remove this and implement individually.
   }


### PR DESCRIPTION
# [DRILL-8017](https://issues.apache.org/jira/browse/DRILL-8017): Fix LGTM Issues Relating to Equals and HashCode Functions

## Description
This PR addresses the LGTM alerts relating to missing `equals` or `hashcode` functions in various classes.

## Documentation
N/A

## Testing
Ran standard unit tests