### PR TITLE
DRILL-8053: Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,13 +60,13 @@ ENV DRILL_HOME=/opt/drill DRILL_USER=drilluser
 
 RUN mkdir $DRILL_HOME
 
-COPY --from=build /opt/drill $DRILL_HOME
-
 RUN groupadd -g 999 $DRILL_USER \
  && useradd -r -u 999 -g $DRILL_USER $DRILL_USER -m -d /var/lib/drill \
  && chown -R $DRILL_USER: $DRILL_HOME
 
 USER $DRILL_USER
+
+COPY --from=build --chown=$DRILL_USER /opt/drill $DRILL_HOME
 
 # Starts Drill in embedded mode and connects to Sqlline
 ENTRYPOINT $DRILL_HOME/bin/drill-embedded

--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -43,6 +43,12 @@
       <groupId>com.splunk</groupId>
       <artifactId>splunk</artifactId>
       <version>1.7.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -137,6 +137,10 @@
         <exclude>org.apache.drill.contrib.storage-hive</exclude>
         <exclude>org.apache.drill.memory</exclude>
         <exclude>org.apache.drill.metastore</exclude>
+        <exclude>org.projectlombok:lombok</exclude>
+        <exclude>org.junit.jupiter:*:jar</exclude>
+        <exclude>org.junit.platform:*:jar</exclude>
+        <exclude>org.junit.vintage:*:jar</exclude>
         <!-- Below Hive jars are already included in drill-hive-exec-shaded.jar -->
         <exclude>junit:junit:jar</exclude>
         <!-- exclude or sqlline has problems -->


### PR DESCRIPTION
# [DRILL-8053](https://issues.apache.org/jira/browse/DRILL-8053): Reduce Docker image size

## Description
Excluded dependencies that shouldn't be included in target distribution.
Copy target distribution after the user is created to reduce layers size.

## Documentation
NA

## Testing
NA
