### PR TITLE
DRILL-8042: Select star from MongoDB with aggregated pipeline fails with empty $project error

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -188,7 +188,9 @@ public class MongoRecordReader extends AbstractRecordReader {
       MongoIterable<BsonDocument> projection;
       if (CollectionUtils.isNotEmpty(operations)) {
         List<Bson> operations = new ArrayList<>(this.operations);
-        operations.add(Aggregates.project(fields));
+        if (!fields.isEmpty()) {
+          operations.add(Aggregates.project(fields));
+        }
         projection = collection.aggregate(operations);
       } else {
         projection = collection.find(filters).projection(fields);

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/RexToMongoTranslator.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/RexToMongoTranslator.java
@@ -219,7 +219,7 @@ class RexToMongoTranslator extends RexVisitorImpl<BsonValue> {
 
     @Override
     public Boolean visitInputRef(RexInputRef inputRef) {
-      return true;
+      return inputRef.getType().getSqlTypeName() != SqlTypeName.DYNAMIC_STAR;
     }
 
     @Override

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
@@ -69,4 +69,13 @@ public class TestMongoLimitPushDown extends MongoTestBase {
       .include("\"\\$limit\": 4", "\"\\$eq\": 52\\.17")
       .match();
   }
+
+  @Test
+  public void testSelectStarWithLimit() throws Exception {
+    testBuilder()
+      .sqlQuery("SELECT * FROM mongo.employee.`empinfo` LIMIT 4")
+      .unOrdered()
+      .expectsNumRecords(4)
+      .go();
+  }
 }


### PR DESCRIPTION
# [DRILL-8042](https://issues.apache.org/jira/browse/DRILL-8042): Select star from MongoDB with aggregated pipeline fails with empty $project error

## Description
Updated code to prevent creating aggregates project for empty pipeline and updated mongo plugin implementor to prevent project pushdown for the case of star queries.

## Documentation
NA

## Testing
Added unit test.

closes #2367