### PR TITLE
DRILL-8051: Update the JQuery for Vulnerability issue

### DIFF
--- a/drill-yarn/src/main/resources/drill-am/generic.ftl
+++ b/drill-yarn/src/main/resources/drill-am/generic.ftl
@@ -34,7 +34,7 @@
       <link href="/static/css/bootstrap.min.css" rel="stylesheet">
       <link href="/drill-am/static/css/drill-am.css" rel="stylesheet">
 
-      <script src="/static/js/jquery-3.4.1.min.js"></script>
+      <script src="/static/js/jquery-3.6.0.min.js"></script>
       <script src="/static/js/bootstrap.min.js"></script>
 
       <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
# [DRILL-8051](https://issues.apache.org/jira/browse/DRILL-8051): Update the JQuery for Vulnerability issue

## Description

Update the JQuery version from 3.4.1 to 3.6.0 for vulnerability issue which reported by @fromrymail https://github.com/apache/drill/issues/2380

## Documentation
This is a package version update for security, no doc update needs

## Testing
Manually tested Drill Web UI basic functions:
Query, Profiles, Storage, Metrics, Threads, Logs
