### PR TITLE
DRILL-8029: Upgrade project parent POM to 24 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>21</version>
+    <version>24</version>
     <relativePath />
   </parent>
 
@@ -41,7 +41,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <sourceReleaseAssemblyDescriptor>source-release-zip-tar</sourceReleaseAssemblyDescriptor>
-
+    <project.build.outputTimestamp>1</project.build.outputTimestamp>
     <target.gen.source.path>${project.basedir}/target/generated-sources</target.gen.source.path>
     <proto.cas.path>${project.basedir}/src/main/protobuf/</proto.cas.path>
     <junit.version>5.7.2</junit.version>
@@ -237,7 +237,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>6.0.4</version>
+        <version>6.4.1</version>
       </plugin>
     </plugins>
   </reporting>
@@ -2086,6 +2086,7 @@
           <plugin>
             <groupId>net.nicoulaj.maven.plugins</groupId>
             <artifactId>checksum-maven-plugin</artifactId>
+            <version>1.11</version>
             <executions>
               <execution>
                 <id>source-release-checksum</id>


### PR DESCRIPTION
# [DRILL-8029](https://issues.apache.org/jira/browse/DRILL-8029): Upgrade project parent POM to 24 version

## Description

This parent POM will allow to use latest maven plugins declared for Apache license projects and improves the project release process.
All details about this Apache Software Foundation Parent POM version and diffs with the previous ones are here:
https://maven.apache.org/pom/asf/

