### PR TITLE
DRILL-8066: Convert non-finite floating point literals to string RexLiterals

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillConstExecutor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillConstExecutor.java
@@ -184,12 +184,26 @@ public class DrillConstExecutor implements RexExecutor {
           case FLOAT4: {
             float value = (materializedExpr.getMajorType().getMode() == TypeProtos.DataMode.OPTIONAL) ?
                 ((NullableFloat4Holder) valueHolder).value : ((Float4Holder) valueHolder).value;
+
+            // +Infinity, -Infinity and NaN must be represented as strings since
+            // BigDecimal cannot represent them.
+            if (!Float.isFinite(value)) {
+              return rexBuilder.makeLiteral(Float.toString(value));
+            }
+
             return rexBuilder.makeLiteral(new BigDecimal(value),
                 TypeInferenceUtils.createCalciteTypeWithNullability(typeFactory, SqlTypeName.FLOAT, newCall.getType().isNullable()), false);
           }
           case FLOAT8: {
             double value = (materializedExpr.getMajorType().getMode() == TypeProtos.DataMode.OPTIONAL) ?
                 ((NullableFloat8Holder) valueHolder).value : ((Float8Holder) valueHolder).value;
+
+            // +Infinity, -Infinity and NaN must be represented as strings since
+            // BigDecimal cannot represent them.
+            if (!Double.isFinite(value)) {
+              return rexBuilder.makeLiteral(Double.toString(value));
+            }
+
             return rexBuilder.makeLiteral(new BigDecimal(value),
                 TypeInferenceUtils.createCalciteTypeWithNullability(typeFactory, SqlTypeName.DOUBLE, newCall.getType().isNullable()), false);
           }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctionsWithNanInf.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctionsWithNanInf.java
@@ -543,6 +543,36 @@ public class TestMathFunctionsWithNanInf extends BaseTestQuery {
       evalTest(table_name, json, query, columns, values);
     }
 
+  @Test
+  public void testNanInfLiteralConversion() throws Exception {
+    String query =
+      "select " +
+      " cast('Infinity' as float) float_inf, " +
+      " cast('-Infinity' as float) float_ninf, " +
+      " cast('NaN' as float) float_nan, " +
+      " cast('Infinity' as double) double_inf, " +
+      " cast('-Infinity' as double) double_ninf, " +
+      " cast('NaN' as double) double_nan";
+
+    String[] columns = {
+      "float_inf", "float_ninf", "float_nan",
+      "double_inf", "double_ninf", "double_nan"
+    };
+
+    Object[] values = {
+      Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN,
+      Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN
+    };
+
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns(columns)
+      .baselineValues(values)
+      .build()
+      .run();
+  }
+
     private void evalTest(String table_name, String json, String query, String[] columns, Object[] values) throws Exception {
       File file = new File(dirTestWatcher.getRootDir(), table_name);
       try {


### PR DESCRIPTION
# [DRILL-8066](https://issues.apache.org/jira/browse/DRILL-8066): Convert non-finite floating point literals to string RexLiterals

## Description

When we encounter floating point literals in a query we attempt to convert them to BigDecimal which can only handle finite floats making queries like this fail: `select cast('-Infinity' as float);`.  This change sends non-finite floats to string-based RexLiterals.

## Documentation
None.

## Testing
New unit test: TestMathFunctionsWithNanInf#testNanInfLiteralConversion
Manually run `select cast('-Infinity' as float);`
