### PR TITLE
DRILL-8041: Fix mongo scan spec deserialization

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/BaseMongoSubScanSpec.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/BaseMongoSubScanSpec.java
@@ -18,6 +18,8 @@
 package org.apache.drill.exec.store.mongo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
@@ -26,7 +28,12 @@ import java.util.List;
 
 @Getter
 @Setter
-@SuperBuilder(setterPrefix = "set")
+@SuperBuilder
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(MongoSubScan.ShardedMongoSubScanSpec.class),
+  @JsonSubTypes.Type(MongoSubScan.MongoSubScanSpec.class)
+})
 public class BaseMongoSubScanSpec {
 
   @JsonProperty

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.mongo;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -113,14 +112,14 @@ public class MongoGroupScan extends AbstractGroupScan implements
       @JsonProperty("storage") MongoStoragePluginConfig storagePluginConfig,
       @JsonProperty("columns") List<SchemaPath> columns,
       @JsonProperty("useAggregate") boolean useAggregate,
-      @JacksonInject StoragePluginRegistry pluginRegistry) throws IOException {
+      @JacksonInject StoragePluginRegistry pluginRegistry) {
     this(userName,
         pluginRegistry.resolve(storagePluginConfig, MongoStoragePlugin.class),
         scanSpec, columns, useAggregate);
   }
 
   public MongoGroupScan(String userName, MongoStoragePlugin storagePlugin,
-      MongoScanSpec scanSpec, List<SchemaPath> columns, boolean useAggregate) throws IOException {
+      MongoScanSpec scanSpec, List<SchemaPath> columns, boolean useAggregate) {
     super(userName);
     this.storagePlugin = storagePlugin;
     this.storagePluginConfig = storagePlugin.getConfig();
@@ -350,7 +349,7 @@ public class MongoGroupScan extends AbstractGroupScan implements
   public GroupScan clone(int maxRecords) {
     MongoGroupScan clone = new MongoGroupScan(this);
     clone.useAggregate = true;
-    clone.getScanSpec().getOperations().add(new Document("$limit", maxRecords));
+    clone.getScanSpec().getOperations().add(new Document("$limit", maxRecords).toJson());
     return clone;
   }
 
@@ -450,19 +449,19 @@ public class MongoGroupScan extends AbstractGroupScan implements
   private BaseMongoSubScanSpec buildSubScanSpecAndGet(ChunkInfo chunkInfo) {
     if (useAggregate) {
       return MongoSubScanSpec.builder()
-          .setOperations(scanSpec.getOperations())
-          .setDbName(scanSpec.getDbName())
-          .setCollectionName(scanSpec.getCollectionName())
-          .setHosts(chunkInfo.getChunkLocList())
+          .operations(scanSpec.getOperations())
+          .dbName(scanSpec.getDbName())
+          .collectionName(scanSpec.getCollectionName())
+          .hosts(chunkInfo.getChunkLocList())
           .build();
     }
     return ShardedMongoSubScanSpec.builder()
-        .setMinFilters(chunkInfo.getMinFilters())
-        .setMaxFilters(chunkInfo.getMaxFilters())
-        .setFilter(scanSpec.getFilters())
-        .setDbName(scanSpec.getDbName())
-        .setCollectionName(scanSpec.getCollectionName())
-        .setHosts(chunkInfo.getChunkLocList())
+        .minFilters(chunkInfo.getMinFilters())
+        .maxFilters(chunkInfo.getMaxFilters())
+        .filter(scanSpec.getFilters())
+        .dbName(scanSpec.getDbName())
+        .collectionName(scanSpec.getCollectionName())
+        .hosts(chunkInfo.getChunkLocList())
         .build();
   }
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoScanSpec.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoScanSpec.java
@@ -22,9 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
-import org.bson.Document;
-
-import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,9 +33,9 @@ public class MongoScanSpec {
   private final String dbName;
   private final String collectionName;
 
-  private Document filters;
+  private String filters;
 
-  private List<Bson> operations = new ArrayList<>();
+  private List<String> operations = new ArrayList<>();
 
   @JsonCreator
   public MongoScanSpec(@JsonProperty("dbName") String dbName,

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
@@ -23,11 +23,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.apache.drill.common.exceptions.ExecutionSetupException;
+import lombok.extern.jackson.Jacksonized;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractBase;
@@ -42,8 +41,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.bson.Document;
-import org.bson.conversions.Bson;
 
 @JsonTypeName("mongo-shard-read")
 public class MongoSubScan extends AbstractBase implements SubScan {
@@ -64,8 +61,7 @@ public class MongoSubScan extends AbstractBase implements SubScan {
       @JsonProperty("userName") String userName,
       @JsonProperty("mongoPluginConfig") StoragePluginConfig mongoPluginConfig,
       @JsonProperty("chunkScanSpecList") LinkedList<BaseMongoSubScanSpec> chunkScanSpecList,
-      @JsonProperty("columns") List<SchemaPath> columns)
-      throws ExecutionSetupException {
+      @JsonProperty("columns") List<SchemaPath> columns) {
     super(userName);
     this.columns = columns;
     this.mongoPluginConfig = (MongoStoragePluginConfig) mongoPluginConfig;
@@ -88,11 +84,6 @@ public class MongoSubScan extends AbstractBase implements SubScan {
   public <T, X, E extends Throwable> T accept(
       PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
     return physicalVisitor.visitSubScan(this, value);
-  }
-
-  @JsonIgnore
-  public MongoStoragePluginConfig getMongoPluginConfig() {
-    return mongoPluginConfig;
   }
 
   @JsonIgnore
@@ -125,11 +116,10 @@ public class MongoSubScan extends AbstractBase implements SubScan {
     return Collections.emptyIterator();
   }
 
-  @JsonTypeName("ShardedMongoSubScanSpec")
   @Getter
   @ToString
-  @SuperBuilder(setterPrefix = "set")
-  @JsonDeserialize(builder = ShardedMongoSubScanSpec.ShardedMongoSubScanSpecBuilder.class)
+  @Jacksonized
+  @SuperBuilder
   public static class ShardedMongoSubScanSpec extends BaseMongoSubScanSpec {
 
     @JsonProperty
@@ -139,19 +129,18 @@ public class MongoSubScan extends AbstractBase implements SubScan {
     private final Map<String, Object> maxFilters;
 
     @JsonProperty
-    private final Document filter;
+    private final String filter;
 
   }
 
-  @JsonTypeName("MongoSubScanSpec")
   @Getter
   @ToString
-  @SuperBuilder(setterPrefix = "set")
-  @JsonDeserialize(builder = MongoSubScanSpec.MongoSubScanSpecBuilder.class)
+  @Jacksonized
+  @SuperBuilder
   public static class MongoSubScanSpec extends BaseMongoSubScanSpec {
 
     @JsonProperty
-    private final List<Bson> operations;
+    private final List<String> operations;
 
   }
 

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoQueries.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoQueries.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.mongo;
 
 import org.apache.drill.categories.MongoStorageTest;
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.exec.ExecConstants;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -50,6 +51,21 @@ public class TestMongoQueries extends MongoTestBase {
       .explainJson();
 
     assertEquals(queryBuilder().physical(plan).run().recordCount(), 11);
+  }
+
+  @Test
+  public void testFragmentSerDe() throws Exception {
+    client.alterSession(ExecConstants.SLICE_TARGET, 1);
+    try {
+      String plan = queryBuilder()
+        .sql(String.format("select t1.id as id, t1.name from mongo.%1$s.`%2$s` t1 where t1.name = 'Cake' union " +
+          "select t2.id as id, t2.name from mongo.%1$s.`%2$s` t2 ", DONUTS_DB, DONUTS_COLLECTION))
+        .explainJson();
+
+      assertEquals(queryBuilder().physical(plan).run().recordCount(), 5);
+    } finally {
+      client.resetSession(ExecConstants.SLICE_TARGET);
+    }
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-8041](https://issues.apache.org/jira/browse/DRILL-8041): Fix mongo scan spec deserialization

## Description
Fixed deserialization of mongo scan spec classes.

## Documentation
NA

## Testing
Added UT

closes #2355 
