### PR TITLE
DRILL-8040: Add HTTP status codes for API errors

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
@@ -98,19 +98,18 @@ public class QueryResources {
   @Produces(MediaType.APPLICATION_JSON)
   public StreamingOutput submitQueryJSON(QueryWrapper query) throws Exception {
 
-    // Prior to Drill 1.18, REST queries would batch the entire result set
-    // in memory, limiting query size. In Drill 1.19 and later, results are
-    // streamed from the executor, to the JSON writer and to the HTTP connection
-    // with no buffering.
-    //
-    // For compatibility with Drill 1.18 and before, Drill places the query
-    // schema *after* the data. Any tool that needs to know the schema will
-    // need to buffer the entire result set to wait for the schema. An obvious
-    // improvement is to provide an option to send the schema *before* the data.
-    // One drawback of doing so is that the schema will report that of the first
-    // batch: Drill allows schema to change across batches and thus the schema
-    // of the JSON-encoded data would change. This is more a bug with how Drill
-    // handles schemas than a JSON issue. (ODBC and JDBC have the same issues.)
+    /*
+    Prior to Drill 1.18, REST queries would batch the entire result set in memory,
+    limiting query size. In Drill 1.19 and later, results are streamed from the
+    executor, to the JSON writer and to the HTTP connection with no buffering.
+
+    Starting with Drill 1.19, the "metadata" property specifying the result column
+    data types is placed *before* the data itself. One drawback of doing so is that
+    the schema will report that of the first batch: Drill allows schema to change
+    across batches and thus the schema of the JSON-encoded data would change. This
+    is more a bug with how Drill handles schemas than a JSON issue. (ODBC and JDBC
+    have the same issues.)
+    */
     QueryRunner runner = new QueryRunner(work, webUserConnection);
     try {
       runner.start(query);

--- a/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
@@ -22,6 +22,8 @@ function serverMessage(data) {
         setTimeout(function() { window.location.href = "/storage"; }, 800);
         return true;
     } else {
+	    const errorMessage = data.errorMessage || data.result;
+
         messageEl.addClass("d-none");
         // Wait a fraction of a second before showing the message again. This
         // makes it clear if a second attempt gives the same error as
@@ -30,7 +32,7 @@ function serverMessage(data) {
             messageEl.removeClass("d-none")
                 .removeClass("alert-info")
                 .addClass("alert-danger")
-                .text("Please retry: " + data.result).alert();
+                .text("Please retry: " + errorMessage).alert();
         }, 200);
         return false;
     }

--- a/exec/java-exec/src/main/resources/rest/storage/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/list.ftl
@@ -131,7 +131,8 @@
             </div>
             <div class="radio">
               <label>
-                <input type="radio" name="format" id="hocon" value="conf">
+                <!-- Exporting to HOCON is not currently supported, see StorageResources.java. -->
+                <input type="radio" name="format" id="hocon" value="conf" disabled>
                 HOCON
               </label>
             </div>
@@ -214,8 +215,13 @@
           if (data.result === "Success") {
             location.reload();
           } else {
-              populateAndShowAlert('pluginEnablingFailure', {'_pluginName_': name,'_errorMessage_': data.result});
+            populateAndShowAlert('pluginEnablingFailure', {'_pluginName_': name,'_errorMessage_': data.result});
           }
+        }).fail(function(response) {
+          populateAndShowAlert(
+            'pluginEnablingFailure',
+            {'_pluginName_': name,'_errorMessage_': response.responseJSON.result}
+          );
         });
       }
     }
@@ -227,7 +233,8 @@
     function doCreate() {
       $("#createForm").ajaxForm({
         dataType: 'json',
-        success: serverMessage
+        success: serverMessage,
+        error: serverMessage
       });
     }
 
@@ -254,7 +261,6 @@
     // Modal windows management
     let exportInstance; // global variable
     $('#pluginsModal').on('show.bs.modal', function(event) {
-        console.log("alarm");
       const button = $(event.relatedTarget); // Button that triggered the modal
       const modal = $(this);
       exportInstance = button.attr("name");

--- a/exec/java-exec/src/main/resources/rest/storage/update.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/update.ftl
@@ -125,6 +125,10 @@
           if (serverMessage(data)) {
               setTimeout(function() { location.reload(); }, 800);
           }
+        }).fail(function(response) {
+          if (serverMessage(response.responseJSON)) {
+              setTimeout(function() { location.reload(); }, 800);
+          }
         });
       }
     });
@@ -132,13 +136,16 @@
     function doUpdate() {
       $("#updateForm").ajaxForm({
         dataType: 'json',
-        success: serverMessage
+        success: serverMessage,
+        error: serverMessage
       });
     }
 
     function deleteFunction() {
       showConfirmationDialog('"${model.getPlugin().getName()}"' + ' plugin will be deleted. Proceed?', function() {
-        $.get("/storage/" + encodeURIComponent("${model.getPlugin().getName()}") + "/delete", serverMessage);
+        $.get("/storage/" + encodeURIComponent("${model.getPlugin().getName()}") + "/delete", serverMessage).fail(function() {
+					serverMessage({ errorMessage: "Error while trying to delete." })
+        });
       });
     }
 


### PR DESCRIPTION
# [DRILL-8040](https://issues.apache.org/jira/browse/DRILL-8040): Return an HTTP error code from failed REST API operations

## Description

Multiple REST API operations, notably affecting storage config operations, return an error message with an HTTP status code of 200 when an operation fails.  The web UI depends on this behaviour in some places.  REST clients should receive an HTTP error code instead.

There are some subtleties.  Submitting a new query than later goes on to fail in execution still sees a 200 returned for the query submission.  The storage plugin store does not raise an error if you try to delete something that it does not contain, so deleting something nonexistent is still a 200.  

## Documentation
Add a note indicating that failed operations will generally result in an HTTP error code.

## Testing
- Existing test coverage.
- Send invalid requests to the REST API and check HTTP response code
- Use all pages of the web UI to test that normal functionality is still working, while monitoring XHR requests made from the browser.
