### PR TITLE
DRILL-8047: Add a custom authn provider for HashiCorp Vault

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/security/VaultUserAuthenticator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/security/VaultUserAuthenticator.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.rpc.user.security;
+
+import com.bettercloud.vault.response.AuthResponse;
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.exception.DrillbitStartupException;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Implement {@link org.apache.drill.exec.rpc.user.security.UserAuthenticator} based on Pluggable Authentication
+ * Module (PAM) configuration. Configure the PAM profiles using "drill.exec.security.user.auth.pam_profiles" BOOT
+ * option. Ex. value  <i>[ "login", "sudo" ]</i> (value is an array of strings).
+ */
+@Slf4j
+@EqualsAndHashCode
+@UserAuthenticatorTemplate(type = "vault")
+public class VaultUserAuthenticator implements UserAuthenticator {
+
+  // Drill boot options used to configure Vault auth.
+  public static final String VAULT_ADDRESS = "drill.exec.security.user.auth.vault.address";
+  public static final String VAULT_TOKEN = "drill.exec.security.user.auth.vault.token";
+  public static final String VAULT_AUTH_METHOD = "drill.exec.security.user.auth.vault.method";
+  public static final String VAULT_USERPASS_MOUNT = "drill.exec.security.user.auth.vault.userpass_mount";
+
+  // The subset of Vault auth methods that are supported by this authenticator
+  public enum VaultAuthMethod {
+    APP_ROLE,
+    GCP,
+    KUBERNETES,
+    LDAP,
+    USER_PASS
+  }
+
+  private Vault vault;
+
+  private VaultAuthMethod authMethod;
+
+  private String userPassMount;
+
+  @Override
+  public void setup(DrillConfig config) throws DrillbitStartupException {
+    // Read config values
+    String vaultAddress = Objects.requireNonNull(
+      config.getString(VAULT_ADDRESS),
+      String.format(
+        "Vault address is not specified. Please set [%s] config property.",
+        VAULT_ADDRESS
+      )
+    );
+
+    String vaultToken = Objects.requireNonNull(
+      config.getString(VAULT_TOKEN),
+      String.format(
+        "Vault token is not specified. Please set [%s] config property.",
+        VAULT_TOKEN
+      )
+    );
+
+    this.authMethod = VaultAuthMethod.valueOf(
+      Objects.requireNonNull(
+        config.getString(VAULT_AUTH_METHOD),
+        String.format(
+          "Vault auth method is not specified. Please set [%s] config property.",
+          VAULT_AUTH_METHOD
+        )
+      )
+    );
+
+    this.userPassMount = config.getString(VAULT_USERPASS_MOUNT);
+
+    // Initialise Vault client
+    try {
+      VaultConfig vaultConfig = new VaultConfig()
+          .address(vaultAddress)
+          .token(vaultToken)
+          .build();
+
+      this.vault = new Vault(vaultConfig);
+    } catch (VaultException e) {
+      logger.error(String.join(System.lineSeparator(),
+          "Error initialising the Vault client library using configuration: ",
+          "\tvaultAddress: {}",
+          "\tvaultToken: {}",
+          "\tauthMethod: {}"
+        ),
+        vaultAddress,
+        vaultToken,
+        authMethod,
+        e
+      );
+      throw new DrillbitStartupException(
+        "Error initialising the Vault client library: " + e.getMessage(),
+        e
+      );
+    }
+  }
+
+  @Override
+  public void authenticate(String user, String password) throws UserAuthenticationException {
+
+    AuthResponse authResp;
+
+    try {
+      switch (authMethod) {
+        case APP_ROLE:
+          authResp = vault.auth().loginByAppRole(user, password);
+          break;
+        case GCP:
+          authResp = vault.auth().loginByGCP(user, password);
+          break;
+        case KUBERNETES:
+          authResp = vault.auth().loginByKubernetes(user, password);
+          break;
+        case LDAP:
+          authResp = vault.auth().loginByLDAP(user, password);
+          break;
+        case USER_PASS:
+          authResp = vault.auth().loginByUserPass(user, password, this.userPassMount);
+        default:
+          throw new UserAuthenticationException(
+            String.format(
+              "The Vault authentication method '%s' is not supported",
+              authMethod
+            )
+          );
+        }
+    } catch (VaultException e) {
+      logger.warn("Failed to authenticate user {} using {}: {}.", user, authMethod, e);
+      throw new UserAuthenticationException(
+        String.format(
+          "Failed to authenticate user %s using %s: %s",
+          user,
+          authMethod,
+          e.getMessage()
+        )
+      );
+    }
+
+    logger.info(
+      "User {} authenticated against Vault successfully.",
+      authResp.getUsername()
+    );
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.vault = null;
+    logger.debug("has been closed.");
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/security/VaultUserAuthenticator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/security/VaultUserAuthenticator.java
@@ -182,7 +182,7 @@ public class VaultUserAuthenticator implements UserAuthenticator {
             .build();
 
           LookupResponse lookupResp = new Vault(lookupConfig).auth().lookupSelf();
-          if (user.equals(lookupResp.getUsername())) {
+          if (!user.equals(lookupResp.getUsername())) {
             throw new UserAuthenticationException(String.format(
               "Attempted to authenticate user %s with a Vault token that is " +
               " valid but belongs to %s!",

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillRestLoginService.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillRestLoginService.java
@@ -104,7 +104,7 @@ public class DrillRestLoginService implements LoginService {
       if (e instanceof UserAuthenticationException) {
         logger.debug("Authentication failed for WebUser '{}'", username, e);
       } else {
-        logger.error("UnExpected failure occurred for WebUser {} during login.", username, e);
+        logger.error("Unexpected failure occurred for WebUser {} during login.", username, e);
       }
       return null;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/vault/VaultCredentialsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/vault/VaultCredentialsProvider.java
@@ -37,6 +37,7 @@ import java.util.Objects;
  */
 public class VaultCredentialsProvider implements CredentialsProvider {
 
+  // Drill boot options used to configure a Vault credentials provider
   public static final String VAULT_ADDRESS = "drill.exec.storage.vault.address";
   public static final String VAULT_TOKEN = "drill.exec.storage.vault.token";
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestHtpasswdFileUserAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestHtpasswdFileUserAuthenticator.java
@@ -17,12 +17,14 @@
  */
 package org.apache.drill.exec.rpc.user.security;
 
+import org.apache.drill.categories.SecurityTest;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +35,7 @@ import java.util.List;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category(SecurityTest.class)
 public class TestHtpasswdFileUserAuthenticator extends ClusterTest {
   private File tempPasswdFile;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestVaultUserAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestVaultUserAuthenticator.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.rpc.user.security;
+
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.vault.VaultContainer;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+public class TestVaultUserAuthenticator extends ClusterTest {
+
+  private static final String VAULT_TOKEN_VALUE = "vault-token";
+
+  @ClassRule
+  public static final VaultContainer<?> vaultContainer =
+      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.1.3"))
+          .withVaultToken(VAULT_TOKEN_VALUE)
+          .withVaultPort(8200)
+          .withSecretInVault(
+            null,
+            "alice=pass1",
+            "bob=buzzkill"
+          );
+
+  @BeforeClass
+  public static void init() throws Exception {
+    String vaultAddr = String.format(
+      "http://%s:%d",
+      vaultContainer.getHost(),
+      vaultContainer.getMappedPort(8200)
+    );
+
+    ClusterFixtureBuilder cfb = ClusterFixture.builder(dirTestWatcher)
+      .configProperty(ExecConstants.ALLOW_LOOPBACK_ADDRESS_BINDING, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, "vault")
+      .configProperty(VaultUserAuthenticator.VAULT_ADDRESS, vaultAddr)
+      .configProperty(VaultUserAuthenticator.VAULT_TOKEN, VAULT_TOKEN_VALUE)
+      .configProperty(
+        VaultUserAuthenticator.VAULT_AUTH_METHOD,
+        VaultUserAuthenticator.VaultAuthMethod.USER_PASS
+      );
+
+    startCluster(cfb);
+  }
+
+  @Test
+  public void passwordChecksGiveCorrectResults() throws Exception {
+    tryCredentials("alice", "pass1", cluster, true);
+    tryCredentials("bob", "buzzkill", cluster, true);
+    tryCredentials("notalice", "pass1", cluster, false);
+    tryCredentials("notbob", "buzzkill", cluster, false);
+    tryCredentials("alice", "wrong", cluster, false);
+    tryCredentials("bob", "incorrect", cluster, false);
+  }
+
+  private static void tryCredentials(String user, String password, ClusterFixture cluster, boolean shouldSucceed) throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, user)
+        .property(DrillProperties.PASSWORD, password)
+        .build();
+
+      // Run few queries using the new client
+      List<String> queries = Arrays.asList(
+        "SHOW SCHEMAS",
+        "USE INFORMATION_SCHEMA",
+        "SHOW TABLES",
+        "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'",
+        "SELECT * FROM cp.`region.json` LIMIT 5");
+
+      for (String query : queries) {
+        client.queryBuilder().sql(query).run();
+      }
+
+      if (!shouldSucceed) {
+        fail("Expected connect to fail because of incorrect username / password combination, but it succeeded");
+      }
+    } catch (IllegalStateException e) {
+      if (shouldSucceed) {
+        throw e;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# [DRILL-8047](https://issues.apache.org/jira/browse/DRILL-8047): Add a custom authn provider for HashiCorp Vault

## Description

Vault is a popular credentials store and authentication provider license under the Mozilla Public License 2.0.  A small addition to Drill should be sufficient to allow it to authenticate users against Vault, giving users another authn option.  Note that Drill already packages vault-java-driver from BetterCloud to support storage config credentials in Vault.

## Documentation

A new Configuring Vault Security page underneath Securing Drill.

## Testing
New unit test class TestVaultUserAuthenticator.
