### PR TITLE
DRILL-8024: Bump Mongo client and Testcontainers version to latest

### DIFF
--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -45,7 +45,7 @@
   <dependency>
     <groupId>org.mongodb</groupId>
     <artifactId>mongodb-driver-sync</artifactId>
-    <version>4.3.1</version>
+    <version>4.3.3</version>
   </dependency>
 
     <!-- Test dependency -->

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuite.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuite.java
@@ -96,7 +96,7 @@ public class MongoTestSuite extends BaseTest implements MongoTestConstants {
   }
 
   private static GenericContainer<?> newContainer(Network network, String host) {
-    GenericContainer<?> container = new GenericContainer<>("mongo:4.4.5")
+    GenericContainer<?> container = new GenericContainer<>("mongo:4.4.10")
         .withNetwork(network)
         .withNetworkAliases(host)
         .withExposedPorts(MONGOS_PORT)
@@ -115,7 +115,7 @@ public class MongoTestSuite extends BaseTest implements MongoTestConstants {
           .collect(Collectors.toList());
 
       String configServerHost = "m4";
-      GenericContainer<?> configServer = new GenericContainer<>("mongo:4.4.5")
+      GenericContainer<?> configServer = new GenericContainer<>("mongo:4.4.10")
           .withNetwork(network)
           .withNetworkAliases(configServerHost)
           .withExposedPorts(MONGOS_PORT)
@@ -129,7 +129,7 @@ public class MongoTestSuite extends BaseTest implements MongoTestConstants {
       logger.info(execResult.toString());
 
       String mongosHost = "m5";
-      GenericContainer<?> mongos = new GenericContainer<>("mongo:4.4.5")
+      GenericContainer<?> mongos = new GenericContainer<>("mongo:4.4.10")
           .withNetwork(network)
           .withNetworkAliases(mongosHost)
           .withExposedPorts(MONGOS_PORT)
@@ -192,7 +192,7 @@ public class MongoTestSuite extends BaseTest implements MongoTestConstants {
 
     @Override
     public String setup() throws IOException {
-      mongoContainers = Collections.singletonList(new GenericContainer<>("mongo:4.4.5")
+      mongoContainers = Collections.singletonList(new GenericContainer<>("mongo:4.4.10")
           .withNetwork(Network.SHARED)
           .withNetworkAliases("M1")
           .withExposedPorts(MONGOS_PORT)

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <commons.cli.version>1.4</commons.cli.version>
     <snakeyaml.version>1.26</snakeyaml.version>
     <commons.lang3.version>3.10</commons.lang3.version>
-    <testcontainers.version>1.15.3</testcontainers.version>
+    <testcontainers.version>1.16.2</testcontainers.version>
     <typesafe.config.version>1.0.0</typesafe.config.version>
     <commons.codec.version>1.14</commons.codec.version>
     <metadata.extractor.version>2.13.0</metadata.extractor.version>


### PR DESCRIPTION
# [DRILL-8024](https://issues.apache.org/jira/browse/DRILL-8024): Bump Mongo client and Testcontainers version to latest

## Description
In the MongoDB, upgrade the client from 4.3.1 to 4.3.3 and mongo container from 4.4.5 to 4.4.10.
In the Testcontainers, the 1.16 release brings many small fixes and improvements :
1. Better M1 Mac compatibility.
2. Startup performance and reliability improvements.
3. See also [What's Changed](https://github.com/testcontainers/testcontainers-java/releases/tag/1.16.0)

## Documentation
N/A

## Testing
N/A
