### PR TITLE
DRILL-8018: Bump Splunk SDK to version 1.7.1

### DIFF
--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.splunk</groupId>
       <artifactId>splunk</artifactId>
-      <version>1.6.5.0</version>
+      <version>1.7.1</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
# [DRILL-8018](https://issues.apache.org/jira/browse/DRILL-8018): Bump Splunk SDK to version 1.7.1

## Description
Bump Splunk SDK to latest version. 

## Documentation
No user facing changes.

## Testing
N/A