### PR TITLE
DRILL-8072: Fix NPE in HTTP Post Requests

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.store.http.HttpApiConfig.HttpMethod;
 import org.apache.drill.exec.store.http.HttpStoragePluginConfig;
 import org.apache.drill.exec.store.http.HttpSubScan;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
-import org.apache.parquet.Strings;
 import org.jetbrains.annotations.NotNull;
 
 import javax.net.ssl.HostnameVerifier;
@@ -366,7 +365,7 @@ public class SimpleHttp {
    */
   private FormBody.Builder buildPostBody(String postBody) {
     FormBody.Builder formBodyBuilder = new FormBody.Builder();
-    if (Strings.isNullOrEmpty(postBody)) {
+    if (StringUtils.isEmpty(postBody)) {
       return formBodyBuilder;
     }
     final Pattern postBodyPattern = Pattern.compile("^.+=.+$");

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -37,6 +37,7 @@ import org.apache.drill.exec.store.http.HttpApiConfig.HttpMethod;
 import org.apache.drill.exec.store.http.HttpStoragePluginConfig;
 import org.apache.drill.exec.store.http.HttpSubScan;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
+import org.apache.parquet.Strings;
 import org.jetbrains.annotations.NotNull;
 
 import javax.net.ssl.HostnameVerifier;
@@ -364,9 +365,12 @@ public class SimpleHttp {
    * @return FormBody.Builder The populated formbody builder
    */
   private FormBody.Builder buildPostBody(String postBody) {
+    FormBody.Builder formBodyBuilder = new FormBody.Builder();
+    if (Strings.isNullOrEmpty(postBody)) {
+      return formBodyBuilder;
+    }
     final Pattern postBodyPattern = Pattern.compile("^.+=.+$");
 
-    FormBody.Builder formBodyBuilder = new FormBody.Builder();
     String[] lines = postBody.split("\\r?\\n");
     for (String line : lines) {
 


### PR DESCRIPTION
# [DRILL-8072](https://issues.apache.org/jira/browse/DRILL-8072): Fix NPE in HTTP Post Requests

## Description
In the REST plugin, if the `postBody` parameter is `null`, the reader will throw a NPE.  This PR adds a null check to prevent this.  

## Documentation
No user facing changes

## Testing
Manually tested.  