### PR TITLE
DRILL-8064: Cannot query text files with names that contain a backslash

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
@@ -270,15 +270,20 @@ public class FileSelection {
     Stopwatch timer = logger.isDebugEnabled() ? Stopwatch.createStarted() : null;
     boolean hasWildcard = path.contains(WILD_CARD);
 
-    Path combined = new Path(parent, DrillStringUtils.removeLeadingSlash(path));
+    String child = DrillStringUtils.removeLeadingSlash(path);
+    Path combined = new Path(parent, child);
+    // Unescape chars escaped with '\' for our root path to be consistent with what
+    // fs.globStatus(...) below will do with them, c.f. DRIL-8064
+    Path root = new Path(parent, DrillStringUtils.unescapeJava(child));
+
     if (!allowAccessOutsideWorkspace) {
       checkBackPaths(new Path(parent).toUri().getPath(), combined.toUri().getPath(), path);
     }
-    FileStatus[] statuses = fs.globStatus(combined); // note: this would expand wildcards
+    FileStatus[] statuses = fs.globStatus(combined); // note: this will expand wildcards
     if (statuses == null) {
       return null;
     }
-    FileSelection fileSel = create(Arrays.asList(statuses), null, combined);
+    FileSelection fileSel = create(Arrays.asList(statuses), null, root);
     if (timer != null) {
       logger.debug("FileSelection.create() took {} ms ", timer.elapsed(TimeUnit.MILLISECONDS));
       timer.stop();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
@@ -273,7 +273,7 @@ public class FileSelection {
     String child = DrillStringUtils.removeLeadingSlash(path);
     Path combined = new Path(parent, child);
     // Unescape chars escaped with '\' for our root path to be consistent with what
-    // fs.globStatus(...) below will do with them, c.f. DRIL-8064
+    // fs.globStatus(...) below will do with them, c.f. DRILL-8064
     Path root = new Path(parent, DrillStringUtils.unescapeJava(child));
 
     if (!allowAccessOutsideWorkspace) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestGlob.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestGlob.java
@@ -31,6 +31,10 @@ public class TestGlob extends BaseTestQuery {
   @BeforeClass
   public static void setupTestFiles() {
     dirTestWatcher.copyResourceToRoot(Paths.get("multilevel"));
+    dirTestWatcher.copyResourceToRoot(
+      Paths.get("emptyStrings.csv"),
+      Paths.get("globEscapeCharIsA\\Backslash.csv")
+    );
   }
 
   @Test
@@ -72,6 +76,18 @@ public class TestGlob extends BaseTestQuery {
       .unOrdered()
       .baselineColumns("EXPR$0")
       .baselineValues(80L)
+      .build()
+      .run();
+  }
+
+  @Test
+  // DRILL-8064
+  public void testGlobEscapeCharRootTextFile() throws Exception {
+    testBuilder()
+      .sqlQuery("select count(*) from dfs.`globEscapeCharIsA\\\\Backslash.csv`")
+      .unOrdered()
+      .baselineColumns("EXPR$0")
+      .baselineValues(3L)
       .build()
       .run();
   }


### PR DESCRIPTION
# [DRILL-8064](https://issues.apache.org/jira/browse/DRILL-8064): Cannot query text files with names that contain a backslash

## Description
Unescapes the root path set by FileSelection so that it is processed in a way that is consistent with the glob processor used to collect a list of files for querying.  This fixes a bug preventing queries like  ``select * from dfs.tmp.`test\\1.csv` `` from running.

## Documentation
None.

## Testing
New unit test: TestGlob#testGlobEscapeCharRootTextFile.
Manually run ``select * from dfs.tmp.`test\\1.csv` ``
