### PR TITLE
DRILL-8027: Format plugin for Apache Iceberg

### DIFF
--- a/contrib/format-iceberg/README.md
+++ b/contrib/format-iceberg/README.md
@@ -16,7 +16,7 @@ For details related to Apache Iceberg table format, please refer to [official do
 
 This format plugin supports project and filter pushdown optimizations.
 
-For the case of project pushdown, only specified in the query columns will be read, even if it is a nested column. In
+For the case of project pushdown, only columns specified in the query will be read, even they are nested columns. In
 conjunction with column-oriented formats like Parquet or ORC, it allows improving reading performance significantly.
 
 ### Filter pushdown
@@ -62,10 +62,10 @@ FROM dfs.tmp.`testAllTypes#snapshots`
 
 ### Querying specific table versions (snapshots)
 
-Apache Icebergs has the ability to track the table modifications and read specific version before or after modifications
+Apache Iceberg has the ability to track the table modifications and read specific version before or after modifications
 or modifications itself.
 
-This storage plugin embraces this ability and provides an easy-to-use way of triggering it.
+This format plugin embraces this ability and provides an easy-to-use way of triggering it.
 
 The following ways of specifying table version are supported:
 

--- a/contrib/format-iceberg/README.md
+++ b/contrib/format-iceberg/README.md
@@ -1,0 +1,117 @@
+# Apache Iceberg format plugin
+
+This format plugin enabled Drill to query Apache Iceberg tables.
+
+Unlike regular format plugins, the Iceberg table is a folder with data and metadata files, but Drill checks the presence
+of the `metadata` folder to ensure that the table is Iceberg one.
+
+Drill supports reading all formats of Iceberg tables available at this moment: Parquet, Avro, and ORC.
+No need to provide actual table format, it will be discovered automatically.
+
+For details related to Apache Iceberg table format, please refer to [official docs](https://iceberg.apache.org/#).
+
+## Supported optimizations and features
+
+### Project pushdown
+
+This format plugin supports project and filter pushdown optimizations.
+
+For the case of project pushdown, only specified in the query columns will be read, even if it is a nested column. In
+conjunction with column-oriented formats like Parquet or ORC, it allows improving reading performance significantly.
+
+### Filter pushdown
+
+For the case of filter pushdown, all expressions supported by Iceberg API will be pushed down, so only data that matches
+the filter expression will be read.
+
+### Schema provisioning
+
+This format plugin supports the schema provisioning feature. Though Iceberg provides table schema, in some cases, it
+might be useful to select data with customized schema, so it can be done using the table function:
+
+```sql
+SELECT int_field,
+       string_field
+FROM table(dfs.tmp.testAllTypes(schema => 'inline=(int_field varchar not null default `error`)'))
+```
+
+In this example, we convert int field to string and return `'error'` literals for null values.
+
+### Querying table metadata
+
+Apache Drill provides the ability to query any kind of table metadata Iceberg can return.
+
+At this point, Apache Iceberg has the following metadata kinds:
+
+* ENTRIES
+* FILES
+* HISTORY
+* SNAPSHOTS
+* MANIFESTS
+* PARTITIONS
+* ALL_DATA_FILES
+* ALL_MANIFESTS
+* ALL_ENTRIES
+
+To query specific metadata, just add the `#metadata_name` suffix to the table location, like in the following example:
+
+```sql
+SELECT *
+FROM dfs.tmp.`testAllTypes#snapshots`
+```
+
+### Querying specific table versions (snapshots)
+
+Apache Icebergs has the ability to track the table modifications and read specific version before or after modifications
+or modifications itself.
+
+This storage plugin embraces this ability and provides an easy-to-use way of triggering it.
+
+The following ways of specifying table version are supported:
+
+- `snapshotId` - id of the specific snapshot
+- `snapshotAsOfTime` - the most recent snapshot as of the given time in milliseconds
+- `fromSnapshotId` - read appended data from `fromSnapshotId` exclusive to the current snapshot inclusive
+- \[`fromSnapshotId` : `toSnapshotId`\] - read appended data from `fromSnapshotId` exclusive to `toSnapshotId` inclusive
+
+Table function can be used to specify one of the above configs in the following way:
+
+```sql
+SELECT *
+FROM table(dfs.tmp.testAllTypes(type => 'iceberg', snapshotId => 123456789));
+
+SELECT *
+FROM table(dfs.tmp.testAllTypes(type => 'iceberg', snapshotAsOfTime => 1636231332000));
+
+SELECT *
+FROM table(dfs.tmp.testAllTypes(type => 'iceberg', fromSnapshotId => 123456789));
+
+SELECT *
+FROM table(dfs.tmp.testAllTypes(type => 'iceberg', fromSnapshotId => 123456789, toSnapshotId => 987654321));
+```
+
+## Configuration
+
+Format plugin has the following configuration options:
+
+- `type` - format plugin type, should be `'iceberg'`
+- `properties` - Iceberg-specific table properties. Please refer to [Configuration](https://iceberg.apache.org/#configuration/) page for more details
+- `caseSensitive` - whether table columns are case-sensitive
+
+### Format config example:
+
+```json
+{
+  "type": "file",
+  "formats": {
+    "iceberg": {
+      "type": "iceberg",
+      "properties": {
+        "read.split.target-size": "134217728",
+        "read.split.metadata-target-size": "33554432"
+      },
+      "caseSensitive": true
+    }
+  }
+}
+```

--- a/contrib/format-iceberg/pom.xml
+++ b/contrib/format-iceberg/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>drill-contrib-parent</artifactId>
+    <groupId>org.apache.drill.contrib</groupId>
+    <version>1.20.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>drill-iceberg-format</artifactId>
+
+  <name>Drill : Contrib : Format : Iceberg</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.drill.exec</groupId>
+      <artifactId>drill-java-exec</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-parquet</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-orc</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-data</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-core</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-common</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-api</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+
+    <!-- Test dependency -->
+    <dependency>
+      <groupId>org.apache.drill.exec</groupId>
+      <artifactId>drill-java-exec</artifactId>
+      <classifier>tests</classifier>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.drill</groupId>
+      <artifactId>drill-common</artifactId>
+      <classifier>tests</classifier>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergBlockMapBuilder.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergBlockMapBuilder.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.store.TimedCallable;
+import org.apache.drill.exec.store.schedule.EndpointByteMap;
+import org.apache.drill.exec.store.schedule.EndpointByteMapImpl;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableRangeMap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Range;
+import org.apache.drill.shaded.guava.com.google.common.collect.RangeMap;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseCombinedScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileScanTask;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class IcebergBlockMapBuilder {
+
+  private final Map<FileScanTask, RangeMap<Long, BlockLocation>> blockMapMap;
+
+  private final Map<String, DrillbitEndpoint> endPointMap;
+
+  private final FileSystem fs;
+
+  public IcebergBlockMapBuilder(FileSystem fs, Collection<DrillbitEndpoint> endpoints) {
+    this.fs = fs;
+    this.blockMapMap = new ConcurrentHashMap<>();
+    this.endPointMap = endpoints.stream()
+      .collect(Collectors.toMap(DrillbitEndpoint::getAddress, endpoint -> endpoint, (a, b) -> b));
+  }
+
+  public List<IcebergCompleteWork> generateFileWork(Iterable<CombinedScanTask> combinedScanTasks) throws IOException {
+    List<TimedCallable<IcebergCompleteWork>> readers = new ArrayList<>();
+    combinedScanTasks.forEach(task -> readers.add(new BlockMapReader(task)));
+
+    if (readers.isEmpty()) {
+      readers.add(new BlockMapReader(new BaseCombinedScanTask()));
+    }
+
+    return TimedCallable.run("Get block maps", logger, readers, 16);
+  }
+
+  /**
+   * Builds a mapping of block locations to file byte range
+   */
+  private RangeMap<Long, BlockLocation> buildBlockMap(FileScanTask work) throws IOException {
+    BlockLocation[] blocks = fs.getFileBlockLocations(
+      new Path(work.file().path().toString()), work.start(), work.length());
+    ImmutableRangeMap.Builder<Long, BlockLocation> blockMapBuilder = new ImmutableRangeMap.Builder<>();
+    for (BlockLocation block : blocks) {
+      long start = block.getOffset();
+      long end = start + block.getLength();
+      Range<Long> range = Range.closedOpen(start, end);
+      blockMapBuilder.put(range, block);
+    }
+    RangeMap<Long, BlockLocation> blockMap = blockMapBuilder.build();
+    blockMapMap.put(work, blockMap);
+    return blockMap;
+  }
+
+  private RangeMap<Long, BlockLocation> getBlockMap(FileScanTask work) throws IOException {
+    RangeMap<Long, BlockLocation> blockMap = blockMapMap.get(work);
+    if (blockMap == null) {
+      blockMap = buildBlockMap(work);
+    }
+    return blockMap;
+  }
+
+  /**
+   * For a given FileWork, calculate how many bytes are available on each on drillbit endpoint
+   *
+   * @param scanTask the CombinedScanTask to calculate endpoint bytes for
+   */
+  public EndpointByteMap getEndpointByteMap(CombinedScanTask scanTask) throws IOException {
+    EndpointByteMapImpl endpointByteMap = new EndpointByteMapImpl();
+    for (FileScanTask work : scanTask.files()) {
+      RangeMap<Long, BlockLocation> blockMap = getBlockMap(work);
+      long start = work.start();
+      long end = start + work.length();
+      Range<Long> scanTaskRange = Range.closedOpen(start, end);
+
+      // Find sub-map of ranges that intersect with the scan task
+      RangeMap<Long, BlockLocation> subRangeMap = blockMap.subRangeMap(scanTaskRange);
+
+      // Iterate through each block in this sub-map and get the host for the block location
+      for (Entry<Range<Long>, BlockLocation> block : subRangeMap.asMapOfRanges().entrySet()) {
+        Range<Long> intersection = scanTaskRange.intersection(block.getKey());
+        long bytes = intersection.upperEndpoint() - intersection.lowerEndpoint();
+
+        // For each host in the current block location, add the intersecting bytes to the corresponding endpoint
+        for (String host : block.getValue().getHosts()) {
+          DrillbitEndpoint endpoint = endPointMap.get(host);
+          if (endpoint != null) {
+            endpointByteMap.add(endpoint, bytes);
+          }
+        }
+      }
+
+      logger.debug("FileScanTask group ({},{}) max bytes {}", work.file().path(), work.start(), endpointByteMap.getMaxBytes());
+    }
+    return endpointByteMap;
+  }
+
+  private class BlockMapReader extends TimedCallable<IcebergCompleteWork> {
+    private final CombinedScanTask scanTask;
+
+    public BlockMapReader(CombinedScanTask scanTask) {
+      this.scanTask = scanTask;
+    }
+
+    @Override
+    protected IcebergCompleteWork runInner() throws Exception {
+      return new IcebergCompleteWork(getEndpointByteMap(scanTask), scanTask);
+    }
+  }
+
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergCompleteWork.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergCompleteWork.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg;
+
+import org.apache.drill.exec.store.schedule.CompleteWork;
+import org.apache.drill.exec.store.schedule.EndpointByteMap;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileScanTask;
+
+public class IcebergCompleteWork implements CompleteWork {
+  private final EndpointByteMap byteMap;
+
+  private final CombinedScanTask scanTask;
+
+  private final long totalBytes;
+
+  public IcebergCompleteWork(
+    EndpointByteMap byteMap,
+    CombinedScanTask scanTask) {
+    this.byteMap = byteMap;
+    this.scanTask = scanTask;
+    this.totalBytes = scanTask.files().stream()
+      .mapToLong(FileScanTask::length)
+      .sum();
+  }
+
+  public CombinedScanTask getScanTask() {
+    return scanTask;
+  }
+
+  @Override
+  public long getTotalBytes() {
+    return totalBytes;
+  }
+
+  @Override
+  public EndpointByteMap getByteMap() {
+    return byteMap;
+  }
+
+  @Override
+  public int compareTo(CompleteWork o) {
+    return 0;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergGroupScan.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergGroupScan.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Builder;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.PathSegment;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.FormatPluginConfig;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.physical.EndpointAffinity;
+import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.ScanStats;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.iceberg.format.IcebergFormatPlugin;
+import org.apache.drill.exec.store.iceberg.plan.DrillExprToIcebergTranslator;
+import org.apache.drill.exec.store.iceberg.snapshot.Snapshot;
+import org.apache.drill.exec.store.schedule.AffinityCreator;
+import org.apache.drill.exec.store.schedule.AssignmentCreator;
+import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.hadoop.HadoopTables;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@JsonTypeName("iceberg-scan")
+@SuppressWarnings("unused")
+public class IcebergGroupScan extends AbstractGroupScan {
+
+  private final IcebergFormatPlugin formatPlugin;
+
+  private final String path;
+
+  private final TupleMetadata schema;
+
+  private final LogicalExpression condition;
+
+  private final DrillFileSystem fs;
+
+  private final List<SchemaPath> columns;
+
+  private int maxRecords;
+
+  private List<IcebergCompleteWork> chunks;
+
+  private TableScan tableScan;
+
+  private List<EndpointAffinity> endpointAffinities;
+
+  private ListMultimap<Integer, IcebergCompleteWork> mappings;
+
+  @JsonCreator
+  public IcebergGroupScan(
+      @JsonProperty("userName") String userName,
+      @JsonProperty("storage") StoragePluginConfig storageConfig,
+      @JsonProperty("format") FormatPluginConfig formatConfig,
+      @JsonProperty("columns") List<SchemaPath> columns,
+      @JsonProperty("schema") TupleMetadata schema,
+      @JsonProperty("path") String path,
+      @JsonProperty("condition") LogicalExpression condition,
+      @JsonProperty("maxRecords") Integer maxRecords,
+      @JacksonInject StoragePluginRegistry pluginRegistry) {
+    this(userName,
+        pluginRegistry.resolveFormat(storageConfig, formatConfig, IcebergFormatPlugin.class),
+        schema, path, condition, columns, maxRecords);
+  }
+
+  @Builder(toBuilder = true)
+  private IcebergGroupScan(String userName, IcebergFormatPlugin formatPlugin,
+    TupleMetadata schema, String path, LogicalExpression condition, List<SchemaPath> columns, int maxRecords) {
+    super(userName);
+    this.formatPlugin = formatPlugin;
+    this.columns = columns;
+    this.path = path;
+    this.schema = schema;
+    this.condition = condition;
+    this.maxRecords = maxRecords;
+    this.fs = ImpersonationUtil.createFileSystem(ImpersonationUtil.resolveUserName(userName), formatPlugin.getFsConf());
+    this.tableScan = initTableScan(formatPlugin, path, condition);
+
+    init();
+  }
+
+  public static TableScan initTableScan(IcebergFormatPlugin formatPlugin, String path, LogicalExpression condition) {
+    TableScan tableScan = new HadoopTables(formatPlugin.getFsConf()).load(path).newScan();
+    Map<String, String> properties = formatPlugin.getConfig().getProperties();
+    if (properties != null) {
+      for (Map.Entry<String, String> entry : properties.entrySet()) {
+        tableScan = tableScan.option(entry.getKey(), entry.getValue());
+      }
+    }
+    if (condition != null) {
+      Expression expression = condition.accept(
+        DrillExprToIcebergTranslator.INSTANCE, null);
+      tableScan = tableScan.filter(expression);
+    }
+    Snapshot snapshot = formatPlugin.getConfig().getSnapshot();
+    if (snapshot != null) {
+      tableScan = snapshot.apply(tableScan);
+    }
+    Boolean caseSensitive = formatPlugin.getConfig().getCaseSensitive();
+    if (caseSensitive != null) {
+      tableScan = tableScan.caseSensitive(caseSensitive);
+    }
+    Boolean includeColumnStats = formatPlugin.getConfig().getIncludeColumnStats();
+    if (includeColumnStats != null && includeColumnStats) {
+      tableScan = tableScan.includeColumnStats();
+    }
+    Boolean ignoreResiduals = formatPlugin.getConfig().getIgnoreResiduals();
+    if (ignoreResiduals != null && ignoreResiduals) {
+      tableScan = tableScan.ignoreResiduals();
+    }
+    return tableScan;
+  }
+
+  /**
+   * Private constructor, used for cloning.
+   *
+   * @param that The IcebergGroupScan to clone
+   */
+  private IcebergGroupScan(IcebergGroupScan that) {
+    super(that);
+    this.columns = that.columns;
+    this.formatPlugin = that.formatPlugin;
+    this.path = that.path;
+    this.condition = that.condition;
+    this.schema = that.schema;
+    this.mappings = that.mappings;
+    this.fs = that.fs;
+    this.maxRecords = that.maxRecords;
+    this.chunks = that.chunks;
+    this.tableScan = that.tableScan;
+    this.endpointAffinities = that.endpointAffinities;
+  }
+
+  @Override
+  public IcebergGroupScan clone(List<SchemaPath> columns) {
+    return toBuilder().columns(columns).build();
+  }
+
+  @Override
+  public IcebergGroupScan applyLimit(int maxRecords) {
+    IcebergGroupScan clone = new IcebergGroupScan(this);
+    clone.maxRecords = maxRecords;
+    return clone;
+  }
+
+  @Override
+  public void applyAssignments(List<DrillbitEndpoint> endpoints) {
+    mappings = AssignmentCreator.getMappings(endpoints, chunks);
+  }
+
+  private void createMappings(List<EndpointAffinity> affinities) {
+    List<DrillbitEndpoint> endpoints = affinities.stream()
+      .map(EndpointAffinity::getEndpoint)
+      .collect(Collectors.toList());
+    applyAssignments(endpoints);
+  }
+
+  @Override
+  public IcebergSubScan getSpecificScan(int minorFragmentId) {
+    if (mappings == null) {
+      createMappings(endpointAffinities);
+    }
+    assert minorFragmentId < mappings.size() : String.format(
+      "Mappings length [%d] should be longer than minor fragment id [%d] but it isn't.", mappings.size(),
+      minorFragmentId);
+
+    List<IcebergCompleteWork> workList = mappings.get(minorFragmentId);
+
+    Preconditions.checkArgument(!workList.isEmpty(),
+      String.format("MinorFragmentId %d has no read entries assigned", minorFragmentId));
+
+    IcebergSubScan subScan = IcebergSubScan.builder()
+      .userName(userName)
+      .formatPlugin(formatPlugin)
+      .columns(columns)
+      .condition(condition)
+      .schema(schema)
+      .workList(convertWorkList(workList))
+      .tableScan(tableScan)
+      .path(path)
+      .maxRecords(maxRecords)
+      .build();
+
+    subScan.setOperatorId(getOperatorId());
+    return subScan;
+  }
+
+  private List<IcebergWork> convertWorkList(List<IcebergCompleteWork> workList) {
+    return workList.stream()
+      .map(IcebergCompleteWork::getScanTask)
+      .map(IcebergWork::new)
+      .collect(Collectors.toList());
+  }
+
+  @JsonIgnore
+  public TableScan getTableScan() {
+    return tableScan;
+  }
+
+  @JsonProperty("maxRecords")
+  public int getMaxRecords() {
+    return maxRecords;
+  }
+
+  @Override
+  public int getMaxParallelizationWidth() {
+    return chunks.size();
+  }
+
+  @Override
+  public String getDigest() {
+    return toString();
+  }
+
+  @Override
+  public ScanStats getScanStats() {
+    int expectedRecordsPerChunk = 1_000_000;
+    if (maxRecords >= 0) {
+      expectedRecordsPerChunk = Math.max(maxRecords, 1);
+    }
+    int estimatedRecords = chunks.size() * expectedRecordsPerChunk;
+    return new ScanStats(ScanStats.GroupScanProperty.NO_EXACT_ROW_COUNT, estimatedRecords, 1, 0);
+  }
+
+  @Override
+  public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
+    Preconditions.checkArgument(children.isEmpty());
+    return new IcebergGroupScan(this);
+  }
+
+  @SneakyThrows
+  private void init() {
+    tableScan = projectColumns(tableScan, columns);
+    chunks = new IcebergBlockMapBuilder(fs, formatPlugin.getContext().getBits())
+      .generateFileWork(tableScan.planTasks());
+    endpointAffinities = AffinityCreator.getAffinityMap(chunks);
+  }
+
+  public static TableScan projectColumns(TableScan tableScan, List<SchemaPath> columns) {
+    boolean hasStar = columns.stream()
+      .anyMatch(SchemaPath::isDynamicStar);
+    if (!hasStar) {
+      List<String> projectColumns = columns.stream()
+        .map(IcebergGroupScan::getPath)
+        .collect(Collectors.toList());
+      return tableScan.select(projectColumns);
+    }
+    return tableScan;
+  }
+
+  public static String getPath(SchemaPath schemaPath) {
+    StringBuilder sb = new StringBuilder();
+    PathSegment segment = schemaPath.getRootSegment();
+    sb.append(segment.getNameSegment().getPath());
+
+    while ((segment = segment.getChild()) != null) {
+      sb.append('.')
+        .append(segment.isNamed()
+          ? segment.getNameSegment().getPath()
+          : "element");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public List<EndpointAffinity> getOperatorAffinity() {
+    if (endpointAffinities == null) {
+      logger.debug("Chunks size: {}", chunks.size());
+      endpointAffinities = AffinityCreator.getAffinityMap(chunks);
+    }
+    return endpointAffinities;
+  }
+
+  @Override
+  public boolean supportsLimitPushdown() {
+    return false;
+  }
+
+  @Override
+  @JsonProperty("columns")
+  public List<SchemaPath> getColumns() {
+    return columns;
+  }
+
+  @JsonProperty("schema")
+  public TupleMetadata getSchema() {
+    return schema;
+  }
+
+  @JsonProperty("storage")
+  public StoragePluginConfig getStorageConfig() {
+    return formatPlugin.getStorageConfig();
+  }
+
+  @JsonProperty("format")
+  public FormatPluginConfig getFormatConfig() {
+    return formatPlugin.getConfig();
+  }
+
+  @JsonProperty("path")
+  public String getPath() {
+    return path;
+  }
+
+  @JsonProperty("condition")
+  public LogicalExpression getCondition() {
+    return condition;
+  }
+
+  @JsonIgnore
+  public IcebergFormatPlugin getFormatPlugin() {
+    return formatPlugin;
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+      .field("path", path)
+      .field("schema", schema)
+      .field("columns", columns)
+      .field("tableScan", tableScan)
+      .field("maxRecords", maxRecords)
+      .toString();
+  }
+
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergSubScan.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergSubScan.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Builder;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.FormatPluginConfig;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.physical.base.AbstractBase;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.PhysicalVisitor;
+import org.apache.drill.exec.physical.base.SubScan;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.iceberg.format.IcebergFormatPlugin;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.iceberg.TableScan;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+@JsonTypeName("iceberg-read")
+@SuppressWarnings("unused")
+public class IcebergSubScan extends AbstractBase implements SubScan {
+
+  private static final String OPERATOR_TYPE = "ICEBERG_SUB_SCAN";
+
+  private final IcebergFormatPlugin formatPlugin;
+
+  private final List<SchemaPath> columns;
+
+  private final LogicalExpression condition;
+
+  private final TupleMetadata schema;
+
+  private final List<IcebergWork> workList;
+
+  private final TableScan tableScan;
+
+  private final String path;
+
+  private final int maxRecords;
+
+  @JsonCreator
+  public IcebergSubScan(
+    @JsonProperty("userName") String userName,
+    @JsonProperty("storage") StoragePluginConfig storageConfig,
+    @JsonProperty("format") FormatPluginConfig formatConfig,
+    @JsonProperty("columns") List<SchemaPath> columns,
+    @JsonProperty("path") String path,
+    @JsonProperty("workList") List<IcebergWork> workList,
+    @JsonProperty("schema") TupleMetadata schema,
+    @JsonProperty("condition") LogicalExpression condition,
+    @JsonProperty("maxRecords") Integer maxRecords,
+    @JacksonInject StoragePluginRegistry pluginRegistry) {
+    this.formatPlugin = pluginRegistry.resolveFormat(storageConfig, formatConfig, IcebergFormatPlugin.class);
+    this.columns = columns;
+    this.workList = workList;
+    this.path = path;
+    this.condition = condition;
+    this.tableScan = getTableScan(columns, path, condition);
+    this.schema = schema;
+    this.maxRecords = maxRecords;
+  }
+
+  @Builder(toBuilder = true)
+  private IcebergSubScan(String userName, IcebergFormatPlugin formatPlugin,
+    List<SchemaPath> columns, LogicalExpression condition, TupleMetadata schema,
+    List<IcebergWork> workList, TableScan tableScan, String path, int maxRecords) {
+    super(userName);
+    this.formatPlugin = formatPlugin;
+    this.columns = columns;
+    this.condition = condition;
+    this.schema = schema;
+    this.workList = workList;
+    this.tableScan = tableScan;
+    this.path = path;
+    this.maxRecords = maxRecords;
+  }
+
+  private TableScan getTableScan(List<SchemaPath> columns, String path, LogicalExpression condition) {
+    return IcebergGroupScan.projectColumns(
+      IcebergGroupScan.initTableScan(formatPlugin, path, condition),
+      columns);
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(
+    PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
+    return physicalVisitor.visitSubScan(this, value);
+  }
+
+  public List<IcebergWork> getWorkList() {
+    return workList;
+  }
+
+  @JsonIgnore
+  public TableScan getTableScan() {
+    return tableScan;
+  }
+
+  public int getMaxRecords() {
+    return maxRecords;
+  }
+
+  public List<SchemaPath> getColumns() {
+    return columns;
+  }
+
+  public LogicalExpression getCondition() {
+    return condition;
+  }
+
+  @Override
+  public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
+    Preconditions.checkArgument(children.isEmpty());
+    return this.toBuilder().build();
+  }
+
+  @JsonProperty("storage")
+  public StoragePluginConfig getStorageConfig() {
+    return formatPlugin.getStorageConfig();
+  }
+
+  @JsonProperty("format")
+  public FormatPluginConfig getFormatConfig() {
+    return formatPlugin.getConfig();
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
+  }
+
+  @Override
+  public Iterator<PhysicalOperator> iterator() {
+    return Collections.emptyIterator();
+  }
+
+  public TupleMetadata getSchema() {
+    return schema;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergWork.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergWork.java
@@ -45,7 +45,7 @@ public class IcebergWork {
 
   /**
    * Special deserializer for {@link IcebergWork} class that deserializes
-   * {@code scanTask} filed from byte array string created using {@link java.io.Serializable}.
+   * {@code scanTask} field from byte array string created using {@link java.io.Serializable}.
    */
   @Slf4j
   public static class IcebergWorkDeserializer extends StdDeserializer<IcebergWork> {
@@ -71,7 +71,7 @@ public class IcebergWork {
 
   /**
    * Special serializer for {@link IcebergWork} class that serializes
-   * {@code scanTask} filed to byte array string created using {@link java.io.Serializable}
+   * {@code scanTask} field to byte array string created using {@link java.io.Serializable}
    * since {@link CombinedScanTask} doesn't use any Jackson annotations.
    */
   public static class IcebergWorkSerializer extends StdSerializer<IcebergWork> {

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergWork.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergWork.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.CombinedScanTask;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
+
+@Value
+@JsonSerialize(using = IcebergWork.IcebergWorkSerializer.class)
+@JsonDeserialize(using = IcebergWork.IcebergWorkDeserializer.class)
+public class IcebergWork {
+  CombinedScanTask scanTask;
+
+  /**
+   * Special deserializer for {@link IcebergWork} class that deserializes
+   * {@code scanTask} filed from byte array string created using {@link java.io.Serializable}.
+   */
+  @Slf4j
+  public static class IcebergWorkDeserializer extends StdDeserializer<IcebergWork> {
+
+    public IcebergWorkDeserializer() {
+      super(IcebergWork.class);
+    }
+
+    @Override
+    public IcebergWork deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      JsonNode node = p.getCodec().readTree(p);
+      String scanTaskString = node.get(IcebergWorkSerializer.SCAN_TASK_FIELD).asText();
+      try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(scanTaskString)))) {
+        Object scanTask = ois.readObject();
+        return new IcebergWork((CombinedScanTask) scanTask);
+      } catch (ClassNotFoundException e) {
+        logger.error(e.getMessage(), e);
+      }
+
+      return null;
+    }
+  }
+
+  /**
+   * Special serializer for {@link IcebergWork} class that serializes
+   * {@code scanTask} filed to byte array string created using {@link java.io.Serializable}
+   * since {@link CombinedScanTask} doesn't use any Jackson annotations.
+   */
+  public static class IcebergWorkSerializer extends StdSerializer<IcebergWork> {
+
+    public static final String SCAN_TASK_FIELD = "scanTask";
+
+    public IcebergWorkSerializer() {
+      super(IcebergWork.class);
+    }
+
+    @Override
+    public void serialize(IcebergWork value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+      gen.writeStartObject();
+      CombinedScanTask scanTask = value.getScanTask();
+      try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+           ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+        objectOutputStream.writeObject(scanTask);
+        gen.writeStringField(SCAN_TASK_FIELD, new String(Base64.getEncoder().encode(byteArrayOutputStream.toByteArray())));
+      }
+      gen.writeEndObject();
+    }
+  }
+
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatLocationTransformer.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatLocationTransformer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.format;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.FormatLocationTransformer;
+import org.apache.iceberg.MetadataTableType;
+
+import java.util.function.Function;
+
+public class IcebergFormatLocationTransformer implements FormatLocationTransformer {
+  public static final FormatLocationTransformer INSTANCE = new IcebergFormatLocationTransformer();
+
+  public static final String METADATA_SEPARATOR = "#";
+
+  @Override
+  public boolean canTransform(String location) {
+    return getMetadataTableType(location) != null;
+  }
+
+  private MetadataTableType getMetadataTableType(String location) {
+    String metadataType = StringUtils.substringAfterLast(location, METADATA_SEPARATOR);
+    return StringUtils.isNotEmpty(metadataType)
+      ? MetadataTableType.from(metadataType)
+      : null;
+  }
+
+  @Override
+  public FileSelection transform(String location, Function<String, FileSelection> selectionFactory) {
+    MetadataTableType metadataTableType = getMetadataTableType(location);
+    location = StringUtils.substringBeforeLast(location, METADATA_SEPARATOR);
+    FileSelection fileSelection = selectionFactory.apply(location);
+    return fileSelection != null
+      ? new IcebergMetadataFileSelection(fileSelection, metadataTableType)
+      : null;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatMatcher.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatMatcher.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.format;
+
+import lombok.AllArgsConstructor;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.FileSystemPlugin;
+import org.apache.drill.exec.store.dfs.FormatLocationTransformer;
+import org.apache.drill.exec.store.dfs.FormatMatcher;
+import org.apache.drill.exec.store.dfs.FormatPlugin;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.exec.store.plan.rel.PluginDrillTable;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class IcebergFormatMatcher extends FormatMatcher {
+  private static final String METADATA_DIR_NAME = "metadata";
+
+  private final IcebergFormatPlugin formatPlugin;
+
+  @Override
+  public boolean supportDirectoryReads() {
+    return true;
+  }
+
+  @Override
+  public DrillTable isReadable(DrillFileSystem fs, FileSelection selection, FileSystemPlugin fsPlugin,
+    String storageEngineName, SchemaConfig schemaConfig) throws IOException {
+    Path selectionRoot = selection.getSelectionRoot();
+    Path metaDir = new Path(selectionRoot, METADATA_DIR_NAME);
+    if (fs.isDirectory(selectionRoot) && fs.exists(metaDir) && fs.isDirectory(metaDir)) {
+      FormatSelection formatSelection = new FormatSelection(formatPlugin.getConfig(), selection);
+      return new PluginDrillTable(fsPlugin, storageEngineName, schemaConfig.getUserName(), formatSelection, formatPlugin.getConvention());
+    }
+    return null;
+  }
+
+  @Override
+  public boolean isFileReadable(DrillFileSystem fs, FileStatus status) {
+    return false;
+  }
+
+  @Override
+  public FormatPlugin getFormatPlugin() {
+    return formatPlugin;
+  }
+
+  public int priority() {
+    return HIGH_PRIORITY;
+  }
+
+  @Override
+  public FormatLocationTransformer getFormatLocationTransformer() {
+    return IcebergFormatLocationTransformer.INSTANCE;
+  }
+
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPlugin.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPlugin.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.format;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.base.AbstractWriter;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.planner.PlannerPhase;
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.store.PluginRulesProviderImpl;
+import org.apache.drill.exec.store.StoragePluginRulesSupplier;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.FileSystemConfig;
+import org.apache.drill.exec.store.dfs.FormatMatcher;
+import org.apache.drill.exec.store.dfs.FormatPlugin;
+import org.apache.drill.exec.store.iceberg.IcebergGroupScan;
+import org.apache.drill.exec.store.iceberg.plan.IcebergPluginImplementor;
+import org.apache.drill.exec.store.plan.rel.PluginRel;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class IcebergFormatPlugin implements FormatPlugin {
+
+  private static final String ICEBERG_CONVENTION_PREFIX = "ICEBERG.";
+
+  private final FileSystemConfig storageConfig;
+
+  private final IcebergFormatPluginConfig config;
+
+  private final Configuration fsConf;
+
+  private final DrillbitContext context;
+
+  private final String name;
+
+  private final IcebergFormatMatcher matcher;
+
+  private final StoragePluginRulesSupplier storagePluginRulesSupplier;
+
+  public IcebergFormatPlugin(
+    String name,
+    DrillbitContext context,
+    Configuration fsConf,
+    FileSystemConfig storageConfig,
+    IcebergFormatPluginConfig config) {
+    this.storageConfig = storageConfig;
+    this.config = config;
+    this.fsConf = fsConf;
+    this.context = context;
+    this.name = name;
+    this.matcher = new IcebergFormatMatcher(this);
+    this.storagePluginRulesSupplier = storagePluginRulesSupplier(name);
+  }
+
+  private static StoragePluginRulesSupplier storagePluginRulesSupplier(String name) {
+    Convention convention = new Convention.Impl(ICEBERG_CONVENTION_PREFIX + name, PluginRel.class);
+    return StoragePluginRulesSupplier.builder()
+      .rulesProvider(new PluginRulesProviderImpl(convention, IcebergPluginImplementor::new))
+      .supportsFilterPushdown(true)
+      .supportsProjectPushdown(true)
+      .supportsLimitPushdown(true)
+      .convention(convention)
+      .build();
+  }
+
+  @Override
+  public boolean supportsRead() {
+    return true;
+  }
+
+  @Override
+  public boolean supportsWrite() {
+    return false;
+  }
+
+  @Override
+  public boolean supportsAutoPartitioning() {
+    return false;
+  }
+
+  @Override
+  public FormatMatcher getMatcher() {
+    return matcher;
+  }
+
+  @Override
+  public AbstractWriter getWriter(PhysicalOperator child, String location, List<String> partitionColumns) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<? extends RelOptRule> getOptimizerRules(PlannerPhase phase) {
+    switch (phase) {
+      case PHYSICAL:
+      case LOGICAL:
+        return storagePluginRulesSupplier.getOptimizerRules();
+      case LOGICAL_PRUNE_AND_JOIN:
+      case LOGICAL_PRUNE:
+      case PARTITION_PRUNING:
+      case JOIN_PLANNING:
+      default:
+        return Collections.emptySet();
+    }
+  }
+
+  @Override
+  public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns) {
+    return IcebergGroupScan.builder()
+      .userName(userName)
+      .formatPlugin(this)
+      .path(getPath(selection))
+      .columns(columns)
+      .maxRecords(-1)
+      .build();
+  }
+
+  @Override
+  public AbstractGroupScan getGroupScan(String userName, FileSelection selection,
+    List<SchemaPath> columns, MetadataProviderManager metadataProviderManager) throws IOException {
+    SchemaProvider schemaProvider = metadataProviderManager.getSchemaProvider();
+    TupleMetadata schema = schemaProvider != null
+      ? schemaProvider.read().getSchema()
+      : null;
+    return IcebergGroupScan.builder()
+      .userName(userName)
+      .formatPlugin(this)
+      .schema(schema)
+      .path(getPath(selection))
+      .columns(columns)
+      .maxRecords(-1)
+      .build();
+  }
+
+  @Override
+  public boolean supportsStatistics() {
+    return false;
+  }
+
+  @Override
+  public DrillStatsTable.TableStatistics readStatistics(FileSystem fs, Path statsTablePath) {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void writeStatistics(DrillStatsTable.TableStatistics statistics, FileSystem fs, Path statsTablePath) {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public IcebergFormatPluginConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  public FileSystemConfig getStorageConfig() {
+    return storageConfig;
+  }
+
+  @Override
+  public Configuration getFsConf() {
+    return fsConf;
+  }
+
+  @Override
+  public DrillbitContext getContext() {
+    return context;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public Convention getConvention() {
+    return storagePluginRulesSupplier.convention();
+  }
+
+  private String getPath(FileSelection selection) {
+    String path = selection.selectionRoot.toUri().getPath();
+    if (selection instanceof IcebergMetadataFileSelection) {
+      IcebergMetadataFileSelection metadataFileSelection = (IcebergMetadataFileSelection) selection;
+      path = String.format("%s%s%s", path, IcebergFormatLocationTransformer.METADATA_SEPARATOR,
+        metadataFileSelection.getMetadataTableType().name().toLowerCase());
+    }
+    return path;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPluginConfig.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPluginConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.format;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.apache.drill.common.logical.FormatPluginConfig;
+import org.apache.drill.exec.store.iceberg.snapshot.Snapshot;
+import org.apache.drill.exec.store.iceberg.snapshot.SnapshotFactory;
+
+import java.util.Map;
+
+@Getter
+@EqualsAndHashCode
+@JsonTypeName(IcebergFormatPluginConfig.NAME)
+public class IcebergFormatPluginConfig implements FormatPluginConfig {
+
+  public static final String NAME = "iceberg";
+
+  private final Map<String, String> properties;
+
+  private final Snapshot snapshot;
+
+  private final Boolean caseSensitive;
+
+  private final Boolean includeColumnStats;
+
+  private final Boolean ignoreResiduals;
+
+  private final Long snapshotId;
+
+  private final Long snapshotAsOfTime;
+
+  private final Long fromSnapshotId;
+
+  private final Long toSnapshotId;
+
+  @Builder
+  @JsonCreator
+  public IcebergFormatPluginConfig(
+    @JsonProperty("properties") Map<String, String> properties,
+    @JsonProperty("caseSensitive") Boolean caseSensitive,
+    @JsonProperty("includeColumnStats") Boolean includeColumnStats,
+    @JsonProperty("ignoreResiduals") Boolean ignoreResiduals,
+    @JsonProperty("snapshotId") Long snapshotId,
+    @JsonProperty("snapshotAsOfTime") Long snapshotAsOfTime,
+    @JsonProperty("fromSnapshotId") Long fromSnapshotId,
+    @JsonProperty("toSnapshotId") Long toSnapshotId) {
+    this.properties = properties;
+    this.caseSensitive = caseSensitive;
+    this.includeColumnStats = includeColumnStats;
+    this.ignoreResiduals = ignoreResiduals;
+    this.snapshotId = snapshotId;
+    this.snapshotAsOfTime = snapshotAsOfTime;
+    this.fromSnapshotId = fromSnapshotId;
+    this.toSnapshotId = toSnapshotId;
+
+    SnapshotFactory.SnapshotContext context = SnapshotFactory.SnapshotContext.builder()
+      .snapshotId(snapshotId)
+      .snapshotAsOfTime(snapshotAsOfTime)
+      .fromSnapshotId(fromSnapshotId)
+      .toSnapshotId(toSnapshotId)
+      .build();
+
+    this.snapshot = SnapshotFactory.INSTANCE.createSnapshot(context);
+  }
+
+  @JsonIgnore
+  public Snapshot getSnapshot() {
+    return snapshot;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergMetadataFileSelection.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergMetadataFileSelection.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.format;
+
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.iceberg.MetadataTableType;
+
+public class IcebergMetadataFileSelection extends FileSelection {
+  private final MetadataTableType metadataTableType;
+
+  protected IcebergMetadataFileSelection(FileSelection selection, MetadataTableType metadataTableType) {
+    super(selection);
+    this.metadataTableType = metadataTableType;
+  }
+
+  public MetadataTableType getMetadataTableType() {
+    return metadataTableType;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/DrillExprToIcebergTranslator.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/DrillExprToIcebergTranslator.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.plan;
+
+import lombok.Value;
+import org.apache.drill.common.FunctionNames;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.expression.ValueExpressions;
+import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
+import org.apache.drill.common.expression.visitors.ExprVisitor;
+import org.apache.drill.exec.store.iceberg.IcebergGroupScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+
+public class DrillExprToIcebergTranslator extends AbstractExprVisitor<Expression, Void, RuntimeException> {
+
+  public static final ExprVisitor<Expression, Void, RuntimeException> INSTANCE = new DrillExprToIcebergTranslator();
+
+  @Override
+  public Expression visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
+    switch (call.getName()) {
+      case FunctionNames.AND: {
+        Expression left = call.arg(0).accept(this, null);
+        Expression right = call.arg(1).accept(this, null);
+        if (left != null && right != null) {
+          return Expressions.and(left, right);
+        }
+        return null;
+      }
+      case FunctionNames.OR: {
+        Expression left = call.arg(0).accept(this, null);
+        Expression right = call.arg(1).accept(this, null);
+        if (left != null && right != null) {
+          return Expressions.or(left, right);
+        }
+        return null;
+      }
+      case FunctionNames.NOT: {
+        Expression expression = call.arg(0).accept(this, null);
+        if (expression != null) {
+          return Expressions.not(expression);
+        }
+        return null;
+      }
+      case FunctionNames.IS_NULL: {
+        LogicalExpression arg = call.arg(0);
+        if (arg instanceof SchemaPath) {
+          String name = IcebergGroupScan.getPath((SchemaPath) arg);
+          return Expressions.isNull(name);
+        }
+        return null;
+      }
+      case FunctionNames.IS_NOT_NULL: {
+        LogicalExpression arg = call.arg(0);
+        if (arg instanceof SchemaPath) {
+          String name = IcebergGroupScan.getPath((SchemaPath) arg);
+          return Expressions.notNull(name);
+        }
+        return null;
+      }
+      case FunctionNames.LT: {
+        LogicalExpression nameRef = call.arg(0);
+        Expression expression = call.arg(1).accept(this, null);
+        if (nameRef instanceof SchemaPath && expression instanceof ConstantExpression) {
+          String name = IcebergGroupScan.getPath((SchemaPath) nameRef);
+          return Expressions.lessThan(name, ((ConstantExpression<?>) expression).getValue());
+        }
+        return null;
+      }
+      case FunctionNames.LE: {
+        LogicalExpression nameRef = call.arg(0);
+        Expression expression = call.arg(1).accept(this, null);
+        if (nameRef instanceof SchemaPath && expression instanceof ConstantExpression) {
+          String name = IcebergGroupScan.getPath((SchemaPath) nameRef);
+          return Expressions.lessThanOrEqual(name, ((ConstantExpression<?>) expression).getValue());
+        }
+        return null;
+      }
+      case FunctionNames.GT: {
+        LogicalExpression nameRef = call.args().get(0);
+        Expression expression = call.args().get(1).accept(this, null);
+        if (nameRef instanceof SchemaPath && expression instanceof ConstantExpression) {
+          String name = IcebergGroupScan.getPath((SchemaPath) nameRef);
+          return Expressions.greaterThan(name, ((ConstantExpression<?>) expression).getValue());
+        }
+        return null;
+      }
+      case FunctionNames.GE: {
+        LogicalExpression nameRef = call.args().get(0);
+        Expression expression = call.args().get(0).accept(this, null);
+        if (nameRef instanceof SchemaPath && expression instanceof ConstantExpression) {
+          String name = IcebergGroupScan.getPath((SchemaPath) nameRef);
+          return Expressions.greaterThanOrEqual(name, ((ConstantExpression<?>) expression).getValue());
+        }
+        return null;
+      }
+      case FunctionNames.EQ: {
+        LogicalExpression nameRef = call.args().get(0);
+        Expression expression = call.args().get(1).accept(this, null);
+        if (nameRef instanceof SchemaPath && expression instanceof ConstantExpression) {
+          String name = IcebergGroupScan.getPath((SchemaPath) nameRef);
+          return Expressions.equal(name, ((ConstantExpression<?>) expression).getValue());
+        }
+        return null;
+      }
+      case FunctionNames.NE: {
+        LogicalExpression nameRef = call.args().get(0);
+        Expression expression = call.args().get(1).accept(this, null);
+        if (nameRef instanceof SchemaPath && expression instanceof ConstantExpression) {
+          String name = IcebergGroupScan.getPath((SchemaPath) nameRef);
+          return Expressions.notEqual(name, ((ConstantExpression<?>) expression).getValue());
+        }
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Expression visitFloatConstant(ValueExpressions.FloatExpression fExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(fExpr.getFloat());
+  }
+
+  @Override
+  public Expression visitIntConstant(ValueExpressions.IntExpression intExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(intExpr.getInt());
+  }
+
+  @Override
+  public Expression visitLongConstant(ValueExpressions.LongExpression longExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(longExpr.getLong());
+  }
+
+  @Override
+  public Expression visitDecimal9Constant(ValueExpressions.Decimal9Expression decExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(decExpr.getIntFromDecimal());
+  }
+
+  @Override
+  public Expression visitDecimal18Constant(ValueExpressions.Decimal18Expression decExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(decExpr.getLongFromDecimal());
+  }
+
+  @Override
+  public Expression visitDecimal28Constant(ValueExpressions.Decimal28Expression decExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(decExpr.getBigDecimal());
+  }
+
+  @Override
+  public Expression visitDecimal38Constant(ValueExpressions.Decimal38Expression decExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(decExpr.getBigDecimal());
+  }
+
+  @Override
+  public Expression visitVarDecimalConstant(ValueExpressions.VarDecimalExpression decExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(decExpr.getBigDecimal());
+  }
+
+  @Override
+  public Expression visitDateConstant(ValueExpressions.DateExpression dateExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(dateExpr.getDate());
+  }
+
+  @Override
+  public Expression visitTimeConstant(ValueExpressions.TimeExpression timeExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(timeExpr.getTime());
+  }
+
+  @Override
+  public Expression visitTimeStampConstant(ValueExpressions.TimeStampExpression timestampExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(timestampExpr.getTimeStamp());
+  }
+
+  @Override
+  public Expression visitDoubleConstant(ValueExpressions.DoubleExpression dExpr, Void value) throws RuntimeException {
+    return new ConstantExpression<>(dExpr.getDouble());
+  }
+
+  @Override
+  public Expression visitBooleanConstant(ValueExpressions.BooleanExpression e, Void value) throws RuntimeException {
+    return new ConstantExpression<>(e.getBoolean());
+  }
+
+  @Override
+  public Expression visitQuotedStringConstant(ValueExpressions.QuotedString e, Void value) throws RuntimeException {
+    return new ConstantExpression<>(e.getString());
+  }
+
+  @Override
+  public Expression visitUnknown(LogicalExpression e, Void value) throws RuntimeException {
+    return null;
+  }
+
+  @Value
+  private static class ConstantExpression<T> implements Expression {
+    T value;
+
+    @Override
+    public Operation op() {
+      return null;
+    }
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.plan;
+
+import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttleImpl;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Util;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.planner.common.DrillLimitRelBase;
+import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+import org.apache.drill.exec.planner.logical.DrillOptiq;
+import org.apache.drill.exec.planner.logical.DrillParseContext;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.store.SubsetRemover;
+import org.apache.drill.exec.store.iceberg.IcebergGroupScan;
+import org.apache.drill.exec.store.plan.AbstractPluginImplementor;
+import org.apache.drill.exec.store.plan.rel.PluginFilterRel;
+import org.apache.drill.exec.store.plan.rel.PluginLimitRel;
+import org.apache.drill.exec.store.plan.rel.PluginProjectRel;
+import org.apache.drill.exec.store.plan.rel.StoragePluginTableScan;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.Expression;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class IcebergPluginImplementor extends AbstractPluginImplementor {
+
+  private IcebergGroupScan groupScan;
+
+  @Override
+  public void implement(StoragePluginTableScan scan) {
+    groupScan = (IcebergGroupScan) scan.getGroupScan();
+  }
+
+  @Override
+  public void implement(PluginFilterRel filter) throws IOException {
+    visitChild(filter.getInput());
+
+    RexNode condition = filter.getCondition();
+    LogicalExpression expression = DrillOptiq.toDrill(
+      new DrillParseContext(PrelUtil.getPlannerSettings(filter.getCluster().getPlanner())),
+      filter.getInput(),
+      condition);
+    groupScan = groupScan.toBuilder().condition(expression).build();
+  }
+
+  @Override
+  public void implement(PluginProjectRel project) throws IOException {
+    visitChild(project.getInput());
+
+    DrillParseContext context = new DrillParseContext(PrelUtil.getPlannerSettings(project.getCluster().getPlanner()));
+    RelNode input = project.getInput();
+
+    List<SchemaPath> projects = project.getProjects().stream()
+      .map(e -> (SchemaPath) DrillOptiq.toDrill(context, input, e))
+      .collect(Collectors.toList());
+    groupScan = groupScan.clone(projects);
+  }
+
+  @Override
+  public boolean canImplement(Filter filter) {
+    RexNode condition = filter.getCondition();
+    LogicalExpression logicalExpression = DrillOptiq.toDrill(
+      new DrillParseContext(PrelUtil.getPlannerSettings(filter.getCluster().getPlanner())),
+      filter.getInput(),
+      condition);
+    Expression expression = logicalExpression.accept(
+      DrillExprToIcebergTranslator.INSTANCE, null);
+
+    if (expression != null) {
+      try {
+        TableScan tableScan = DrillRelOptUtil.findScan(filter.accept(SubsetRemover.INSTANCE));
+        DrillTable drillTable = DrillRelOptUtil.getDrillTable(tableScan);
+        GroupScan scan = drillTable.getGroupScan();
+        if (scan instanceof IcebergGroupScan) {
+          IcebergGroupScan groupScan = (IcebergGroupScan) scan;
+          // ensures that expression compatible with table schema
+          expression = Binder.bind(groupScan.getTableScan().schema().asStruct(), expression, true);
+        } else {
+          return false;
+        }
+      } catch (ValidationException | IOException e) {
+        return false;
+      }
+    }
+    return expression != null;
+  }
+
+  @Override
+  public void implement(PluginLimitRel limit) throws IOException {
+    visitChild(limit.getInput());
+    int maxRecords = getArtificialLimit(limit);
+    if (maxRecords >= 0) {
+      groupScan = groupScan.applyLimit(maxRecords);
+    }
+  }
+
+  @Override
+  public boolean canImplement(DrillLimitRelBase limit) {
+    FirstLimitFinder finder = new FirstLimitFinder();
+    limit.getInput().accept(finder);
+    int oldLimit = getArtificialLimit(finder.getFetch(), finder.getOffset());
+    int newLimit = getArtificialLimit(limit);
+    return newLimit >= 0 && (oldLimit < 0 || newLimit < oldLimit);
+  }
+
+  @Override
+  public boolean artificialLimit() {
+    return true;
+  }
+
+  @Override
+  public boolean splitProject(Project project) {
+    return true;
+  }
+
+  @Override
+  public boolean canImplement(Project project) {
+    return true;
+  }
+
+  @Override
+  public GroupScan getPhysicalOperator() {
+    return groupScan;
+  }
+
+  private int rexLiteralIntValue(RexLiteral offset) {
+    return ((BigDecimal) offset.getValue()).intValue();
+  }
+
+  private int getArtificialLimit(DrillLimitRelBase limit) {
+    return getArtificialLimit(limit.getFetch(), limit.getOffset());
+  }
+
+  private int getArtificialLimit(RexNode fetch, RexNode offset) {
+    int maxRows = -1;
+    if (fetch != null) {
+      maxRows = rexLiteralIntValue((RexLiteral) fetch);
+      if (offset != null) {
+        maxRows += rexLiteralIntValue((RexLiteral) offset);
+      }
+    }
+    return maxRows;
+  }
+
+  private static class FirstLimitFinder extends RelShuttleImpl {
+    private RexNode fetch;
+
+    private RexNode offset;
+
+    @Override
+    public RelNode visit(RelNode other) {
+      if (other instanceof DrillLimitRelBase) {
+        DrillLimitRelBase limitRelBase = (DrillLimitRelBase) other;
+        fetch = limitRelBase.getFetch();
+        offset = limitRelBase.getOffset();
+        return other;
+      } else if (other instanceof RelSubset) {
+        RelSubset relSubset = (RelSubset) other;
+        Util.first(relSubset.getBest(), relSubset.getOriginal()).accept(this);
+      }
+      return super.visit(other);
+    }
+
+    public RexNode getFetch() {
+      return fetch;
+    }
+
+    public RexNode getOffset() {
+      return offset;
+    }
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/IcebergColumnConverterFactory.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/IcebergColumnConverterFactory.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.read;
+
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.record.ColumnConverter;
+import org.apache.drill.exec.record.ColumnConverterFactory;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.DictColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.ValueWriter;
+import org.apache.drill.exec.vector.complex.DictVector;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class IcebergColumnConverterFactory extends ColumnConverterFactory {
+
+  public IcebergColumnConverterFactory(TupleMetadata providedSchema) {
+    super(providedSchema);
+  }
+
+  @Override
+  protected ColumnConverter getMapConverter(TupleMetadata providedSchema,
+    TupleMetadata readerSchema, TupleWriter tupleWriter) {
+    Map<String, ColumnConverter> converters = StreamSupport.stream(readerSchema.spliterator(), false)
+      .collect(Collectors.toMap(
+        ColumnMetadata::name,
+        columnMetadata ->
+          getConverter(providedSchema, columnMetadata, tupleWriter.column(columnMetadata.name()))));
+
+    return new MapColumnConverter(this, providedSchema, tupleWriter, converters);
+  }
+
+  @Override
+  public ColumnConverter.ScalarColumnConverter buildScalar(ColumnMetadata readerSchema, ValueWriter writer) {
+    switch (readerSchema.type()) {
+      case BIT:
+        return new ColumnConverter.ScalarColumnConverter(value -> writer.setBoolean((Boolean) value));
+      case TIMESTAMP:
+        return new ColumnConverter.ScalarColumnConverter(value -> {
+          Instant instant;
+          if (value instanceof LocalDateTime) {
+            LocalDateTime dateTime = (LocalDateTime) value;
+            instant = dateTime.toInstant(ZoneOffset.UTC);
+          } else {
+            instant = Instant.ofEpochMilli((Long) value / 1000);
+          }
+          writer.setTimestamp(instant);
+        });
+      case VARDECIMAL:
+        return new ColumnConverter.ScalarColumnConverter(value -> writer.setDecimal((BigDecimal) value));
+      case VARBINARY:
+        return new ColumnConverter.ScalarColumnConverter(value -> {
+          byte[] bytes;
+          if (value instanceof ByteBuffer) {
+            ByteBuffer byteBuf = (ByteBuffer) value;
+            bytes = byteBuf.array();
+          } else {
+            bytes = (byte[]) value;
+          }
+          writer.setBytes(bytes, bytes.length);
+        });
+      default:
+        return super.buildScalar(readerSchema, writer);
+    }
+  }
+
+  public static ColumnMetadata getColumnMetadata(Types.NestedField field) {
+    Type type = field.type();
+    String name = field.name();
+    return getColumnMetadata(name, type, field.isOptional() ? TypeProtos.DataMode.OPTIONAL : TypeProtos.DataMode.REQUIRED);
+  }
+
+  private static ColumnMetadata getColumnMetadata(String name, Type type, TypeProtos.DataMode dataMode) {
+    switch (type.typeId()) {
+      case MAP:
+        return getDictColumnMetadata(name, type, dataMode);
+      case STRUCT:
+        return MetadataUtils.newMap(name, dataMode, convertSchema(type.asStructType()));
+      case LIST:
+        Type elementType = type.asListType().elementType();
+        switch (elementType.typeId()) {
+          case MAP:
+            return getDictColumnMetadata(name, elementType, TypeProtos.DataMode.REPEATED);
+          case STRUCT:
+            return MetadataUtils.newMapArray(name, convertSchema(elementType.asStructType()));
+          case LIST:
+            return MetadataUtils.newRepeatedList(name, getColumnMetadata(name, elementType, TypeProtos.DataMode.REPEATED));
+          default:
+            return getPrimitiveMetadata(name, elementType, TypeProtos.DataMode.REPEATED);
+        }
+      default:
+        return getPrimitiveMetadata(name, type, dataMode);
+    }
+  }
+
+  private static ColumnMetadata getPrimitiveMetadata(String name, Type type, TypeProtos.DataMode dataMode) {
+    TypeProtos.MinorType minorType = getType(type);
+    if (minorType == null) {
+      throw new UnsupportedOperationException(String.format("Unsupported type: %s for column: %s", type, name));
+    }
+    TypeProtos.MajorType.Builder builder = TypeProtos.MajorType.newBuilder()
+      .setMinorType(minorType)
+      .setMode(dataMode);
+    switch (type.typeId()) {
+      case DECIMAL: {
+        Types.DecimalType decimalType = (Types.DecimalType) type;
+        builder.setScale(decimalType.scale())
+          .setPrecision(decimalType.precision());
+        break;
+      }
+      case FIXED: {
+        Types.FixedType fixedType = (Types.FixedType) type;
+        builder.setWidth(fixedType.length());
+      }
+    }
+    MaterializedField materializedField = MaterializedField.create(name, builder.build());
+    return MetadataUtils.fromField(materializedField);
+  }
+
+  private static DictColumnMetadata getDictColumnMetadata(String name, Type type, TypeProtos.DataMode dataMode) {
+    MaterializedField dictField = SchemaBuilder.columnSchema(name, TypeProtos.MinorType.DICT, dataMode);
+    TupleSchema dictSchema = new TupleSchema();
+    dictSchema.add(getColumnMetadata(DictVector.FIELD_KEY_NAME, type.asMapType().keyType(), TypeProtos.DataMode.REQUIRED));
+    dictSchema.add(getColumnMetadata(DictVector.FIELD_VALUE_NAME, type.asMapType().valueType(), TypeProtos.DataMode.REQUIRED));
+    return MetadataUtils.newDict(dictField, dictSchema);
+  }
+
+  public static TupleSchema convertSchema(Types.StructType structType) {
+    TupleSchema schema = new TupleSchema();
+    for (Types.NestedField field : structType.fields()) {
+      ColumnMetadata columnMetadata = getColumnMetadata(field);
+      schema.add(columnMetadata);
+    }
+    return schema;
+  }
+
+  private static TypeProtos.MinorType getType(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return TypeProtos.MinorType.BIT;
+      case INTEGER:
+        return TypeProtos.MinorType.INT;
+      case LONG:
+        return TypeProtos.MinorType.BIGINT;
+      case FLOAT:
+        return TypeProtos.MinorType.FLOAT4;
+      case DOUBLE:
+        return TypeProtos.MinorType.FLOAT8;
+      case DATE:
+        return TypeProtos.MinorType.DATE;
+      case TIME:
+        return TypeProtos.MinorType.TIME;
+      case TIMESTAMP:
+        return TypeProtos.MinorType.TIMESTAMP;
+      case STRING:
+        return TypeProtos.MinorType.VARCHAR;
+      case UUID:
+      case FIXED:
+      case BINARY:
+        return TypeProtos.MinorType.VARBINARY;
+      case DECIMAL:
+        return TypeProtos.MinorType.VARDECIMAL;
+    }
+    return null;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/IcebergRecordReader.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/IcebergRecordReader.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.read;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.v3.FixedReceiver;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.ColumnConverter;
+import org.apache.drill.exec.record.ColumnConverterFactory;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.exec.store.iceberg.IcebergWork;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.ScanTaskTableScanIterable;
+import org.apache.iceberg.io.CloseableIterable;
+
+import java.util.Iterator;
+
+@Slf4j
+public class IcebergRecordReader implements ManagedReader<SchemaNegotiator> {
+  private final IcebergWork work;
+
+  private final TableScan tableScan;
+
+  private final int maxRecords;
+
+  private ResultSetLoader loader;
+
+  private Iterator<Record> records;
+
+  private ColumnConverter converter;
+
+  private CloseableIterable<Record> taskToClose;
+
+  public IcebergRecordReader(TableScan tableScan, IcebergWork work, int maxRecords) {
+    this.work = work;
+    this.tableScan = tableScan;
+    this.maxRecords = maxRecords;
+  }
+
+  @Override
+  public boolean open(SchemaNegotiator negotiator) {
+    TupleSchema tableSchema = new TupleSchema();
+    tableScan.schema().columns().stream()
+      .map(IcebergColumnConverterFactory::getColumnMetadata)
+      .forEach(tableSchema::add);
+    TupleMetadata providedSchema = negotiator.providedSchema();
+    TupleMetadata tupleSchema = FixedReceiver.Builder.mergeSchemas(providedSchema, tableSchema);
+    negotiator.tableSchema(tupleSchema, true);
+    loader = negotiator.build();
+
+    this.taskToClose = new ScanTaskTableScanIterable(tableScan, work.getScanTask());
+    this.records = taskToClose.iterator();
+
+    ColumnConverterFactory factory = new IcebergColumnConverterFactory(providedSchema);
+    converter = factory.getRootConverter(providedSchema, tableSchema, loader.writer());
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+    RowSetLoader rowWriter = loader.writer();
+    while (!rowWriter.isFull()) {
+      if (!nextLine(rowWriter)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void close() {
+    AutoCloseables.closeSilently(taskToClose);
+    loader.close();
+  }
+
+  private boolean nextLine(RowSetLoader rowWriter) {
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
+
+    if (!records.hasNext()) {
+      return false;
+    }
+
+    rowWriter.start();
+    converter.convert(records.next());
+    rowWriter.save();
+
+    return true;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/IcebergScanBatchCreator.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/IcebergScanBatchCreator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.read;
+
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.physical.impl.scan.framework.BasicScanFactory;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.store.iceberg.IcebergSubScan;
+import org.apache.drill.exec.store.iceberg.IcebergWork;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.iceberg.TableScan;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+public class IcebergScanBatchCreator implements BatchCreator<IcebergSubScan> {
+
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+    IcebergSubScan subScan, List<RecordBatch> children) throws ExecutionSetupException {
+    Preconditions.checkArgument(children.isEmpty());
+
+    try {
+      ManagedScanFramework.ScanFrameworkBuilder builder = createBuilder(subScan);
+      return builder.buildScanOperator(context, subScan);
+    } catch (UserException e) {
+      // Rethrow user exceptions directly
+      throw e;
+    } catch (Throwable e) {
+      // Wrap all others
+      throw new ExecutionSetupException(e);
+    }
+  }
+
+  private ManagedScanFramework.ScanFrameworkBuilder createBuilder(IcebergSubScan subScan) {
+    ManagedScanFramework.ScanFrameworkBuilder builder = new ManagedScanFramework.ScanFrameworkBuilder();
+    builder.projection(subScan.getColumns());
+    builder.setUserName(subScan.getUserName());
+    builder.providedSchema(subScan.getSchema());
+
+    ManagedScanFramework.ReaderFactory readerFactory = new BasicScanFactory(
+      subScan.getWorkList().stream()
+          .map(icebergWork -> getRecordReader(subScan.getTableScan(), icebergWork, subScan.getMaxRecords()))
+          .iterator());
+    builder.setReaderFactory(readerFactory);
+    builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));
+    return builder;
+  }
+
+  private static ManagedReader<SchemaNegotiator> getRecordReader(TableScan tableScan, IcebergWork icebergWork, int maxRecords) {
+    return new IcebergRecordReader(tableScan, icebergWork, maxRecords);
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/MapColumnConverter.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/read/MapColumnConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.read;
+
+import org.apache.drill.exec.physical.impl.scan.v3.FixedReceiver;
+import org.apache.drill.exec.record.ColumnConverter;
+import org.apache.drill.exec.record.ColumnConverterFactory;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.iceberg.data.Record;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapColumnConverter implements ColumnConverter {
+
+  private final ColumnConverterFactory factory;
+
+  private final TupleMetadata providedSchema;
+
+  private final TupleWriter tupleWriter;
+
+  private final Map<String, ColumnConverter> converters;
+
+  public MapColumnConverter(ColumnConverterFactory factory,
+    TupleMetadata providedSchema,
+    TupleWriter tupleWriter, Map<String, ColumnConverter> converters) {
+    this.factory = factory;
+    this.providedSchema = providedSchema;
+    this.tupleWriter = tupleWriter;
+    this.converters = new HashMap<>(converters);
+  }
+
+  @Override
+  public void convert(Object value) {
+    if (value == null) {
+      return;
+    }
+
+    Record record = (Record) value;
+
+    if (converters.isEmpty()) {
+      buildMapMembers(record, providedSchema, tupleWriter, converters);
+    }
+
+    record.struct().fields()
+      .forEach(field -> processValue(field.name(), record.getField(field.name())));
+  }
+
+  private void processValue(String name, Object columnValue) {
+    ColumnConverter columnConverter = converters.get(name);
+    if (columnConverter != null) {
+      columnConverter.convert(columnValue);
+    }
+  }
+
+  public void buildMapMembers(Record record, TupleMetadata providedSchema,
+    TupleWriter tupleWriter, Map<String, ColumnConverter> converters) {
+    TupleMetadata readerSchema = IcebergColumnConverterFactory.convertSchema(record.struct());
+    TupleMetadata tableSchema = FixedReceiver.Builder.mergeSchemas(providedSchema, readerSchema);
+    tableSchema.toMetadataList().forEach(tupleWriter::addColumn);
+
+    for (ColumnMetadata columnMetadata : tableSchema) {
+      String name = columnMetadata.name();
+      converters.put(name, factory.getConverter(providedSchema,
+        readerSchema.metadata(name), tupleWriter.column(name)));
+    }
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/Snapshot.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/Snapshot.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.snapshot;
+
+import org.apache.iceberg.TableScan;
+
+public interface Snapshot {
+
+  TableScan apply(TableScan tableScan);
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotAfter.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotAfter.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import org.apache.iceberg.TableScan;
+
+@JsonTypeName("appendsAfter")
+@AllArgsConstructor
+public class SnapshotAfter implements Snapshot {
+  private final long fromSnapshotId;
+
+  @Override
+  public TableScan apply(TableScan tableScan) {
+    return tableScan.appendsAfter(fromSnapshotId);
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotById.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotById.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.iceberg.TableScan;
+
+@JsonTypeName("useSnapshot")
+public class SnapshotById implements Snapshot {
+
+  private final long snapshotId;
+
+  public SnapshotById(long snapshotId) {
+    this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public TableScan apply(TableScan tableScan) {
+    return tableScan.useSnapshot(snapshotId);
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotByTime.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotByTime.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import org.apache.iceberg.TableScan;
+
+@JsonTypeName("asOfTime")
+@AllArgsConstructor
+public class SnapshotByTime implements Snapshot {
+
+  private final long snapshotAtTime;
+
+  @Override
+  public TableScan apply(TableScan tableScan) {
+    return tableScan.asOfTime(snapshotAtTime);
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotFactory.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.snapshot;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+public class SnapshotFactory {
+
+  public static final SnapshotFactory INSTANCE = new SnapshotFactory();
+
+  public Snapshot createSnapshot(SnapshotContext snapshotContext) {
+    if (snapshotContext.getSnapshotId() != null) {
+      Preconditions.checkArgument(snapshotContext.getSnapshotAsOfTime() == null,
+        "Both 'snapshotId' and 'snapshotAsOfTime' cannot be specified");
+      Preconditions.checkArgument(snapshotContext.getFromSnapshotId() == null,
+        "Both 'snapshotId' and 'fromSnapshotId' cannot be specified");
+      Preconditions.checkArgument(snapshotContext.getToSnapshotId() == null,
+        "Both 'snapshotId' and 'toSnapshotId' cannot be specified");
+      return new SnapshotById(snapshotContext.getSnapshotId());
+    } else if (snapshotContext.getSnapshotAsOfTime() != null) {
+      Preconditions.checkArgument(snapshotContext.getSnapshotId() == null,
+        "Both 'snapshotId' and 'snapshotAsOfTime' cannot be specified");
+      Preconditions.checkArgument(snapshotContext.getFromSnapshotId() == null,
+        "Both 'snapshotAsOfTime' and 'fromSnapshotId' cannot be specified");
+      Preconditions.checkArgument(snapshotContext.getToSnapshotId() == null,
+        "Both 'snapshotAsOfTime' and 'toSnapshotId' cannot be specified");
+      return new SnapshotByTime(snapshotContext.getSnapshotAsOfTime());
+    } else if (snapshotContext.getFromSnapshotId() != null) {
+      Preconditions.checkArgument(snapshotContext.getSnapshotId() == null,
+        "Both 'snapshotId' and 'fromSnapshotId' cannot be specified");
+      Preconditions.checkArgument(snapshotContext.getSnapshotAsOfTime() == null,
+        "Both 'snapshotAsOfTime' and 'fromSnapshotId' cannot be specified");
+
+      return snapshotContext.getToSnapshotId() == null
+        ? new SnapshotAfter(snapshotContext.getFromSnapshotId())
+        : new SnapshotsBetween(snapshotContext.getFromSnapshotId(), snapshotContext.getToSnapshotId());
+    } else {
+      return null;
+    }
+  }
+
+  @Builder
+  @Getter
+  public static class SnapshotContext {
+    private final Long snapshotId;
+
+    private final Long snapshotAsOfTime;
+
+    private final Long fromSnapshotId;
+
+    private final Long toSnapshotId;
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotsBetween.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/snapshot/SnapshotsBetween.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import org.apache.iceberg.TableScan;
+
+@JsonTypeName("appendsBetween")
+@AllArgsConstructor
+public class SnapshotsBetween implements Snapshot {
+  private final long fromSnapshotId;
+  private final long toSnapshotId;
+
+  @Override
+  public TableScan apply(TableScan tableScan) {
+    return tableScan.appendsBetween(fromSnapshotId, toSnapshotId);
+  }
+}

--- a/contrib/format-iceberg/src/main/java/org/apache/iceberg/data/ScanTaskTableScanIterable.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/iceberg/data/ScanTaskTableScanIterable.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.data;
+
+import org.apache.iceberg.BaseCombinedScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataTask;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructProjection;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ScanTaskTableScanIterable extends CloseableGroup implements CloseableIterable<Record> {
+  private final GenericReader reader;
+
+  private final CombinedScanTask genericTask;
+
+  private final List<DataTask> dataTasks;
+
+  private final Types.StructType schema;
+
+  public ScanTaskTableScanIterable(TableScan scan, CombinedScanTask task) {
+    this.reader = new GenericReader(scan, false);
+    this.dataTasks = new ArrayList<>();
+    this.schema = scan.schema().asStruct();
+    List<FileScanTask> fileScanTasks = new ArrayList<>();
+    task.files().forEach(scanTask -> {
+      if (scanTask.isDataTask()) {
+        dataTasks.add(scanTask.asDataTask());
+      } else {
+        fileScanTasks.add(scanTask);
+      }
+    });
+
+    this.genericTask = new BaseCombinedScanTask(fileScanTasks);
+  }
+
+  @Override
+  public CloseableIterator<Record> iterator() {
+    List<CloseableIterable<Record>> dataTasksIterators = dataTasks.stream()
+      .map(DataTask::rows)
+      .map(rows -> CloseableIterable.transform(rows, sl -> structLikeToRecord(sl, schema)))
+      .collect(Collectors.toList());
+
+    dataTasksIterators.add(reader.open(genericTask));
+    CloseableIterator<Record> iterator = CloseableIterable.concat(dataTasksIterators).iterator();
+    addCloseable(iterator);
+    return iterator;
+  }
+
+  private static Record structLikeToRecord(StructLike structLike, Types.StructType schema) {
+    GenericRecord genericRecord = GenericRecord.create(schema);
+    for (int i = 0; i < schema.fields().size(); i++) {
+      Object value = structLike.get(i, Object.class);
+      if (value instanceof StructProjection) {
+        // convert StructLike value to Record recursively
+        value = structLikeToRecord(
+          ((StructLike) value),
+          schema.fields().get(i).type().asStructType());
+      }
+      genericRecord.set(i, value);
+    }
+    return genericRecord;
+  }
+}

--- a/contrib/format-iceberg/src/main/resources/bootstrap-format-plugins.json
+++ b/contrib/format-iceberg/src/main/resources/bootstrap-format-plugins.json
@@ -1,0 +1,20 @@
+{
+  "storage":{
+    "dfs": {
+      "type": "file",
+      "formats": {
+        "iceberg": {
+          "type": "iceberg"
+        }
+      }
+    },
+    "s3": {
+      "type": "file",
+      "formats": {
+        "iceberg": {
+          "type": "iceberg"
+        }
+      }
+    }
+  }
+}

--- a/contrib/format-iceberg/src/main/resources/drill-module.conf
+++ b/contrib/format-iceberg/src/main/resources/drill-module.conf
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#  This file tells Drill to consider this module when class path scanning.
+#  This file can also include any supplementary configuration information.
+#  This file is in HOCON format, see https://github.com/typesafehub/config/blob/master/HOCON.md for more information.
+drill.classpath.scanning: {
+  packages += "org.apache.drill.exec.store.iceberg"
+}

--- a/contrib/format-iceberg/src/test/java/org/apache/drill/exec/store/iceberg/IcebergQueriesTest.java
+++ b/contrib/format-iceberg/src/test/java/org/apache/drill/exec/store/iceberg/IcebergQueriesTest.java
@@ -1,0 +1,682 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.iceberg;
+
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.common.logical.FormatPluginConfig;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.dfs.FileSystemConfig;
+import org.apache.drill.exec.store.iceberg.format.IcebergFormatPluginConfig;
+import org.apache.drill.exec.util.JsonStringHashMap;
+import org.apache.drill.exec.util.Text;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.HistoryEntry;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.types.Types;
+import org.hamcrest.MatcherAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.drill.exec.util.StoragePluginTestUtils.DFS_PLUGIN_NAME;
+import static org.apache.drill.test.TestBuilder.listOf;
+import static org.apache.drill.test.TestBuilder.mapOf;
+import static org.apache.drill.test.TestBuilder.mapOfObject;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IcebergQueriesTest extends ClusterTest {
+  private static Table table;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
+
+    StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
+    FileSystemConfig pluginConfig = (FileSystemConfig) pluginRegistry.getPlugin(DFS_PLUGIN_NAME).getConfig();
+    Map<String, FormatPluginConfig> formats = new HashMap<>(pluginConfig.getFormats());
+    formats.put("iceberg", IcebergFormatPluginConfig.builder().build());
+    FileSystemConfig newPluginConfig = new FileSystemConfig(
+      pluginConfig.getConnection(),
+      pluginConfig.getConfig(),
+      pluginConfig.getWorkspaces(),
+      formats,
+      PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
+    newPluginConfig.setEnabled(pluginConfig.isEnabled());
+    pluginRegistry.put(DFS_PLUGIN_NAME, newPluginConfig);
+
+    Configuration config = new Configuration();
+    config.set(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
+
+    HadoopTables tables = new HadoopTables(config);
+    Schema structSchema = new Schema(
+      Types.NestedField.optional(13, "struct_int_field", Types.IntegerType.get()),
+      Types.NestedField.optional(14, "struct_string_field", Types.StringType.get())
+    );
+    Types.ListType repeatedStructType =  Types.ListType.ofOptional(
+      16, Types.StructType.of(
+      Types.NestedField.optional(17, "struct_int_field", Types.IntegerType.get()),
+      Types.NestedField.optional(18, "struct_string_field", Types.StringType.get())
+    ));
+    Schema schema = new Schema(
+      Types.NestedField.optional(1, "int_field", Types.IntegerType.get()),
+      Types.NestedField.optional(2, "long_field", Types.LongType.get()),
+      Types.NestedField.optional(3, "float_field", Types.FloatType.get()),
+      Types.NestedField.optional(4, "double_field", Types.DoubleType.get()),
+      Types.NestedField.optional(5, "string_field", Types.StringType.get()),
+      Types.NestedField.optional(6, "boolean_field", Types.BooleanType.get()),
+      Types.NestedField.optional(26, "time_field", Types.TimeType.get()),
+      Types.NestedField.optional(27, "timestamp_field", Types.TimestampType.withoutZone()),
+      Types.NestedField.optional(28, "date_field", Types.DateType.get()),
+      Types.NestedField.optional(29, "decimal_field", Types.DecimalType.of(4, 2)),
+      Types.NestedField.optional(30, "uuid_field", Types.UUIDType.get()),
+      Types.NestedField.optional(31, "fixed_field", Types.FixedType.ofLength(10)),
+      Types.NestedField.optional(32, "binary_field", Types.BinaryType.get()),
+      Types.NestedField.optional(7, "list_field", Types.ListType.ofOptional(
+        10, Types.StringType.get())),
+      Types.NestedField.optional(8, "map_field", Types.MapType.ofOptional(
+        11, 12, Types.StringType.get(), Types.FloatType.get())),
+      Types.NestedField.required(9, "struct_field", structSchema.asStruct()),
+      Types.NestedField.required(15, "repeated_struct_field", repeatedStructType),
+      Types.NestedField.required(19, "repeated_list_field", Types.ListType.ofOptional(
+        20, Types.ListType.ofOptional(21, Types.StringType.get()))),
+      Types.NestedField.optional(22, "repeated_map_field", Types.ListType.ofOptional(
+        23, Types.MapType.ofOptional(24, 25, Types.StringType.get(), Types.FloatType.get())))
+    );
+
+    List<String> listValue = Arrays.asList("a", "b", "c");
+
+    Map<String, Float> mapValue = new HashMap<>();
+    mapValue.put("a", 0.1F);
+    mapValue.put("b", 0.2F);
+
+    Map<String, Float> secondMapValue = new HashMap<>();
+    secondMapValue.put("true", 1F);
+    secondMapValue.put("false", 0F);
+
+    Record structValue = GenericRecord.create(structSchema);
+    structValue.setField("struct_int_field", 123);
+    structValue.setField("struct_string_field", "abc");
+
+    Record secondStructValue = GenericRecord.create(structSchema);
+    secondStructValue.setField("struct_int_field", 321);
+    secondStructValue.setField("struct_string_field", "def");
+
+    Record record = GenericRecord.create(schema);
+    record.setField("int_field", 1);
+    record.setField("long_field", 100L);
+    record.setField("float_field", 0.5F);
+    record.setField("double_field", 1.5D);
+    record.setField("string_field", "abc");
+    record.setField("boolean_field", true);
+    record.setField("time_field", LocalTime.of(2, 42, 42));
+    record.setField("timestamp_field", LocalDateTime.of(1994, 4, 18, 11, 0, 0));
+    record.setField("date_field", LocalDate.of(1994, 4, 18));
+    record.setField("decimal_field", new BigDecimal("12.34"));
+    record.setField("uuid_field", new byte[16]);
+    record.setField("fixed_field", new byte[10]);
+    record.setField("binary_field", ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+    record.setField("list_field", listValue);
+    record.setField("map_field", mapValue);
+    record.setField("struct_field", structValue);
+    record.setField("repeated_struct_field", Arrays.asList(structValue, structValue));
+    record.setField("repeated_list_field", Arrays.asList(listValue, listValue));
+    record.setField("repeated_map_field", Arrays.asList(mapValue, mapValue));
+
+    Record nullsRecord = GenericRecord.create(schema);
+    nullsRecord.setField("int_field", null);
+    nullsRecord.setField("long_field", null);
+    nullsRecord.setField("float_field", null);
+    nullsRecord.setField("double_field", null);
+    nullsRecord.setField("string_field", null);
+    nullsRecord.setField("boolean_field", null);
+    nullsRecord.setField("time_field", null);
+    nullsRecord.setField("timestamp_field", null);
+    nullsRecord.setField("date_field", null);
+    nullsRecord.setField("decimal_field", null);
+    nullsRecord.setField("uuid_field", null);
+    nullsRecord.setField("fixed_field", null);
+    nullsRecord.setField("binary_field", null);
+    nullsRecord.setField("list_field", null);
+    nullsRecord.setField("map_field", null);
+    nullsRecord.setField("struct_field", GenericRecord.create(structSchema));
+    nullsRecord.setField("repeated_struct_field", Collections.emptyList());
+    nullsRecord.setField("repeated_list_field", Collections.emptyList());
+    nullsRecord.setField("repeated_map_field", Collections.emptyList());
+
+    Record secondRecord = GenericRecord.create(schema);
+    secondRecord.setField("int_field", 988);
+    secondRecord.setField("long_field", 543L);
+    secondRecord.setField("float_field", Float.NaN);
+    secondRecord.setField("double_field", Double.MAX_VALUE);
+    secondRecord.setField("string_field", "def");
+    secondRecord.setField("boolean_field", false);
+    secondRecord.setField("time_field", LocalTime.of(3, 41, 53));
+    secondRecord.setField("timestamp_field", LocalDateTime.of(1995, 9, 10, 9, 0, 0));
+    secondRecord.setField("date_field", LocalDate.of(1995, 9, 10));
+    secondRecord.setField("decimal_field", new BigDecimal("99.99"));
+    secondRecord.setField("uuid_field", new byte[16]);
+    secondRecord.setField("fixed_field", new byte[10]);
+    secondRecord.setField("binary_field", ByteBuffer.wrap("world".getBytes(StandardCharsets.UTF_8)));
+    secondRecord.setField("list_field", Arrays.asList("y", "n"));
+    secondRecord.setField("map_field", secondMapValue);
+    secondRecord.setField("struct_field", secondStructValue);
+    secondRecord.setField("repeated_struct_field", Arrays.asList(structValue, secondStructValue));
+    secondRecord.setField("repeated_list_field", Arrays.asList(listValue, Arrays.asList("y", "n")));
+    secondRecord.setField("repeated_map_field", Arrays.asList(mapValue, secondMapValue));
+
+    String location = Paths.get(dirTestWatcher.getDfsTestTmpDir().toURI().getPath(), "testAllTypes").toUri().getPath();
+    table = tables.create(schema, location);
+
+    writeParquetAndCommitDataFile(table, "allTypes", Arrays.asList(record, nullsRecord));
+    writeParquetAndCommitDataFile(table, "allTypes_1", Collections.singleton(secondRecord));
+
+    String avroLocation = Paths.get(dirTestWatcher.getDfsTestTmpDir().toURI().getPath(), "testAllTypesAvro").toUri().getPath();
+    writeAndCommitDataFile(tables.create(structSchema, avroLocation), "allTypes", FileFormat.AVRO,
+      Arrays.asList(structValue, GenericRecord.create(structSchema), secondStructValue));
+
+    String orcLocation = Paths.get(dirTestWatcher.getDfsTestTmpDir().toURI().getPath(), "testAllTypesOrc").toUri().getPath();
+    writeAndCommitDataFile(tables.create(structSchema, orcLocation), "allTypes", FileFormat.ORC,
+      Arrays.asList(structValue, GenericRecord.create(structSchema), secondStructValue));
+
+    String emptyTableLocation = Paths.get(dirTestWatcher.getDfsTestTmpDir().toURI().getPath(), "testAllTypesEmpty").toUri().getPath();
+    tables.create(structSchema, emptyTableLocation);
+  }
+
+  private static void writeParquetAndCommitDataFile(Table table, String name, Iterable<Record> records) throws IOException {
+    writeAndCommitDataFile(table, name, FileFormat.PARQUET, records);
+  }
+
+  private static void writeAndCommitDataFile(Table table, String name, FileFormat fileFormat, Iterable<Record> records) throws IOException {
+    OutputFile outputFile = table.io().newOutputFile(
+      new Path(table.location(), fileFormat.addExtension(name)).toUri().getPath());
+
+    FileAppender<Record> fileAppender = new GenericAppenderFactory(table.schema())
+      .newAppender(outputFile, fileFormat);
+    fileAppender.addAll(records);
+    fileAppender.close();
+
+    DataFile dataFile = DataFiles.builder(table.spec())
+      .withInputFile(outputFile.toInputFile())
+      .withMetrics(fileAppender.metrics())
+      .build();
+
+    Transaction transaction = table.newTransaction();
+    transaction.newAppend()
+      .appendFile(dataFile)
+      .commit();
+    transaction.commitTransaction();
+  }
+
+  @Test
+  public void testSerDe() throws Exception {
+    String plan = queryBuilder().sql("select * from dfs.tmp.testAllTypes").explainJson();
+    long count = queryBuilder().physical(plan).run().recordCount();
+    assertEquals(3, count);
+  }
+
+  @Test
+  public void testSelectWithSnapshotId() throws Exception {
+    String snapshotQuery = "select snapshot_id from dfs.tmp.`testAllTypes#snapshots` order by committed_at limit 1";
+
+    String query = "select * from table(dfs.tmp.testAllTypes(type => 'iceberg', snapshotId => %s))";
+
+    long snapshotId = queryBuilder().sql(snapshotQuery).singletonLong();
+    String plan = queryBuilder().sql(query, snapshotId).explainJson();
+    long count = queryBuilder().physical(plan).run().recordCount();
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSelectWithSnapshotAsOfTime() throws Exception {
+    String snapshotQuery = "select committed_at from dfs.tmp.`testAllTypes#snapshots` order by committed_at limit 1";
+
+    String query = "select * from table(dfs.tmp.testAllTypes(type => 'iceberg', snapshotAsOfTime => %s))";
+
+    long snapshotId = queryBuilder().sql(snapshotQuery).singletonLong();
+    String plan = queryBuilder().sql(query, snapshotId).explainJson();
+    long count = queryBuilder().physical(plan).run().recordCount();
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSelectFromSnapshotId() throws Exception {
+    String snapshotQuery = "select snapshot_id from dfs.tmp.`testAllTypes#snapshots` order by committed_at limit 1";
+
+    String query = "select * from table(dfs.tmp.testAllTypes(type => 'iceberg', fromSnapshotId => %s))";
+
+    long snapshotId = queryBuilder().sql(snapshotQuery).singletonLong();
+    String plan = queryBuilder().sql(query, snapshotId).explainJson();
+    long count = queryBuilder().physical(plan).run().recordCount();
+    assertEquals(1, count);
+  }
+
+  @Test
+  public void testSelectFromSnapshotIdAndToSnapshotId() throws Exception {
+    String snapshotQuery = "select snapshot_id from dfs.tmp.`testAllTypes#snapshots` order by committed_at";
+
+    String query = "select * from table(dfs.tmp.testAllTypes(type => 'iceberg', fromSnapshotId => %s, toSnapshotId => %s))";
+
+    DirectRowSet rowSet = queryBuilder().sql(snapshotQuery).rowSet();
+    try {
+      RowSetReader reader = rowSet.reader();
+      assertTrue(reader.next());
+      Long fromSnapshotId = (Long) reader.column(0).reader().getObject();
+      assertTrue(reader.next());
+      Long toSnapshotId = (Long) reader.column(0).reader().getObject();
+
+      String plan = queryBuilder().sql(query, fromSnapshotId, toSnapshotId).explainJson();
+      long count = queryBuilder().physical(plan).run().recordCount();
+      assertEquals(1, count);
+    } finally {
+      rowSet.clear();
+    }
+  }
+
+  @Test
+  public void testSelectWithSnapshotIdAndSnapshotAsOfTime() throws Exception {
+    String query = "select * from table(dfs.tmp.testAllTypes(type => 'iceberg', snapshotId => %s, snapshotAsOfTime => %s))";
+    try {
+      queryBuilder().sql(query, 123, 456).run();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("Both 'snapshotId' and 'snapshotAsOfTime' cannot be specified"));
+    }
+  }
+
+  @Test
+  public void testAllTypes() throws Exception {
+    testBuilder()
+      .sqlQuery("select * from dfs.tmp.testAllTypes")
+      .unOrdered()
+      .baselineColumns("int_field", "long_field", "float_field", "double_field", "string_field",
+        "boolean_field", "time_field", "timestamp_field", "date_field", "decimal_field", "uuid_field",
+        "fixed_field", "binary_field", "list_field", "map_field", "struct_field", "repeated_struct_field",
+        "repeated_list_field", "repeated_map_field")
+      .baselineValues(1, 100L, 0.5F, 1.5D, "abc", true, LocalTime.of(2, 42, 42),
+        LocalDateTime.of(1994, 4, 18, 11, 0, 0), LocalDate.of(1994, 4, 18),
+        new BigDecimal("12.34"), new byte[16], new byte[10], "hello".getBytes(StandardCharsets.UTF_8),
+        listOf("a", "b", "c"),
+        mapOfObject(
+          new Text("a"), 0.1F,
+          new Text("b"), 0.2F),
+        mapOf(
+          "struct_int_field", 123,
+          "struct_string_field", "abc"),
+        listOf(
+          mapOf(
+            "struct_int_field", 123,
+            "struct_string_field", "abc"),
+          mapOf(
+            "struct_int_field", 123,
+            "struct_string_field", "abc")),
+        listOf(listOf("a", "b", "c"), listOf("a", "b", "c")),
+        listOf(
+          mapOfObject(
+            new Text("a"), 0.1F,
+            new Text("b"), 0.2F),
+          mapOfObject(
+            new Text("a"), 0.1F,
+            new Text("b"), 0.2F))
+        )
+      .baselineValues(null, null, null, null, null, null, null, null, null, null, null, null, null,
+        listOf(), mapOfObject(), mapOf(), listOf(), listOf(), listOf())
+      .baselineValues(988, 543L, Float.NaN, Double.MAX_VALUE, "def", false, LocalTime.of(3, 41, 53),
+        LocalDateTime.of(1995, 9, 10, 9, 0, 0), LocalDate.of(1995, 9, 10),
+        new BigDecimal("99.99"), new byte[16], new byte[10], "world".getBytes(StandardCharsets.UTF_8),
+        listOf("y", "n"),
+        mapOfObject(
+          new Text("true"), 1F,
+          new Text("false"), 0F),
+        mapOf(
+          "struct_int_field", 321,
+          "struct_string_field", "def"),
+        listOf(
+          mapOf(
+            "struct_int_field", 123,
+            "struct_string_field", "abc"),
+          mapOf(
+            "struct_int_field", 321,
+            "struct_string_field", "def")),
+        listOf(listOf("a", "b", "c"), listOf("y", "n")),
+        listOf(
+          mapOfObject(
+            new Text("a"), 0.1F,
+            new Text("b"), 0.2F),
+          mapOfObject(
+            new Text("true"), 1F,
+            new Text("false"), 0F))
+      )
+      .go();
+  }
+
+  @Test
+  public void testProjectingColumns() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("projection\\=struct<1: int_field: optional int, 5: string_field: optional string>")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("int_field", "string_field")
+      .baselineValues(1, "abc")
+      .baselineValues(null, null)
+      .baselineValues(988, "def")
+      .go();
+  }
+
+  @Test
+  public void testProjectNestedColumn() throws Exception {
+    String query = "select t.struct_field.struct_int_field as i, list_field[1] as l," +
+      "t.repeated_struct_field[0].struct_string_field s from dfs.tmp.testAllTypes t";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("projection\\=struct<" +
+        "14: list_field: optional list<string>, " +
+        "16: struct_field: required struct<23: struct_int_field: optional int>, " +
+        "17: repeated_struct_field: required list<struct<27: struct_string_field: optional string>>")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("i", "l", "s")
+      .baselineValues(123, "b", "abc")
+      .baselineValues(null, null, null)
+      .baselineValues(321, "n", "abc")
+      .go();
+  }
+
+  @Test
+  public void testFilterPushdown() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes where long_field = 100";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("filter\\=ref\\(name\\=\"long_field\"\\) \\=\\= 100")
+      .include("projection\\=struct<1: int_field: optional int, 2: long_field: optional long, 5: string_field: optional string>")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("int_field", "string_field")
+      .baselineValues(1, "abc")
+      .go();
+  }
+
+  @Test
+  public void testEmptyResults() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes where long_field = 101";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("filter\\=ref\\(name\\=\"long_field\"\\) \\=\\= 101")
+      .include("projection\\=struct<1: int_field: optional int, 2: long_field: optional long, 5: string_field: optional string>")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .expectsEmptyResultSet()
+      .go();
+  }
+
+  @Test
+  public void testFilterWithDifferentTypes() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes where long_field = '100'";
+
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("int_field", "string_field")
+      .baselineValues(1, "abc")
+      .go();
+  }
+
+  @Test
+  public void testSelectEntriesMetadata() throws Exception {
+    String query = "select * from dfs.tmp.`testAllTypes#entries`";
+
+    long count = queryBuilder().sql(query).run().recordCount();
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSelectFilesMetadata() throws Exception {
+    String query = "select * from dfs.tmp.`testAllTypes#files`";
+
+    long count = queryBuilder().sql(query).run().recordCount();
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSelectHistoryMetadata() throws Exception {
+    String query = "select * from dfs.tmp.`testAllTypes#history`";
+
+    List<HistoryEntry> entries = table.history();
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("made_current_at", "snapshot_id", "parent_id", "is_current_ancestor")
+      .baselineValues(LocalDateTime.ofInstant(Instant.ofEpochMilli(entries.get(0).timestampMillis()), ZoneId.of("UTC")),
+        entries.get(0).snapshotId(), null, true)
+      .baselineValues(LocalDateTime.ofInstant(Instant.ofEpochMilli(entries.get(1).timestampMillis()), ZoneId.of("UTC")),
+        entries.get(1).snapshotId(), entries.get(0).snapshotId(), true)
+      .go();
+  }
+
+  @Test
+  public void testSelectSnapshotsMetadata() throws Exception {
+    String query = "select * from dfs.tmp.`testAllTypes#snapshots`";
+
+    List<Snapshot> snapshots = new ArrayList<>();
+    table.snapshots().forEach(snapshots::add);
+
+    JsonStringHashMap<Object, Object> summaryMap = new JsonStringHashMap<>();
+    snapshots.get(0).summary().forEach((k, v) ->
+      summaryMap.put(new Text(k.getBytes(StandardCharsets.UTF_8)), new Text(v.getBytes(StandardCharsets.UTF_8))));
+
+    JsonStringHashMap<Object, Object> secondSummaryMap = new JsonStringHashMap<>();
+    snapshots.get(1).summary().forEach((k, v) ->
+      secondSummaryMap.put(new Text(k.getBytes(StandardCharsets.UTF_8)), new Text(v.getBytes(StandardCharsets.UTF_8))));
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("committed_at", "snapshot_id", "parent_id", "operation", "manifest_list", "summary")
+      .baselineValues(LocalDateTime.ofInstant(Instant.ofEpochMilli(snapshots.get(0).timestampMillis()), ZoneId.of("UTC")),
+        snapshots.get(0).snapshotId(), snapshots.get(0).parentId(), snapshots.get(0).operation(), snapshots.get(0).manifestListLocation(), summaryMap)
+      .baselineValues(LocalDateTime.ofInstant(Instant.ofEpochMilli(snapshots.get(1).timestampMillis()), ZoneId.of("UTC")),
+        snapshots.get(1).snapshotId(), snapshots.get(1).parentId(), snapshots.get(1).operation(), snapshots.get(1).manifestListLocation(), secondSummaryMap)
+      .go();
+  }
+
+  @Test
+  public void testSelectManifestsMetadata() throws Exception {
+    String query = "select * from dfs.tmp.`testAllTypes#manifests`";
+
+    long count = queryBuilder().sql(query).run().recordCount();
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSelectPartitionsMetadata() throws Exception {
+    String query = "select * from dfs.tmp.`testAllTypes#partitions`";
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("record_count", "file_count")
+      .baselineValues(3L, 2)
+      .go();
+  }
+
+  @Test
+  public void testSchemaProvisioning() throws Exception {
+    String query = "select int_field, string_field from table(dfs.tmp.testAllTypes(schema => 'inline=(int_field varchar not null default `error`)'))";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("projection\\=struct<1: int_field: optional int, 5: string_field: optional string>")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("int_field", "string_field")
+      .baselineValues("1", "abc")
+      .baselineValues("error", null)
+      .baselineValues("988", "def")
+      .go();
+  }
+
+  @Test
+  public void testSelectAvroFormat() throws Exception {
+    testBuilder()
+      .sqlQuery("select * from dfs.tmp.testAllTypesAvro")
+      .unOrdered()
+      .baselineColumns("struct_int_field", "struct_string_field")
+      .baselineValues(123, "abc")
+      .baselineValues(null, null)
+      .baselineValues(321, "def")
+      .go();
+  }
+
+  @Test
+  public void testSelectOrcFormat() throws Exception {
+    testBuilder()
+      .sqlQuery("select * from dfs.tmp.testAllTypesOrc")
+      .unOrdered()
+      .baselineColumns("struct_int_field", "struct_string_field")
+      .baselineValues(123, "abc")
+      .baselineValues(null, null)
+      .baselineValues(321, "def")
+      .go();
+  }
+
+  @Test
+  public void testSelectEmptyTable() throws Exception {
+    testBuilder()
+      .sqlQuery("select * from dfs.tmp.testAllTypesEmpty")
+      .unOrdered()
+      .expectsEmptyResultSet()
+      .go();
+  }
+
+  @Test
+  public void testLimit() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes limit 1";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("Limit\\(fetch\\=\\[1\\]\\)")
+      .include("maxRecords\\=1")
+      .match();
+
+    long count = queryBuilder().sql(query).run().recordCount();
+    assertEquals(1, count);
+  }
+
+  @Test
+  public void testLimitWithFilter() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes where int_field = 1 limit 1";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("Limit\\(fetch\\=\\[1\\]\\)")
+      .include("maxRecords\\=1")
+      .include("filter\\=ref\\(name=\"int_field\"\\) \\=\\= 1")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("int_field", "string_field")
+      .baselineValues(1, "abc")
+      .go();
+  }
+
+  @Test
+  public void testNoLimitWithSort() throws Exception {
+    String query = "select int_field, string_field from dfs.tmp.testAllTypes order by int_field limit 1";
+
+    queryBuilder()
+      .sql(query)
+      .planMatcher()
+      .include("Limit\\(fetch\\=\\[1\\]\\)")
+      .include("maxRecords\\=-1")
+      .match();
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("int_field", "string_field")
+      .baselineValues(1, "abc")
+      .go();
+  }
+
+}

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -64,6 +64,7 @@
     <module>storage-druid</module>
     <module>storage-elasticsearch</module>
     <module>storage-cassandra</module>
