### PR TITLE
DRILL-8057: INFORMATION_SCHEMA filter push down is inefficient

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -60,7 +60,7 @@ public class DynamicRootSchema extends DynamicSchema {
 
   /** Creates a root schema. */
   DynamicRootSchema(StoragePluginRegistry storages, SchemaConfig schemaConfig, AliasRegistryProvider aliasRegistryProvider) {
-    super(null, new RootSchema(), ROOT_SCHEMA_NAME);
+    super(null, new RootSchema(storages), ROOT_SCHEMA_NAME);
     ((RootSchema)this.schema).setDynRootSchema(this);
     this.schemaConfig = schemaConfig;
     this.storages = storages;

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -171,6 +171,11 @@ public class DynamicRootSchema extends DynamicSchema {
           DataContext.ROOT,
           BuiltInMethod.DATA_CONTEXT_GET_ROOT_SCHEMA.method);
     }
+
+    @Override
+    public boolean showInInformationSchema() {
+      return false;
+    }
   }
 }
 

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -23,7 +23,6 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.util.BuiltInMethod;
-import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserExceptionUtils;
 import org.apache.drill.common.expression.SchemaPath;
@@ -49,7 +48,7 @@ import java.util.Set;
  * Loads schemas from storage plugins later when {@link #getSubSchema(String, boolean)}
  * is called.
  */
-public class DynamicRootSchema extends DynamicSchema implements AutoCloseable {
+public class DynamicRootSchema extends DynamicSchema {
   private static final Logger logger = LoggerFactory.getLogger(DynamicRootSchema.class);
 
   private static final String ROOT_SCHEMA_NAME = "";
@@ -153,13 +152,6 @@ public class DynamicRootSchema extends DynamicSchema implements AutoCloseable {
               .addContext(ex.getClass().getName() + ": " + ex.getMessage())
               .addContext(UserExceptionUtils.getUserHint(ex)); //Provide hint if it exists
       throw exceptBuilder.build(logger);
-    }
-  }
-
-  @Override
-  public void close() throws Exception {
-    for (CalciteSchema cs : subSchemaMap.map().values()) {
-  		AutoCloseables.closeWithUserException(cs.plus().unwrap(AbstractSchema.class));
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -311,7 +311,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
         .setIgnoreAuthErrors(isImpersonationEnabled)
         .build();
 
-    return queryContext.getFullRootSchema(schemaConfig);
+    return queryContext.getRootSchema(schemaConfig);
   }
 
   private SchemaPlus getFragmentContextRootSchema() {
@@ -323,7 +323,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
         .setIgnoreAuthErrors(isImpersonationEnabled)
         .build();
 
-    return schemaTreeProvider.createFullRootSchema(schemaConfig);
+    return schemaTreeProvider.createRootSchema(schemaConfig); //createFullRootSchema(schemaConfig);
   }
 
   @Override
@@ -696,7 +696,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
 
     @Override
     public SchemaPlus getRootSchema(String userName) {
-      return schemaTreeProvider.createFullRootSchema(userName, this);
+      return schemaTreeProvider.createRootSchema(userName, this);
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -323,7 +323,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
         .setIgnoreAuthErrors(isImpersonationEnabled)
         .build();
 
-    return schemaTreeProvider.createRootSchema(schemaConfig); //createFullRootSchema(schemaConfig);
+    return schemaTreeProvider.createRootSchema(schemaConfig);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -198,16 +198,6 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   public SchemaPlus getRootSchema(SchemaConfig schemaConfig) {
     return schemaTreeProvider.createRootSchema(schemaConfig);
   }
-  /**
-   *  Create and return a fully initialized SchemaTree with given <i>schemaConfig</i>.
-   * @param schemaConfig
-   * @return A fully initialized SchemaTree with given <i>schemaConfig</i>.
-   */
-  /*
-  public SchemaPlus getFullRootSchema(SchemaConfig schemaConfig) {
-    return schemaTreeProvider.createFullRootSchema(schemaConfig);
-  }
-  */
 
   /**
    * Get the user name of the user who issued the query that is managed by this QueryContext.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -203,10 +203,12 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    * @param schemaConfig
    * @return A fully initialized SchemaTree with given <i>schemaConfig</i>.
    */
-
+  /*
   public SchemaPlus getFullRootSchema(SchemaConfig schemaConfig) {
     return schemaTreeProvider.createFullRootSchema(schemaConfig);
   }
+  */
+
   /**
    * Get the user name of the user who issued the query that is managed by this QueryContext.
    * @return The user name of the user who issued the query that is managed by this QueryContext.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaTreeProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaTreeProvider.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.store;
 import java.util.List;
 
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.ViewExpansionContext;
 import org.apache.calcite.jdbc.DynamicSchema;
@@ -118,6 +117,7 @@ public class SchemaTreeProvider implements AutoCloseable {
    * @param provider {@link SchemaConfigInfoProvider} instance
    * @return Root of the schema tree.
    */
+  //TODO jnturton: clean up
   /*
   public SchemaPlus createFullRootSchema(final String userName, final SchemaConfigInfoProvider provider) {
     final String schemaUser = isImpersonationEnabled ? userName : ImpersonationUtil.getProcessUserName();
@@ -160,15 +160,19 @@ public class SchemaTreeProvider implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    List<AutoCloseable> toClose = Lists.newArrayList();
+    //TODO jnturton: clean up
     /*
+    List<AutoCloseable> toClose = Lists.newArrayList();
     for(SchemaPlus tree : schemaTreesToClose) {
       addSchemasToCloseList(tree, toClose);
     }
-    */
+
     AutoCloseables.close(toClose);
+    */
   }
 
+  //TODO jnturton: clean up
+  /*
   private static void addSchemasToCloseList(final SchemaPlus tree, final List<AutoCloseable> toClose) {
     for(String subSchemaName : tree.getSubSchemaNames()) {
       addSchemasToCloseList(tree.getSubSchema(subSchemaName), toClose);
@@ -181,4 +185,5 @@ public class SchemaTreeProvider implements AutoCloseable {
       // Ignore as the SchemaPlus is not an implementation of Drill schema.
     }
   }
+   */
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaTreeProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaTreeProvider.java
@@ -17,12 +17,10 @@
  */
 package org.apache.drill.exec.store;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.AutoCloseables;
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.ViewExpansionContext;
 import org.apache.calcite.jdbc.DynamicSchema;
@@ -120,17 +118,20 @@ public class SchemaTreeProvider implements AutoCloseable {
    * @param provider {@link SchemaConfigInfoProvider} instance
    * @return Root of the schema tree.
    */
+  /*
   public SchemaPlus createFullRootSchema(final String userName, final SchemaConfigInfoProvider provider) {
     final String schemaUser = isImpersonationEnabled ? userName : ImpersonationUtil.getProcessUserName();
     final SchemaConfig schemaConfig = SchemaConfig.newBuilder(schemaUser, provider).build();
     return createFullRootSchema(schemaConfig);
   }
+  */
 
   /**
    * Create and return a Full SchemaTree with given <i>schemaConfig</i>.
    * @param schemaConfig
    * @return
    */
+  /*
   public SchemaPlus createFullRootSchema(SchemaConfig schemaConfig) {
     try {
       SchemaPlus rootSchema = DynamicSchema.createRootSchema(dContext.getStorage(), schemaConfig,
@@ -138,6 +139,7 @@ public class SchemaTreeProvider implements AutoCloseable {
       dContext.getSchemaFactory().registerSchemas(schemaConfig, rootSchema);
       schemaTreesToClose.add(rootSchema);
       return rootSchema;
+
     }
     catch(IOException e) {
       // We can't proceed further without a schema, throw a runtime exception.
@@ -154,14 +156,16 @@ public class SchemaTreeProvider implements AutoCloseable {
           .build(logger);
     }
   }
+  */
 
   @Override
   public void close() throws Exception {
     List<AutoCloseable> toClose = Lists.newArrayList();
+    /*
     for(SchemaPlus tree : schemaTreesToClose) {
       addSchemasToCloseList(tree, toClose);
     }
-
+    */
     AutoCloseables.close(toClose);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.collections.ImmutableEntry;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
@@ -198,7 +197,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
   public StoragePluginRegistryImpl(DrillbitContext context) {
     this.context = new DrillbitPluginRegistryContext(context);
     this.pluginCache = new StoragePluginMap();
-    this.schemaFactory = new DrillSchemaFactory(null, this);
+    this.schemaFactory = new DrillSchemaFactory(null);
     locators.add(new ClassicConnectorLocator(this.context));
     locators.add(new SystemPluginLocator(this.context));
     this.pluginStore = new StoragePluginStoreImpl(context);
@@ -905,27 +904,6 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
         .build(logger);
     }
     return connector.pluginEntryFor(name, pluginConfig, type);
-  }
-
-  // TODO: Replace this. Inefficient to obtain schemas we don't need.
-  protected void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) {
-    // Refresh against the persistent store.
-    // TODO: This will hammer the system if queries come in rapidly.
-    // Need some better solution: grace period, alert from ZK that there
-    // is something new, etc. Even better, don't register all the schemas.
-    refresh();
-
-    // Register schemas with the refreshed plugins
-    // TODO: this code requires instantiating all plugins, even though
-    // the query won't use them. Need a way to do deferred registration.
-    for (PluginHandle handle : pluginCache.plugins()) {
-      try {
-        handle.plugin().registerSchemas(schemaConfig, parent);
-      } catch (Exception e) {
-        logger.warn("Error during `{}` schema initialization: {}",
-            handle.name(), e.getMessage(), e.getCause());
-      }
-    }
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -918,12 +918,12 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     // Register schemas with the refreshed plugins
     // TODO: this code requires instantiating all plugins, even though
     // the query won't use them. Need a way to do deferred registration.
-    for (PluginHandle plugin : pluginCache.plugins()) {
+    for (PluginHandle handle : pluginCache.plugins()) {
       try {
-        plugin.plugin().registerSchemas(schemaConfig, parent);
+        handle.plugin().registerSchemas(schemaConfig, parent);
       } catch (Exception e) {
         logger.warn("Error during `{}` schema initialization: {}",
-            plugin.name(), e.getMessage(), e.getCause());
+            handle.name(), e.getMessage(), e.getCause());
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/FilterEvaluator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/FilterEvaluator.java
@@ -58,7 +58,7 @@ public interface FilterEvaluator {
    * @return whether to prune this schema and all its descendants from the
    * search tree.
    */
-  boolean shouldPruneSchema(String schemaName, SchemaPlus schema);
+  boolean shouldPruneSchema(String schemaName);
 
   /**
    * Visit the given schema.
@@ -116,7 +116,7 @@ public interface FilterEvaluator {
     }
 
     @Override
-    public boolean shouldPruneSchema(String schemaName, SchemaPlus schema) {
+    public boolean shouldPruneSchema(String schemaName) {
       return false;
     }
 
@@ -170,7 +170,7 @@ public interface FilterEvaluator {
     }
 
     @Override
-    public boolean shouldPruneSchema(String schemaName, SchemaPlus schema) {
+    public boolean shouldPruneSchema(String schemaName) {
       Map<String, String> recordValues = ImmutableMap.of(
         CATS_COL_CATALOG_NAME, IS_CATALOG_NAME,
         SHRD_COL_TABLE_SCHEMA, schemaName,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/FilterEvaluator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/FilterEvaluator.java
@@ -51,6 +51,16 @@ public interface FilterEvaluator {
   boolean shouldVisitCatalog();
 
   /**
+   * Prune the given schema.
+   *
+   * @param schemaName name of the schema
+   * @param schema schema object
+   * @return whether to prune this schema and all its descendants from the
+   * search tree.
+   */
+  boolean shouldPruneSchema(String schemaName, SchemaPlus schema);
+
+  /**
    * Visit the given schema.
    *
    * @param schemaName name of the schema
@@ -106,11 +116,12 @@ public interface FilterEvaluator {
     }
 
     @Override
-    public boolean shouldVisitSchema(String schemaName, SchemaPlus schema) {
-      if (schemaName == null || schemaName.isEmpty()) {
-        return false;
-      }
+    public boolean shouldPruneSchema(String schemaName, SchemaPlus schema) {
+      return false;
+    }
 
+    @Override
+    public boolean shouldVisitSchema(String schemaName, SchemaPlus schema) {
       try {
         AbstractSchema drillSchema = schema.unwrap(AbstractSchema.class);
         return drillSchema.showInInformationSchema();
@@ -156,6 +167,16 @@ public interface FilterEvaluator {
       Map<String, String> recordValues = ImmutableMap.of(CATS_COL_CATALOG_NAME, IS_CATALOG_NAME);
 
       return filter.evaluate(recordValues) != InfoSchemaFilter.Result.FALSE;
+    }
+
+    @Override
+    public boolean shouldPruneSchema(String schemaName, SchemaPlus schema) {
+      Map<String, String> recordValues = ImmutableMap.of(
+        CATS_COL_CATALOG_NAME, IS_CATALOG_NAME,
+        SHRD_COL_TABLE_SCHEMA, schemaName,
+        SCHS_COL_SCHEMA_NAME, schemaName);
+
+      return filter.evaluate(recordValues, true) == InfoSchemaFilter.Result.FALSE;
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -24,8 +24,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import org.apache.drill.common.FunctionNames;
+import org.apache.drill.exec.expr.fn.impl.RegexpUtil;
+import org.apache.drill.exec.expr.fn.impl.RegexpUtil.SqlPatternType;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode.Type;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
+import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 
 import java.util.List;
 import java.util.Map;
@@ -137,54 +140,106 @@ public class InfoSchemaFilter {
    */
   @JsonIgnore
   public Result evaluate(Map<String, String> recordValues) {
-    return evaluateHelper(recordValues, getExprRoot());
+    return evaluateHelper(recordValues, false, getExprRoot());
   }
 
-  private Result evaluateHelper(Map<String, String> recordValues, ExprNode exprNode) {
+  /**
+   * Evaluate the filter for given <COLUMN NAME, VALUE> pairs.
+   *
+   * @param recordValues map of field names and their values
+   * @param prefixMatchesInconclusive whether a prefix match between a column value and a filter value
+   *                                  results in Result.INCONCLUSIVE.  Used for pruning the schema search
+   *                                  tree, e.g. "dfs" need not be recursed to find a schema of "cp.default"
+   * @return evaluation result
+   */
+  @JsonIgnore
+  public Result evaluate(Map<String, String> recordValues, boolean prefixMatchesInconclusive) {
+    return evaluateHelper(recordValues, prefixMatchesInconclusive, getExprRoot());
+  }
+
+  private Result evaluateHelper(
+    Map<String, String> recordValues,
+    boolean prefixMatchesInconclusive,
+    ExprNode exprNode
+  ) {
     if (exprNode.type == Type.FUNCTION) {
-      return evaluateHelperFunction(recordValues, (FunctionExprNode) exprNode);
+      return evaluateHelperFunction(
+        recordValues,
+        prefixMatchesInconclusive,
+        (FunctionExprNode) exprNode
+      );
     }
 
     throw new UnsupportedOperationException(
         String.format("Unknown expression type '%s' in InfoSchemaFilter", exprNode.type));
   }
 
-  private Result evaluateHelperFunction(Map<String, String> recordValues, FunctionExprNode exprNode) {
+  private Result evaluateHelperFunction(
+    Map<String, String> recordValues,
+    boolean prefixMatchesInconclusive,
+    FunctionExprNode exprNode
+  ) {
     switch (exprNode.function) {
       case FunctionNames.LIKE: {
         FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
         ConstantExprNode pattern = (ConstantExprNode) exprNode.args.get(1);
         ConstantExprNode escape = exprNode.args.size() > 2 ? (ConstantExprNode) exprNode.args.get(2) : null;
         final String fieldValue = recordValues.get(col.field);
-        if (fieldValue != null) {
-          if (escape == null) {
-            return Pattern.matches(sqlToRegexLike(pattern.value).getJavaPatternString(), fieldValue) ?
-                Result.TRUE : Result.FALSE;
-          } else {
-            return Pattern.matches(sqlToRegexLike(pattern.value, escape.value).getJavaPatternString(), fieldValue) ?
-                Result.TRUE : Result.FALSE;
-          }
+        if (fieldValue == null) {
+          return Result.INCONCLUSIVE;
         }
 
+        RegexpUtil.SqlPatternInfo spi = escape == null
+          ? sqlToRegexLike(pattern.value)
+          : sqlToRegexLike(pattern.value, escape.value);
+
+        if (Pattern.matches(spi.getJavaPatternString(), fieldValue)) {
+          return Result.TRUE;
+        }
+        if (!prefixMatchesInconclusive) {
+          return Result.FALSE;
+        }
+        if ((spi.getPatternType() == SqlPatternType.STARTS_WITH || spi.getPatternType() == SqlPatternType.CONSTANT) &&
+          !pattern.value.startsWith(fieldValue)) {
+            return Result.FALSE;
+          }
         return Result.INCONCLUSIVE;
       }
       case FunctionNames.EQ:
       case "not equal": // TODO: Is this name correct?
       case "notequal":  // TODO: Is this name correct?
       case FunctionNames.NE: {
-        FieldExprNode arg0 = (FieldExprNode) exprNode.args.get(0);
-        ConstantExprNode arg1 = (ConstantExprNode) exprNode.args.get(1);
+        FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
+        ConstantExprNode arg = (ConstantExprNode) exprNode.args.get(1);
+        final String value = recordValues.get(col.field);
+        if (Strings.isNullOrEmpty(value)) {
+          return Result.INCONCLUSIVE;
+        }
+        
+        boolean prefixMatch = arg.value.startsWith(value);
+        boolean exactMatch = prefixMatch && arg.value.equals(value);
 
-        final String value = recordValues.get(arg0.field);
-        if (value != null) {
-          if (exprNode.function.equals(FunctionNames.EQ)) {
-            return arg1.value.equals(value) ? Result.TRUE : Result.FALSE;
+        if (exprNode.function.equals(FunctionNames.EQ)) {
+          if (exactMatch) {
+            return Result.TRUE;
           } else {
-            return arg1.value.equals(value) ? Result.FALSE : Result.TRUE;
+            if (prefixMatchesInconclusive && prefixMatch) {
+              return Result.INCONCLUSIVE;
+            } else {
+              return Result.FALSE;
+            }
+          }
+        } else {
+          if (exactMatch) {
+            return Result.FALSE;
+          } else {
+            if (prefixMatchesInconclusive && prefixMatch) {
+              return Result.INCONCLUSIVE;
+            } else {
+              return Result.TRUE;
+            }
           }
         }
-
-        return Result.INCONCLUSIVE;
       }
 
       case FunctionNames.OR:
@@ -194,7 +249,7 @@ public class InfoSchemaFilter {
         // For all other cases, return INCONCLUSIVE
         Result result = Result.FALSE;
         for(ExprNode arg : exprNode.args) {
-          Result exprResult = evaluateHelper(recordValues, arg);
+          Result exprResult = evaluateHelper(recordValues, prefixMatchesInconclusive, arg);
           if (exprResult == Result.TRUE) {
             return Result.TRUE;
           } else if (exprResult == Result.INCONCLUSIVE) {
@@ -213,7 +268,7 @@ public class InfoSchemaFilter {
         Result result = Result.TRUE;
 
         for(ExprNode arg : exprNode.args) {
-          Result exprResult = evaluateHelper(recordValues, arg);
+          Result exprResult = evaluateHelper(recordValues, prefixMatchesInconclusive, arg);
           if (exprResult == Result.FALSE) {
             return exprResult;
           }
@@ -226,6 +281,10 @@ public class InfoSchemaFilter {
       }
 
       case "in": {
+        // I don't believe that this case will ever run.  The IN operator is compiled either
+        // to a chain of boolean ORs, or to a hash join with a relation which uses VALUES to
+        // generate the list of constants provided to the IN operator in the query. See
+        // the planner.in_subquery_threshold option.
         FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
         List<ExprNode> args = exprNode.args.subList(1, exprNode.args.size());
         final String fieldValue = recordValues.get(col.field);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -215,7 +215,7 @@ public class InfoSchemaFilter {
         if (Strings.isNullOrEmpty(value)) {
           return Result.INCONCLUSIVE;
         }
-        
+
         boolean prefixMatch = arg.value.startsWith(value);
         boolean exactMatch = prefixMatch && arg.value.equals(value);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -281,10 +281,11 @@ public class InfoSchemaFilter {
       }
 
       case "in": {
-        // I don't believe that this case will ever run.  The IN operator is compiled either
-        // to a chain of boolean ORs, or to a hash join with a relation which uses VALUES to
-        // generate the list of constants provided to the IN operator in the query. See
-        // the planner.in_subquery_threshold option.
+        // This case will probably only ever run if the user submits a manually
+        // crafted plan because the IN operator is compiled either to a chain
+        // of boolean ORs, or to a hash join with a relation which uses VALUES
+        // to generate the list of constants provided to the IN operator in
+        // the query. See the planner.in_subquery_threshold option.
         FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
         List<ExprNode> args = exprNode.args.subList(1, exprNode.args.size());
         final String fieldValue = recordValues.get(col.field);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaRecordGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaRecordGenerator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.ischema;
 
+import org.apache.calcite.jdbc.DynamicRootSchema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.exec.store.pojo.PojoRecordReader;
 
@@ -76,7 +77,11 @@ public abstract class InfoSchemaRecordGenerator<S> {
       return;
     }
 
-    for (String name: schema.getSubSchemaNames()) {
+    Set<String> subSchemaNames = schema instanceof DynamicRootSchema.RootSchema
+      ? ((DynamicRootSchema.RootSchema) schema).getSubSchemaNames()
+      : schema.getSubSchemaNames();
+
+    for (String name: subSchemaNames) {
       String subSchemaPath = schemaPath.isEmpty() ? name : schemaPath + "." + name;
       scanSchemaImpl(subSchemaPath, schema.getSubSchema(name), visitedPaths);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaRecordGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaRecordGenerator.java
@@ -72,6 +72,10 @@ public abstract class InfoSchemaRecordGenerator<S> {
    * @param visitedPaths set used to ensure same path won't be visited twice
    */
   private void scanSchemaImpl(String schemaPath, SchemaPlus schema, Set<String> visitedPaths) {
+    if (filterEvaluator.shouldPruneSchema(schemaPath, schema)) {
+      return;
+    }
+
     for (String name: schema.getSubSchemaNames()) {
       String subSchemaPath = schemaPath.isEmpty() ? name : schemaPath + "." + name;
       scanSchemaImpl(subSchemaPath, schema.getSubSchema(name), visitedPaths);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockBreakageStorage.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockBreakageStorage.java
@@ -39,6 +39,8 @@ public class MockBreakageStorage extends MockStorageEngine {
 
   private boolean breakRegister;
 
+  public int registerAttemptCount = 0;
+
   public MockBreakageStorage(MockBreakageStorageEngineConfig configuration, DrillbitContext context, String name) {
     super(configuration, context, name);
     breakRegister = false;
@@ -51,6 +53,7 @@ public class MockBreakageStorage extends MockStorageEngine {
   @Override
   public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
     if (breakRegister) {
+      registerAttemptCount++;
       throw new IOException("mock breakRegister!");
     }
     super.registerSchemas(schemaConfig, parent);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
@@ -569,7 +569,7 @@ public class MetadataProvider {
   private static <S> PojoRecordReader<S> getPojoRecordReader(final InfoSchemaTableType tableType, final InfoSchemaFilter filter, final DrillConfig config,
       final SchemaTreeProvider provider, final UserSession userSession, final MetastoreRegistry metastoreRegistry) {
     final SchemaPlus rootSchema =
-        provider.createFullRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(config, userSession, provider));
+        provider.createRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(config, userSession, provider));
     return tableType.getRecordReader(rootSchema, filter, userSession.getOptions(), metastoreRegistry);
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -108,7 +108,6 @@ public class PlanningBase extends ExecTest {
     final DrillOperatorTable table = new DrillOperatorTable(functionRegistry, systemOptions);
     SchemaConfig schemaConfig = SchemaConfig.newBuilder("foo", context).build();
     SchemaPlus root = DynamicSchema.createRootSchema(registry, schemaConfig, new AliasRegistryProvider(dbContext));
-    registry.getSchemaFactory().registerSchemas(schemaConfig, root);
 
     when(context.getNewDefaultSchema()).thenReturn(root);
     when(context.getLpPersistence()).thenReturn(new LogicalPlanPersistence(config, ClassPathScanner.fromPrescan(config)));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSchema.java
@@ -41,7 +41,7 @@ public class TestSchema extends DrillTest {
   public static void setup() throws Exception {
     cluster = ClusterFixture.builder(dirTestWatcher).buildCustomMockStorage();
     boolean breakRegisterSchema = true;
-    // With a broken storage which will throw exception in regiterSchema, every query (even on other storage)
+    // With a broken storage which will throw exception in registerSchema, every query (even on other storage)
     // shall fail if Drill is still loading all schemas (include the broken schema) before a query.
     cluster.insertMockStorage("mock_broken", breakRegisterSchema);
     cluster.insertMockStorage("mock_good", !breakRegisterSchema);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
@@ -64,13 +64,13 @@ public class TestInfoSchema extends BaseTestQuery {
 
   @Test
   public void selectFromAllTables() throws Exception{
-//    test("select * from INFORMATION_SCHEMA.SCHEMATA");
-//    test("select * from INFORMATION_SCHEMA.CATALOGS");
-//    test("select * from INFORMATION_SCHEMA.VIEWS");
-    test("select * from INFORMATION_SCHEMA.`TABLES` where table_schema = 'cp.default'");
-//    test("select * from INFORMATION_SCHEMA.COLUMNS");
-//    test("select * from INFORMATION_SCHEMA.`FILES`");
-//    test("select * from INFORMATION_SCHEMA.`PARTITIONS`");
+    test("select * from INFORMATION_SCHEMA.SCHEMATA");
+    test("select * from INFORMATION_SCHEMA.CATALOGS");
+    test("select * from INFORMATION_SCHEMA.VIEWS");
+    test("select * from INFORMATION_SCHEMA.`TABLES`");
+    test("select * from INFORMATION_SCHEMA.COLUMNS");
+    test("select * from INFORMATION_SCHEMA.`FILES`");
+    test("select * from INFORMATION_SCHEMA.`PARTITIONS`");
   }
 
   @Test
@@ -162,16 +162,16 @@ public class TestInfoSchema extends BaseTestQuery {
         .baselineValues("dfs.tmp")
         .go();
   }
-
+  
   @Test
-  public void showDatabasesWhereIn() throws Exception{
-    testBuilder()
-      .sqlQuery("SHOW DATABASES WHERE SCHEMA_NAME in ('dfs.tmp', 'dfs.root')")
-      .unOrdered()
-      .baselineColumns("SCHEMA_NAME")
-      .baselineValues("dfs.tmp")
-      .baselineValues("dfs.root")
-      .go();
+  public void showDatabasesWhereIn() throws Exception {
+      testBuilder()
+        .sqlQuery("SHOW DATABASES WHERE SCHEMA_NAME in ('dfs.tmp', 'dfs.root')")
+        .unOrdered()
+        .baselineColumns("SCHEMA_NAME")
+        .baselineValues("dfs.tmp")
+        .baselineValues("dfs.root")
+        .go();
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
@@ -162,7 +162,7 @@ public class TestInfoSchema extends BaseTestQuery {
         .baselineValues("dfs.tmp")
         .go();
   }
-  
+
   @Test
   public void showDatabasesWhereIn() throws Exception {
       testBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
@@ -64,13 +64,13 @@ public class TestInfoSchema extends BaseTestQuery {
 
   @Test
   public void selectFromAllTables() throws Exception{
-    test("select * from INFORMATION_SCHEMA.SCHEMATA");
-    test("select * from INFORMATION_SCHEMA.CATALOGS");
-    test("select * from INFORMATION_SCHEMA.VIEWS");
-    test("select * from INFORMATION_SCHEMA.`TABLES`");
-    test("select * from INFORMATION_SCHEMA.COLUMNS");
-    test("select * from INFORMATION_SCHEMA.`FILES`");
-    test("select * from INFORMATION_SCHEMA.`PARTITIONS`");
+//    test("select * from INFORMATION_SCHEMA.SCHEMATA");
+//    test("select * from INFORMATION_SCHEMA.CATALOGS");
+//    test("select * from INFORMATION_SCHEMA.VIEWS");
+    test("select * from INFORMATION_SCHEMA.`TABLES` where table_schema = 'cp.default'");
+//    test("select * from INFORMATION_SCHEMA.COLUMNS");
+//    test("select * from INFORMATION_SCHEMA.`FILES`");
+//    test("select * from INFORMATION_SCHEMA.`PARTITIONS`");
   }
 
   @Test
@@ -161,6 +161,17 @@ public class TestInfoSchema extends BaseTestQuery {
         .baselineColumns("SCHEMA_NAME")
         .baselineValues("dfs.tmp")
         .go();
+  }
+
+  @Test
+  public void showDatabasesWhereIn() throws Exception{
+    testBuilder()
+      .sqlQuery("SHOW DATABASES WHERE SCHEMA_NAME in ('dfs.tmp', 'dfs.root')")
+      .unOrdered()
+      .baselineColumns("SCHEMA_NAME")
+      .baselineValues("dfs.tmp")
+      .baselineValues("dfs.root")
+      .go();
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-8057](https://issues.apache.org/jira/browse/DRILL-8057): INFORMATION_SCHEMA filter push down is inefficient

## Description

WHERE clauses in queries against INFORMATION_SCHEMA do not stop Drill from fetching a schema hierarchy from all enabled storage configs.  This results in abysmal performance when unresponsive data sources are enabled, as reported by users in the Apache Drill Slack channels.  This PR teaches info schema to prune irrelevant schema subtrees from the search tree and removes eager subschema registration by DrillSchemaFactory.

## Documentation
No user-visible change

## Testing
Existing info schema unit tests + one addition for IN operator
TestInfoSchemFilterPushDown#testLazySchemaRegistration to test that eager schema registration is not taking place.