### PR TITLE
DRILL-8069: remove use of excel sheet getLastRowNum

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>3.2.3</version>
+      <version>3.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -258,9 +258,9 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
 
   private void buildColumnWritersFromProvidedSchema(TupleMetadata finalSchema) {
     rowIterator = sheet.iterator();
-    
+
     // Case for empty sheet
-    if(!rowIterator.hasNext()) {
+    if (!rowIterator.hasNext()) {
       return;
     }
 

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -260,7 +260,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
     rowIterator = sheet.iterator();
 
     // Case for empty sheet
-    if (!rowIterator.hasNext()) {
+    if (rowIterator == null || !rowIterator.hasNext()) {
       return;
     }
 
@@ -285,7 +285,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
     rowIterator = sheet.iterator();
 
     // Case for empty sheet
-    if (!rowIterator.hasNext()) {
+    if (rowIterator == null || !rowIterator.hasNext()) {
       builder.buildSchema();
       return;
     }

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -257,11 +257,6 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void buildColumnWritersFromProvidedSchema(TupleMetadata finalSchema) {
-    // Case for empty sheet
-    if (sheet.getLastRowNum() == 0) {
-      return;
-    }
-
     columnWriters = new ArrayList<>();
     metadataColumnWriters = new ArrayList<>();
     cellWriterArray = new ArrayList<>();
@@ -281,12 +276,6 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void getColumnHeaders(SchemaBuilder builder) {
-    // Case for empty sheet
-    if (sheet.getLastRowNum() == 0) {
-      builder.buildSchema();
-      return;
-    }
-
     columnWriters = new ArrayList<>();
     metadataColumnWriters = new ArrayList<>();
 
@@ -435,10 +424,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private boolean nextLine(RowSetLoader rowWriter) {
-    if (sheet.getLastRowNum() == 0) {
-      // Case for empty sheet
-      return false;
-    } else if (recordCount >= readerConfig.lastRow) {
+    if (recordCount >= readerConfig.lastRow) {
       return false;
     }
 

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -257,10 +257,16 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void buildColumnWritersFromProvidedSchema(TupleMetadata finalSchema) {
+    rowIterator = sheet.iterator();
+    
+    // Case for empty sheet
+    if(!rowIterator.hasNext()) {
+      return;
+    }
+
     columnWriters = new ArrayList<>();
     metadataColumnWriters = new ArrayList<>();
     cellWriterArray = new ArrayList<>();
-    rowIterator = sheet.iterator();
 
     // Get the number of columns.
     // This method also advances the row reader to the location of the first row of data
@@ -276,10 +282,16 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void getColumnHeaders(SchemaBuilder builder) {
+    rowIterator = sheet.iterator();
+
+    // Case for empty sheet
+    if (!rowIterator.hasNext()) {
+      builder.buildSchema();
+      return;
+    }
+
     columnWriters = new ArrayList<>();
     metadataColumnWriters = new ArrayList<>();
-
-    rowIterator = sheet.iterator();
 
     // Get the number of columns.
     // This method also advances the row reader to the location of the first row of data

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -154,7 +154,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   private int totalColumnCount;
   private boolean firstLine;
   private FileSplit split;
-  private int recordCount = 0;
+  private int recordCount;
   private Map<String, String> stringMetadata;
   private Map<String, Date> dateMetadata;
   private Map<String, List<String>> listMetadata;

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -154,7 +154,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   private int totalColumnCount;
   private boolean firstLine;
   private FileSplit split;
-  private int recordCount;
+  private int recordCount = 0;
   private Map<String, String> stringMetadata;
   private Map<String, Date> dateMetadata;
   private Map<String, List<String>> listMetadata;
@@ -257,7 +257,9 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void buildColumnWritersFromProvidedSchema(TupleMetadata finalSchema) {
-    rowIterator = sheet.iterator();
+    if (rowIterator == null) {
+      rowIterator = sheet.rowIterator();
+    }
 
     // Case for empty sheet
     if (rowIterator == null || !rowIterator.hasNext()) {
@@ -282,7 +284,9 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void getColumnHeaders(SchemaBuilder builder) {
-    rowIterator = sheet.iterator();
+    if (rowIterator == null) {
+      rowIterator = sheet.rowIterator();
+    }
 
     // Case for empty sheet
     if (rowIterator == null || !rowIterator.hasNext()) {
@@ -436,7 +440,15 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private boolean nextLine(RowSetLoader rowWriter) {
-    if (recordCount >= readerConfig.lastRow) {
+    if (rowIterator == null) {
+      rowIterator = sheet.rowIterator();
+    }
+
+    if (currentRow == null && rowIterator != null && rowIterator.hasNext()) {
+      currentRow = rowIterator.next();
+    }
+
+    if (currentRow == null || recordCount >= readerConfig.lastRow) {
       return false;
     }
 


### PR DESCRIPTION
# [DRILL-8069](https://issues.apache.org/jira/browse/DRILL-8069): remove use of excel sheet getLastRowNum

## Description
It is not guaranteed that getLastRowNum will return the right data - it depends on dimension data that excel saves in the sheet XML but it seems increasingly common for this to be omitted

## Documentation
None

## Testing
Unit tests