+    <module>format-iceberg</module>
   </modules>
 
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -443,6 +443,11 @@
           <artifactId>drill-druid-storage</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.drill.contrib</groupId>
+          <artifactId>drill-iceberg-format</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
     </profile>
 

--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -62,6 +62,7 @@
         <include>org.apache.drill.contrib:drill-opentsdb-storage:jar</include>
         <include>org.apache.drill.contrib:drill-udfs:jar</include>
         <include>org.apache.drill.contrib:drill-druid-storage:jar</include>
+        <include>org.apache.drill.contrib:drill-iceberg-format:jar</include>
       </includes>
       <outputDirectory>jars</outputDirectory>
       <useProjectArtifact>false</useProjectArtifact>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractBase.java
@@ -34,7 +34,7 @@ public abstract class AbstractBase implements PhysicalOperator {
   protected long initialAllocation = INIT_ALLOCATION;
   protected long maxAllocation = MAX_ALLOCATION;
 
-  private final String userName;
+  protected final String userName;
   private int id;
   private PrelCostEstimates cost = PrelCostEstimates.ZERO_COST;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillProjectRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillProjectRel.java
@@ -41,7 +41,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
  * Project implemented in Drill.
  */
 public class DrillProjectRel extends DrillProjectRelBase implements DrillRel {
-  protected DrillProjectRel(RelOptCluster cluster, RelTraitSet traits, RelNode child, List<? extends RexNode> exps,
+  public DrillProjectRel(RelOptCluster cluster, RelTraitSet traits, RelNode child, List<? extends RexNode> exps,
       RelDataType rowType) {
     super(DRILL_LOGICAL, cluster, traits, child, exps, rowType);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
@@ -87,7 +87,7 @@ public class DrillPushProjectIntoScanRule extends RelOptRule {
         }
       };
 
-  protected DrillPushProjectIntoScanRule(Class<? extends Project> projectClass, Class<? extends TableScan> scanClass, String description) {
+  public DrillPushProjectIntoScanRule(Class<? extends Project> projectClass, Class<? extends TableScan> scanClass, String description) {
     super(RelOptHelper.some(projectClass, RelOptHelper.any(scanClass)), description);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DynamicDrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DynamicDrillTable.java
@@ -24,17 +24,20 @@ import org.apache.drill.exec.planner.types.RelDataTypeHolder;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.drill.exec.util.ImpersonationUtil;
 
-public class DynamicDrillTable extends DrillTable{
+public class DynamicDrillTable extends DrillTable {
 
-  private final RelDataTypeHolder holder = new RelDataTypeHolder();
+  private final RelDataTypeHolder holder;
 
   public DynamicDrillTable(StoragePlugin plugin, String storageEngineName, String userName, Object selection) {
-    super(storageEngineName, plugin, userName, selection);
+    this(plugin, storageEngineName, userName, selection, null);
   }
 
-  public DynamicDrillTable(StoragePlugin plugin, String storageEngineName, String userName, Object selection, MetadataProviderManager metadataProviderManager) {
+  public DynamicDrillTable(StoragePlugin plugin, String storageEngineName, String userName,
+    Object selection, MetadataProviderManager metadataProviderManager) {
     super(storageEngineName, plugin, Schema.TableType.TABLE, userName, selection, metadataProviderManager);
+    this.holder = new RelDataTypeHolder();
   }
 
   /**
@@ -44,7 +47,7 @@ public class DynamicDrillTable extends DrillTable{
    * constructor.
    */
   public DynamicDrillTable(StoragePlugin plugin, String storageEngineName, Object selection) {
-    super(storageEngineName, plugin, selection);
+    this(plugin, storageEngineName, ImpersonationUtil.getProcessUserName(), selection, null);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/RelDataTypeHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/RelDataTypeHolder.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.exec.planner.types;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.calcite.rel.type.DynamicRecordType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -31,7 +31,7 @@ import org.apache.drill.common.expression.SchemaPath;
 public class RelDataTypeHolder extends AbstractRelDataTypeHolder {
 
   public RelDataTypeHolder() {
-    super(Lists.<RelDataTypeField>newArrayList());
+    super(new ArrayList<>());
   }
 
   public List<RelDataTypeField> getFieldList(RelDataTypeFactory typeFactory) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/ColumnConverterFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/ColumnConverterFactory.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.vector.accessor.ValueWriter;
 import org.apache.drill.exec.vector.complex.DictVector;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -91,8 +92,10 @@ public class ColumnConverterFactory {
 
   private TupleMetadata providedChildSchema(TupleMetadata providedSchema,
       ColumnMetadata readerSchema) {
-    return providedSchema == null ? null :
-      providedSchema.metadata(readerSchema.name()).tupleSchema();
+    return Optional.ofNullable(providedSchema)
+      .map(schema -> providedSchema.metadata(readerSchema.name()))
+      .map(ColumnMetadata::tupleSchema)
+      .orElse(null);
   }
 
   private ColumnConverter getArrayConverter(TupleMetadata providedSchema,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/SubsetRemover.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/SubsetRemover.java
@@ -21,6 +21,7 @@ import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.RelShuttleImpl;
+import org.apache.calcite.util.Util;
 
 /**
  * Removes {@link RelSubset} nodes from the plan.
@@ -33,7 +34,8 @@ public class SubsetRemover extends RelShuttleImpl {
   @Override
   public RelNode visit(RelNode other) {
     if (other instanceof RelSubset) {
-      return ((RelSubset) other).getBest().accept(this);
+      RelSubset relSubset = (RelSubset) other;
+      return Util.first(relSubset.getBest(), relSubset.getOriginal()).accept(this);
     } else {
       return super.visit(other);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatLocationTransformer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatLocationTransformer.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.dfs;
+
+import java.util.function.Function;
+
+/**
+ * Provides the ability to transform format location before creating
+ * {@link FileSelection} if required.
+ * <p>
+ * For example, a specified location can have some metadata info,
+ * so location transformer implementation may extract this metadata info,
+ * and create {@link FileSelection} with the actual location.
+ */
+public interface FormatLocationTransformer {
+
+  /**
+   * Checks whether specified location can be transformed.
+   *
+   * @param location location to check
+   * @return {@code true} if specified location can be transformed,
+   * {@code false} otherwise
+   */
+  boolean canTransform(String location);
+
+  /**
+   * Transforms specified location and returns {@link FileSelection} instance with updated location.
+   *
+   * @param location         location to transform
+   * @param selectionFactory file selection factory
+   * @return {@link FileSelection} instance with updated location
+   */
+  FileSelection transform(String location, Function<String, FileSelection> selectionFactory);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatMatcher.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatMatcher.java
@@ -25,10 +25,33 @@ import java.io.IOException;
 
 public abstract class FormatMatcher {
 
+  public static final int MEDIUM_PRIORITY = 5;
+  public static final int HIGH_PRIORITY = 7;
+
   public abstract boolean supportDirectoryReads();
   public abstract DrillTable isReadable(DrillFileSystem fs,
       FileSelection selection, FileSystemPlugin fsPlugin,
       String storageEngineName, SchemaConfig schemaConfig) throws IOException;
   public abstract boolean isFileReadable(DrillFileSystem fs, FileStatus status) throws IOException;
   public abstract FormatPlugin getFormatPlugin();
+
+  /**
+   * Priority of specific format matcher to be applied.
+   * Can be used for the case when several formats can match the format,
+   * but matchers with some more specific requirements should be applied at first.
+   *
+   * @return priority of {@link this} format matcher.
+   */
+  public int priority() {
+    return MEDIUM_PRIORITY;
+  }
+
+  /**
+   * Returns {@link FormatLocationTransformer} instance relevant for {@link this} format matcher.
+   *
+   * @return {@link FormatLocationTransformer} instance
+   */
+  public FormatLocationTransformer getFormatLocationTransformer() {
+    return null;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
@@ -69,7 +69,8 @@ public interface FormatPlugin {
       case PHYSICAL:
         return getOptimizerRules();
       case LOGICAL:
-      case JOIN_PLANNING:case LOGICAL_PRUNE_AND_JOIN:
+      case JOIN_PLANNING:
+      case LOGICAL_PRUNE_AND_JOIN:
       case LOGICAL_PRUNE:
       case PARTITION_PRUNING:
       default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
@@ -18,9 +18,11 @@
 package org.apache.drill.exec.store.dfs;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.calcite.plan.RelOptRule;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -28,10 +30,11 @@ import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.physical.base.AbstractWriter;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.planner.PlannerPhase;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -56,7 +59,23 @@ public interface FormatPlugin {
   AbstractWriter getWriter(PhysicalOperator child, String location,
       List<String> partitionColumns) throws IOException;
 
-  Set<StoragePluginOptimizerRule> getOptimizerRules();
+  @Deprecated
+  default Set<? extends RelOptRule> getOptimizerRules() {
+    return Collections.emptySet();
+  }
+
+  default Set<? extends RelOptRule> getOptimizerRules(PlannerPhase phase) {
+    switch (phase) {
+      case PHYSICAL:
+        return getOptimizerRules();
+      case LOGICAL:
+      case JOIN_PLANNING:case LOGICAL_PRUNE_AND_JOIN:
+      case LOGICAL_PRUNE:
+      case PARTITION_PRUNING:
+      default:
+        return ImmutableSet.of();
+    }
+  }
 
   AbstractGroupScan getGroupScan(String userName, FileSelection selection,
       List<SchemaPath> columns) throws IOException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/EnumerableRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/EnumerableRecordReader.java
@@ -164,5 +164,6 @@ public class EnumerableRecordReader implements ManagedReader<SchemaNegotiator> {
 
   @Override
   public void close() {
+    loader.close();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
@@ -126,6 +126,16 @@ public abstract class AbstractPluginImplementor implements PluginImplementor {
     return false;
   }
 
+  @Override
+  public boolean splitProject(Project project) {
+    return false;
+  }
+
+  @Override
+  public boolean artificialLimit() {
+    return false;
+  }
+
   private UserException getUnsupported(String rel) {
     return UserException.unsupportedError()
         .message("Plugin implementor doesn't support push down for %s", rel)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/PluginImplementor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/PluginImplementor.java
@@ -83,4 +83,14 @@ public interface PluginImplementor {
   default void visitChild(RelNode input) throws IOException {
     ((PluginRel) input).implement(this);
   }
+
+  boolean splitProject(Project project);
+
+  /**
+   * If the plugin doesn't support native limit pushdown,
+   * but the reader can limit the number of rows to read.
+   * In this case limit operator on top of the scan should be preserved
+   * to ensure returning the correct rows number.
+   */
+  boolean artificialLimit();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginConverterRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginConverterRule.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.plan.rule;
 
+import lombok.Getter;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTrait;
@@ -39,6 +40,7 @@ import java.util.function.Predicate;
  */
 public abstract class PluginConverterRule extends ConverterRule {
 
+  @Getter
   private final PluginImplementor pluginImplementor;
 
   protected PluginConverterRule(Class<? extends RelNode> clazz,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginProjectRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginProjectRule.java
@@ -21,8 +21,19 @@ import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.rules.ProjectRemoveRule;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+import org.apache.drill.exec.planner.index.ExprToRex;
+import org.apache.drill.exec.planner.logical.DrillProjectRel;
+import org.apache.drill.exec.planner.logical.DrillRel;
 import org.apache.drill.exec.store.plan.PluginImplementor;
 import org.apache.drill.exec.store.plan.rel.PluginProjectRel;
+import org.apache.drill.exec.util.Utilities;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The rule that converts provided project operator to plugin-specific implementation.
@@ -36,12 +47,63 @@ public class PluginProjectRule extends PluginConverterRule {
   @Override
   public RelNode convert(RelNode rel) {
     Project project = (Project) rel;
-    return new PluginProjectRel(
+
+    if (!getPluginImplementor().splitProject(project)) {
+      return new PluginProjectRel(
         getOutConvention(),
         project.getCluster(),
         project.getTraitSet().replace(getOutConvention()),
         convert(project.getInput(), project.getTraitSet().replace(getOutConvention())),
         project.getProjects(),
         project.getRowType());
+    }
+
+    RelDataType inputRowType = project.getInput().getRowType();
+    if (inputRowType.getFieldList().isEmpty()) {
+      return null;
+    }
+
+    DrillRelOptUtil.ProjectPushInfo projectPushInfo =
+      DrillRelOptUtil.getFieldsInformation(inputRowType, project.getProjects());
+    Project pluginProject = createPluginProject(project, projectPushInfo);
+    if (Utilities.isStarQuery(projectPushInfo.getFields()) ||
+      pluginProject.getRowType().equals(inputRowType)) {
+      return null;
+    }
+
+    List<RexNode> newProjects = project.getChildExps().stream()
+      .map(n -> n.accept(projectPushInfo.getInputReWriter()))
+      .collect(Collectors.toList());
+
+    Project newProject =
+      createProject(project, pluginProject, newProjects);
+
+    if (ProjectRemoveRule.isTrivial(newProject)) {
+      return pluginProject;
+    } else {
+      return newProject;
+    }
+  }
+
+  protected Project createPluginProject(Project project, DrillRelOptUtil.ProjectPushInfo projectPushInfo) {
+    ExprToRex exprToRex = new ExprToRex(project.getInput(), project.getInput().getRowType(), project.getCluster().getRexBuilder());
+    List<RexNode> newProjects = projectPushInfo.getFields().stream()
+      .map(f -> f.accept(exprToRex, null))
+      .collect(Collectors.toList());
+    return new PluginProjectRel(
+      getOutConvention(),
+      project.getCluster(),
+      project.getTraitSet().replace(getOutConvention()),
+      convert(project.getInput(), project.getTraitSet().replace(getOutConvention())),
+      newProjects,
+      projectPushInfo.createNewRowType(project.getCluster().getTypeFactory()));
+  }
+
+  protected Project createProject(Project project, Project input, List<RexNode> newProjects) {
+    return new DrillProjectRel(project.getCluster(),
+      project.getTraitSet().plus(DrillRel.DRILL_LOGICAL),
+      input,
+      newProjects,
+      project.getRowType());
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
@@ -344,7 +344,9 @@ public class FragmentExecutor implements Runnable {
       // Swallow interrupted exceptions since we intentionally interrupt the root when cancelling a query
       logger.trace("Interrupted root: {}", root, e);
     } catch (Throwable t) {
-      root.dumpBatches(t);
+      if (root != null) {
+        root.dumpBatches(t);
+      }
       fail(t);
     } finally {
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MetadataUtils.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MetadataUtils.java
@@ -133,7 +133,7 @@ public class MetadataUtils {
   }
 
   public static MapColumnMetadata newMap(String name, TupleMetadata schema) {
-    return new MapColumnMetadata(name, DataMode.REQUIRED, (TupleSchema) schema);
+    return newMap(name, DataMode.REQUIRED, schema);
   }
 
   public static MapColumnMetadata newMap(String name) {
@@ -185,7 +185,11 @@ public class MetadataUtils {
   }
 
   public static ColumnMetadata newMapArray(String name, TupleMetadata schema) {
-    return new MapColumnMetadata(name, DataMode.REPEATED, (TupleSchema) schema);
+    return newMap(name, DataMode.REPEATED, schema);
+  }
+
+  public static MapColumnMetadata newMap(String name, DataMode dataMode, TupleMetadata schema) {
+    return new MapColumnMetadata(name, dataMode, (TupleSchema) schema);
   }
 
   public static ColumnMetadata newMapArray(String name) {
@@ -227,12 +231,12 @@ public class MetadataUtils {
     if (precision > maxPrecision) {
       throw new IllegalArgumentException(String.format(
           "%s(%d, %d) exceeds maximum suppored precision of %d",
-          type.toString(), precision, scale, maxPrecision));
+        type, precision, scale, maxPrecision));
     }
     if (scale > precision) {
       throw new IllegalArgumentException(String.format(
           "%s(%d, %d) scale exceeds precision",
-          type.toString(), precision, scale));
+        type, precision, scale));
     }
     MaterializedField field = new ColumnBuilder(name, type)
         .setMode(mode)
@@ -276,7 +280,7 @@ public class MetadataUtils {
 
   public static ColumnMetadata cloneMapWithSchema(ColumnMetadata source,
       TupleMetadata members) {
-    return new MapColumnMetadata(source.name(), source.mode(), (TupleSchema) members);
+    return newMap(source.name(), source.mode(), members);
   }
 
   public static ColumnMetadata diffMap(ColumnMetadata map, ColumnMetadata other) {

--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -31,7 +31,6 @@
   <name>Drill : Metastore : Iceberg</name>
 
   <properties>
-    <iceberg.version>0.12.0</iceberg.version>
     <caffeine.version>2.7.0</caffeine.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
     <lombok.version>1.18.20</lombok.version>
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <aircompressor.version>0.20</aircompressor.version>
+    <iceberg.version>0.12.1</iceberg.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
# [DRILL-8027](https://issues.apache.org/jira/browse/DRILL-8027): Format plugin for Apache Iceberg

## Description
Format plugin for Apache Iceberg.

Functionality:
- [x] support reading data from Iceberg tables in Parquet, Avro, and ORC formats
- [x] push down fields used in the project
- [x] push down supported filter expressions
- [x] artificial limit push down
- [x] spit and parallelize reading tasks
- [x] provide a way for specifying Iceberg-specific configurations
- [x] support schema provisioning
- [x] read specific snapshot versions if configured
- [x] read table metadata (entries, files, history, snapshots, manifests, partitions, etc.)
- [x] additional testing
- [x] documentation

## Documentation
Please refer to https://github.com/apache/drill/pull/2357/files#diff-a13d1dd7ae87c610fb4695b2cb410bca0cee6d8d912bf21bae9b4166e83a72de

After merging this PR and adding documentation to the Drill website, we can leave a reference to it in official Icebeberg documentation [here](https://iceberg.apache.org/#) as it is done for Trino and PrestoDB.

## Testing
Added UT, checked several scenarios manually.

closes #2269 