### PR TITLE
DRILL-8049: Make rule names for Iceberg plugin instances unique

### DIFF
--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPlugin.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPlugin.java
@@ -46,10 +46,18 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class IcebergFormatPlugin implements FormatPlugin {
 
   private static final String ICEBERG_CONVENTION_PREFIX = "ICEBERG.";
+
+  /**
+   * Generator for format id values. Formats with the same name may be defined
+   * in multiple storage plugins, so using the unique id within the convention name
+   * to ensure the rule names will be unique for different plugin instances.
+   */
+  private static final AtomicInteger NEXT_ID = new AtomicInteger(0);
 
   private final FileSystemConfig storageConfig;
 
@@ -77,7 +85,7 @@ public class IcebergFormatPlugin implements FormatPlugin {
     this.context = context;
     this.name = name;
     this.matcher = new IcebergFormatMatcher(this);
-    this.storagePluginRulesSupplier = storagePluginRulesSupplier(name);
+    this.storagePluginRulesSupplier = storagePluginRulesSupplier(name + NEXT_ID.getAndIncrement());
   }
 
   private static StoragePluginRulesSupplier storagePluginRulesSupplier(String name) {

--- a/contrib/format-iceberg/src/test/java/org/apache/drill/exec/store/iceberg/IcebergQueriesTest.java
+++ b/contrib/format-iceberg/src/test/java/org/apache/drill/exec/store/iceberg/IcebergQueriesTest.java
@@ -96,6 +96,10 @@ public class IcebergQueriesTest extends ClusterTest {
     newPluginConfig.setEnabled(pluginConfig.isEnabled());
     pluginRegistry.put(DFS_PLUGIN_NAME, newPluginConfig);
 
+    // defining another plugin with iceberg format to ensure that DRILL-8049 is fixed
+    FileSystemConfig anotherFileSystemConfig = pluginConfig.copyWithFormats(formats);
+    pluginRegistry.put("dfs2", anotherFileSystemConfig);
+
     Configuration config = new Configuration();
     config.set(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
 


### PR DESCRIPTION
# [DRILL-8049](https://issues.apache.org/jira/browse/DRILL-8049): Make rule names for Iceberg plugin instances unique

## Description
Added generator for format id values. Formats with the same name may be defined in multiple storage plugins, so using the unique id within the convention name to ensure the rule names will be unique for different plugin instances.

## Documentation
NA

## Testing
Updated tests to check this scenario.
