### PR TITLE
DRILL-8025: Bump HBase client version to 2.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     -->
     <hive.version>3.1.2</hive.version>
     <hadoop.version>3.2.2</hadoop.version>
-    <hbase.version>2.4.2</hbase.version>
+    <hbase.version>2.4.8</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>
     <javassist.version>3.27.0-GA</javassist.version>


### PR DESCRIPTION
# [DRILL-8025](https://issues.apache.org/jira/browse/DRILL-8025): Bump HBase client version to 2.4.8

## Description

Bump HBase client version to 2.4.8

## Documentation
user will not really notice that change.

## Testing
Just ran build and tests... at least the hbase part was successfull.... splunk had a problem but i dont think this has something to do with that change.

Regards,
Christian 
