### PR TITLE
DRILL-8043: Excel Reader Regression Fix

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Format : Excel</name>
 
   <properties>
-    <poi.version>5.1.0</poi.version>
+    <poi.version>5.0.0</poi.version>
   </properties>
   <dependencies>
     <dependency>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>3.2.0</version>
+      <version>3.1.6</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
# [DRILL-8043](https://issues.apache.org/jira/browse/DRILL-8043): Excel Reader Regression Fix

## Description
DRILL-8033 (https://github.com/apache/drill/pull/2363) caused a regression with reading excel files.  See (https://github.com/pjfanning/excel-streaming-reader/issues/76)  This PR reverts back to the previous version of POI.

The issue seems to be related to the change in logging in POI to log4j 2.x.  I attempted to exclude the logger in POI as well as include `org.apache.logging.log4j:log4j-to-slf4j:2.14.1` in the Excel module.  Neither solved the issue.  For the time being I would propose we revert back to the original dependencies which work. 

As a bit of an aside, I found it curious that the unit tests all successfully completed, but when you tried to query Excel normally, the queries all failed. It might be worth looking into why that is the case.

## Documentation
No user facing changes.

## Testing
Ran all unit tests and manually ran queries on Excel files.