### PR TITLE
DRILL-8045: Fix storage export regression introduced by DRILL-8040

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -208,7 +208,7 @@ public class StorageResources {
         .build();
     }
 
-    return Response.ok(getPluginConfig(name))
+    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
       .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format))
       .build();
   }

--- a/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
@@ -22,7 +22,7 @@ function serverMessage(data) {
         setTimeout(function() { window.location.href = "/storage"; }, 800);
         return true;
     } else {
-	    const errorMessage = data.errorMessage || data.result;
+	    const errorMessage = data.errorMessage || data.responseJSON["result"];
 
         messageEl.addClass("d-none");
         // Wait a fraction of a second before showing the message again. This


### PR DESCRIPTION
# [DRILL-8045](https://issues.apache.org/jira/browse/DRILL-8045): Fix storage export regression introduced by DRILL-8040

## Description

Since DRILL-8040, attempts to export an individual storage config from the REST API fail with the following.

```
 ERROR o.g.j.m.i.WriterInterceptorExecutor - MessageBodyWriter not found for media type=application/json, type=class org.apache.hbase.thirdparty.org.glassfish.jersey.message.internal.OutboundJaxrsResponse, genericType=class org.apache.hbase.thirdparty.org.glassfish.jersey.message.internal.OutboundJaxrsResponse.
16:56:04.187 [qtp558821862-372] ERROR o.g.j.m.i.WriterInterceptorExecutor - MessageBodyWriter not found for media type=application/json, type=class org.apache.hbase.thirdparty.org.glassfish.jersey.message.internal.OutboundJaxrsResponse, genericType=class org.apache.hbase.thirdparty.org.glassfish.jersey.message.internal.OutboundJaxrsResponse.
```

## Documentation
N/A

## Testing
Test individual storage config exports from the web UI.  Test serverMessage detail text when an storage config update request fails.
