### PR TITLE
DRILL-8026: Update Sqlline to 1.12

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillSqlLineApplication.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillSqlLineApplication.java
@@ -23,8 +23,6 @@ import org.apache.drill.common.scanner.ClassPathScanner;
 import org.apache.drill.common.util.DrillVersionInfo;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.jline.reader.impl.completer.StringsCompleter;
-import org.jline.utils.AttributedString;
-import org.jline.utils.AttributedStringBuilder;
 import sqlline.Application;
 import sqlline.CommandHandler;
 import sqlline.ConnectionMetadata;
@@ -179,9 +177,8 @@ public class DrillSqlLineApplication extends Application {
     if (config.hasPath(PROMPT_WITH_SCHEMA) && config.getBoolean(PROMPT_WITH_SCHEMA)) {
       return new PromptHandler(sqlLine) {
         @Override
-        protected AttributedString getDefaultPrompt(int connectionIndex, String url, String defaultPrompt) {
-          AttributedStringBuilder builder = new AttributedStringBuilder();
-          builder.style(resolveStyle("f:y"));
+        protected String getDefaultPrompt(int connectionIndex, String url, String defaultPrompt) {
+          StringBuilder builder = new StringBuilder();
           builder.append("apache drill");
 
           ConnectionMetadata meta = sqlLine.getConnectionMetadata();
@@ -190,7 +187,7 @@ public class DrillSqlLineApplication extends Application {
           if (currentSchema != null) {
             builder.append(" (").append(currentSchema).append(")");
           }
-          return builder.style(resolveStyle("default")).append("> ").toAttributedString();
+          return builder.append("> ").toString();
         }
       };
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillSqlLineApplicationTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillSqlLineApplicationTest.java
@@ -63,7 +63,7 @@ public class DrillSqlLineApplicationTest extends BaseTest {
 
   @Test
   public void testDrivers() {
-    Collection<String> drivers = application.initDrivers();
+    Collection<String> drivers = application.allowedDrivers();
     assertEquals(1L, drivers.size());
     assertEquals("org.apache.drill.jdbc.Driver", drivers.iterator().next());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <calcite.version>1.21.0-drill-r5</calcite.version>
     <avatica.version>1.17.0</avatica.version>
     <janino.version>3.0.11</janino.version>
-    <sqlline.version>1.9.0</sqlline.version>
+    <sqlline.version>1.12.0</sqlline.version>
     <jackson.version>2.12.1</jackson.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <mapr.release.version>6.1.0-mapr</mapr.release.version>


### PR DESCRIPTION
# [DRILL-8026](https://issues.apache.org/jira/browse/DRILL-8026): Update Sqlline to 1.12

## Description
Updated Sqlline version to fix running drill in embedded mode on Apple M1.

## Documentation
NA

## Testing
NA
