### PR TITLE
Exclude .js Files From LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Format of this file: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file
 path_classifiers:
   documentation:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,6 @@
+# Format of this file: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file
+path_classifiers:
+  documentation:
+    - docs/dev/*
+  excludes:
+    - exec/java-exec/src/main/resources/rest/static/js/*.js

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,7 @@
             <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->
             <exclude>**/resources/parquet/**/*</exclude>
             <exclude>**/.asf.yaml</exclude>
+            <exclude>**/.lgtm.yml</exclude>
             <exclude>**/*.woff2</exclude>
             <exclude>**/*.ks</exclude>
             <exclude>**/*.pcap</exclude>
@@ -688,6 +689,7 @@
               <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->
               <exclude>**/resources/parquet/**/*</exclude>
               <exclude>**/.asf.yaml</exclude>
+              <exclude>**/.lgtm.yml</exclude>
               <exclude>**/*.woff2</exclude>
               <exclude>**/*.ks</exclude>
               <exclude>**/*.pcap</exclude>


### PR DESCRIPTION
Adds an exclusion to LGTM code audit.  Specifically all the minified `js` files from D3.

## Description
This minor update creates an `lgtm.yml` file and excludes the D3 files from code audit.  Since these files are not maintained by the Drill team and are mimified, they create some alerts that are not relevant to Drill. 

## Documentation
N/A

## Testing
N/A