### PR TITLE
DRILL-8073: Add support for persistent table and storage aliases

### DIFF
--- a/contrib/format-iceberg/src/test/java/org/apache/drill/exec/store/iceberg/IcebergQueriesTest.java
+++ b/contrib/format-iceberg/src/test/java/org/apache/drill/exec/store/iceberg/IcebergQueriesTest.java
@@ -75,6 +75,7 @@ import static org.apache.drill.test.TestBuilder.mapOfObject;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class IcebergQueriesTest extends ClusterTest {
   private static Table table;
@@ -333,6 +334,7 @@ public class IcebergQueriesTest extends ClusterTest {
     String query = "select * from table(dfs.tmp.testAllTypes(type => 'iceberg', snapshotId => %s, snapshotAsOfTime => %s))";
     try {
       queryBuilder().sql(query, 123, 456).run();
+      fail();
     } catch (UserRemoteException e) {
       MatcherAssert.assertThat(e.getVerboseMessage(), containsString("Both 'snapshotId' and 'snapshotAsOfTime' cannot be specified"));
     }

--- a/docs/dev/Aliases.md
+++ b/docs/dev/Aliases.md
@@ -1,0 +1,101 @@
+# Aliases
+
+Apache Drill provides functionality for creating persistent aliases for its tables and storage names.
+These aliases can be used in queries instead of specifying the original name.
+
+This feature is enabled by default and can be disabled using `exec.enable_aliases` **system** option.
+
+Aliases can be either public or user-specific.
+
+## Public aliases
+Public aliases are available for all users, but only admins can create, modify or delete them.
+
+The following command may be used to create public table alias:
+```sql
+CREATE PUBLIC ALIAS tpch_lineitem FOR TABLE cp.`tpch/lineitem.parquet`
+```
+
+Public alias for storage can be created with the following command:
+```sql
+CREATE PUBLIC ALIAS classpath FOR STORAGE cp
+```
+
+Existing public table aliases can be replaced with the following command:
+```sql
+CREATE OR REPLACE PUBLIC ALIAS tpch_lineitem FOR TABLE cp.`tpch/nation.parquet`
+```
+
+It is possible to omit `TABLE` keyword:
+```sql
+CREATE OR REPLACE PUBLIC ALIAS tpch_lineitem FOR cp.`tpch/nation.parquet`
+```
+
+The following command can be used to drop public table alias:
+```sql
+DROP PUBLIC ALIAS tpch_lineitem FOR TABLE
+```
+
+Query to drop all public table aliases is the following:
+```sql
+DROP ALL PUBLIC ALIASES FOR TABLE
+```
+
+## User aliases
+User aliases are specific for the concrete users, so different users can have aliases with the same name
+but different values.
+User aliases have a greater priority than public aliases, but if no user alias is found, a public one will be used.
+
+The following command may be used to create user table alias:
+```sql
+CREATE ALIAS tpch_lineitem FOR TABLE cp.`tpch/lineitem.parquet`
+```
+
+User alias for storage can be created with the following command:
+```sql
+CREATE ALIAS classpath FOR STORAGE cp
+```
+
+Drill admins can also create aliases for other users with the following command:
+```sql
+CREATE ALIAS tpch_lineitem FOR TABLE cp.`tpch/lineitem.parquet` AS USER 'user1'
+```
+_Non-admin users also can use syntax above, but only with their username._
+
+Commands for replacing or deleting user aliases similar to the public one:
+```sql
+CREATE OR REPLACE ALIAS tpch_lineitem FOR TABLE cp.`tpch/nation.parquet`;
+CREATE OR REPLACE ALIAS tpch_lineitem FOR TABLE cp.`tpch/nation.parquet` AS USER 'user1';
+
+DROP ALIAS tpch_lineitem FOR TABLE;
+DROP ALIAS tpch_lineitem FOR TABLE AS USER 'user1';
+
+DROP ALL ALIASES FOR TABLE;
+DROP ALL ALIASES FOR TABLE AS USER 'user1';
+```
+
+## System tables for storage and table aliases
+Table aliases can be queried using `sys.table_aliases` system table:
+```sql
+SELECT * FROM sys.table_aliases
+```
+| alias<VARCHAR(OPTIONAL)> | name<VARCHAR(OPTIONAL)>      | user<VARCHAR(OPTIONAL)> | isPublic<BIT(REQUIRED)> |
+|:-------------------------|:-----------------------------|:------------------------|:------------------------|
+| `t1`                     | `cp`.`tpch/lineitem.parquet` | null                    | true                    |
+| `t2`                     | `cp`.`tpch/lineitem.parquet` | null                    | true                    |
+| `t3`                     | `cp`.`tpch/lineitem.parquet` | testUser2               | false                   |
+| `t3`                     | `cp`.`tpch/nation.parquet`   | testUser1               | false                   |
+
+Storage aliases can be obtained from `sys.storage_aliases` system table:
+```sql
+SELECT * FROM sys.storage_aliases
+```
+| alias<VARCHAR(OPTIONAL)> | name<VARCHAR(OPTIONAL)> | user<VARCHAR(OPTIONAL)> | isPublic<BIT(REQUIRED)> |
+|:-------------------------|:------------------------|:------------------------|:------------------------|
+| `t1`                     | `dfs`                   | null                    | true                    |
+| `t2`                     | `cp`                    | null                    | true                    |
+| `t3`                     | `dfs`                   | testUser2               | false                   |
+| `t3`                     | `cp`                    | testUser1               | false                   |
+
+## Developer notes
+Table and storage aliases are stored in the pre-configured persistent store using `storage_aliases` and 
+`table_aliases` accordingly.

--- a/exec/java-exec/src/main/codegen/data/Parser.tdd
+++ b/exec/java-exec/src/main/codegen/data/Parser.tdd
@@ -46,7 +46,10 @@
     "STATISTICS",
     "SAMPLE",
     "COLUMNS",
-    "REMOVE"
+    "REMOVE",
+    "ALIAS",
+    "ALIASES",
+    "STORAGE"
   ]
 
   # List of methods for parsing custom SQL statements.
@@ -57,6 +60,8 @@
     "SqlDescribeTable()",
     "SqlUseSchema()",
     "SqlCreateOrReplace()"
+    "SqlDropAlias()",
+    "SqlDropAllAliases()",
     "SqlDrop()",
     "SqlShowFiles()",
     "SqlRefreshMetadata()",
@@ -122,6 +127,8 @@
         "ADD"
         "ADMIN"
         "AFTER"
+        "ALIAS"
+        "ALIASES"
         "ALWAYS"
         "APPLY"
         "ASC"
@@ -372,6 +379,7 @@
         "SQL_VARCHAR"
         "STATE"
         "STATEMENT"
+        "STORAGE"
         "STRUCTURE"
         "STYLE"
         "SUBCLASS_ORIGIN"

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicSchema.java
@@ -19,6 +19,7 @@ package org.apache.calcite.jdbc;
 
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
@@ -40,12 +41,12 @@ public class DynamicSchema extends SimpleCalciteSchema {
     if (s != null) {
       return new DynamicSchema(this, s, schemaName);
     }
-    CalciteSchema ret = getSubSchemaMap().get(schemaName);
-    return ret;
+    return getSubSchemaMap().get(schemaName);
   }
 
-  public static SchemaPlus createRootSchema(StoragePluginRegistry storages, SchemaConfig schemaConfig) {
-    DynamicRootSchema rootSchema = new DynamicRootSchema(storages, schemaConfig);
+  public static SchemaPlus createRootSchema(StoragePluginRegistry storages,
+      SchemaConfig schemaConfig, AliasRegistryProvider aliasRegistryProvider) {
+    DynamicRootSchema rootSchema = new DynamicRootSchema(storages, schemaConfig, aliasRegistryProvider);
     return rootSchema.plus();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -1230,6 +1230,10 @@ public final class ExecConstants {
           "the sender to send out its data more rapidly, but you should know that it has a risk to OOM when the system is solving parallel " +
           "large queries until we have a more accurate resource manager."));
 
+  public static final String ENABLE_ALIASES = "exec.enable_aliases";
+  public static final BooleanValidator ENABLE_ALIASES_VALIDATOR = new BooleanValidator(
+    ENABLE_ALIASES, new OptionDescription("Enable storage and tables aliases functionality. (Drill 1.20+)"));
+
   public static final String ENABLE_REST_VERBOSE_ERRORS_KEY = "drill.exec.http.rest.errors.verbose";
   public static final OptionValidator ENABLE_REST_VERBOSE_ERRORS = new BooleanValidator(ENABLE_REST_VERBOSE_ERRORS_KEY,
       new OptionDescription("Toggles verbose output of executable error messages in rest response"));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasRegistry.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Registry for public and user-owned aliases.
+ */
+public interface AliasRegistry extends AutoCloseable {
+  /**
+   * Returns aliases table for specified {@code userName}.
+   *
+   * @param userName name of the user whose aliases table should be obtained
+   * @return aliases table for specified {@code userName}
+   */
+  Aliases getUserAliases(String userName);
+
+  /**
+   * Returns public aliases table.
+   */
+  Aliases getPublicAliases();
+
+  /**
+   * Creates if required aliases table for specified {@code userName}.
+   *
+   * @param userName name of the user whose aliases table should be created
+   */
+  void createUserAliases(String userName);
+
+  /**
+   * Creates if required public aliases table.
+   */
+  void createPublicAliases();
+
+  /**
+   * Deletes aliases table for specified {@code userName}.
+   *
+   * @param userName name of the user whose aliases table should be removed
+   */
+  void deleteUserAliases(String userName);
+
+  /**
+   * Deletes public aliases table.
+   */
+  void deletePublicAliases();
+
+  /**
+   * Returns iterator for aliases table entries.
+   */
+  Iterator<Map.Entry<String, Aliases>> getAllAliases();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasRegistryProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasRegistryProvider.java
@@ -40,7 +40,7 @@ public class AliasRegistryProvider implements AutoCloseable {
   }
 
   public AliasRegistry getStorageAliasesRegistry() {
-    if (context.getOptionManager().getOption(ExecConstants.ENABLE_ALIASES).bool_val) {
+    if (context.getOptionManager().getBoolean(ExecConstants.ENABLE_ALIASES)) {
       if (storageAliasesRegistry == null) {
         initRemoteRegistries();
       }
@@ -50,7 +50,7 @@ public class AliasRegistryProvider implements AutoCloseable {
   }
 
   public AliasRegistry getTableAliasesRegistry() {
-    if (context.getOptionManager().getOption(ExecConstants.ENABLE_ALIASES).bool_val) {
+    if (context.getOptionManager().getBoolean(ExecConstants.ENABLE_ALIASES)) {
       if (tableAliasesRegistry == null) {
         initRemoteRegistries();
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasRegistryProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasRegistryProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.server.DrillbitContext;
+
+/**
+ * Class for obtaining and managing storage and table alias registries.
+ */
+public class AliasRegistryProvider implements AutoCloseable {
+  private static final String STORAGE_REGISTRY_PATH = "storage_aliases";
+
+  private static final String TABLE_REGISTRY_PATH = "table_aliases";
+
+  private final DrillbitContext context;
+
+  private AliasRegistry storageAliasesRegistry;
+
+  private AliasRegistry tableAliasesRegistry;
+
+  public AliasRegistryProvider(DrillbitContext context) {
+    this.context = context;
+  }
+
+  public AliasRegistry getStorageAliasesRegistry() {
+    if (context.getOptionManager().getOption(ExecConstants.ENABLE_ALIASES).bool_val) {
+      if (storageAliasesRegistry == null) {
+        initRemoteRegistries();
+      }
+      return storageAliasesRegistry;
+    }
+    return NoopAliasRegistry.INSTANCE;
+  }
+
+  public AliasRegistry getTableAliasesRegistry() {
+    if (context.getOptionManager().getOption(ExecConstants.ENABLE_ALIASES).bool_val) {
+      if (tableAliasesRegistry == null) {
+        initRemoteRegistries();
+      }
+      return tableAliasesRegistry;
+    }
+    return NoopAliasRegistry.INSTANCE;
+  }
+
+  private synchronized void initRemoteRegistries() {
+    if (storageAliasesRegistry == null) {
+      storageAliasesRegistry = new PersistentAliasRegistry(context, STORAGE_REGISTRY_PATH);
+      tableAliasesRegistry = new PersistentAliasRegistry(context, TABLE_REGISTRY_PATH);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    AutoCloseables.closeSilently(storageAliasesRegistry, tableAliasesRegistry);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasTarget.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/AliasTarget.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+/**
+ * Target object type for which alias will be applied.
+ */
+public enum AliasTarget {
+  STORAGE,
+  TABLE
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/Aliases.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/Aliases.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Aliases table. Provides API for managing and obtaining aliases.
+ */
+public interface Aliases {
+  /**
+   * Key of {@link this} aliases table.
+   */
+  String getKey();
+
+  /**
+   * Returns value from aliases table that corresponds to provided alias.
+   *
+   * @param alias alias of the value to obtain
+   * @return value from aliases table that corresponds to provided alias
+   */
+  String get(String alias);
+
+  /**
+   * Associates provided alias with provided alias in aliases table.
+   *
+   * @param alias   alias of the value to associate with
+   * @param value   value that will be associated with provided alias
+   * @param replace whether existing value for the same alias should be replaced
+   * @return {@code true} if provided alias was associated with
+   * the provided value in aliases table
+   */
+  boolean put(String alias, String value, boolean replace);
+
+  /**
+   * Removes value for specified alias from aliases table.
+   * @param alias alias of the value to remove
+   * @return {@code true} if the value associated with
+   * provided alias was removed from the aliases table
+   */
+  boolean remove(String alias);
+
+  /**
+   * Returns iterator for all entries of {@link this} aliases table.
+   */
+  Iterator<Map.Entry<String, String>> getAllAliases();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/EmptyAliases.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/EmptyAliases.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Implementation of aliases table that doesn't hold or return information.
+ */
+public class EmptyAliases implements Aliases {
+  public static final EmptyAliases INSTANCE = new EmptyAliases();
+
+  @Override
+  public String getKey() {
+    return null;
+  }
+
+  @Override
+  public String get(String alias) {
+    return null;
+  }
+
+  @Override
+  public boolean put(String alias, String value, boolean replace) {
+    throw new UnsupportedOperationException("EmptyAliases cannot be set");
+  }
+
+  @Override
+  public boolean remove(String alias) {
+    return false;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> getAllAliases() {
+    return Collections.emptyIterator();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/NoopAliasRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/NoopAliasRegistry.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Implementation of {@link AliasRegistry} that does nothing.
+ */
+public class NoopAliasRegistry implements AliasRegistry {
+  public static final AliasRegistry INSTANCE = new NoopAliasRegistry();
+
+  private NoopAliasRegistry() {
+  }
+
+  public Iterator<Map.Entry<String, Aliases>> getAllAliases() {
+    return Collections.emptyIterator();
+  }
+
+  @Override
+  public Aliases getUserAliases(String userName) {
+    return EmptyAliases.INSTANCE;
+  }
+
+  @Override
+  public void createUserAliases(String userName) {
+    throw new UnsupportedOperationException("Cannot create user aliases for NoopAliasRegistry");
+  }
+
+  @Override
+  public void createPublicAliases() {
+    throw new UnsupportedOperationException("Cannot create user aliases for NoopAliasRegistry");
+  }
+
+  @Override
+  public void deleteUserAliases(String userName) {
+  }
+
+  @Override
+  public void deletePublicAliases() {
+  }
+
+  @Override
+  public Aliases getPublicAliases() {
+    return EmptyAliases.INSTANCE;
+  }
+
+  @Override
+  public void close() throws Exception {
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/PersistentAliasRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/PersistentAliasRegistry.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.exception.StoreException;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.store.sys.PersistentStore;
+import org.apache.drill.exec.store.sys.PersistentStoreConfig;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Implementation of {@link AliasRegistry} that persists aliases tables
+ * to the pre-configured persistent store.
+ */
+public class PersistentAliasRegistry implements AliasRegistry {
+  public static final String PUBLIC_ALIASES_KEY = "$public_aliases";
+
+  private final PersistentStore<PersistentAliasesTable> store;
+
+  private final boolean useUserAliases;
+
+  public PersistentAliasRegistry(DrillbitContext context, String registryPath) {
+    try {
+      ObjectMapper mapper = context.getLpPersistence().getMapper().copy();
+      InjectableValues injectables = new InjectableValues.Std()
+        .addValue(StoreProvider.class, new StoreProvider(this::getStore));
+
+      mapper.setInjectableValues(injectables);
+      this.store = context
+        .getStoreProvider()
+        .getOrCreateStore(PersistentStoreConfig
+          .newJacksonBuilder(mapper, PersistentAliasesTable.class)
+          .name(registryPath)
+          .build());
+
+      this.useUserAliases = context.getConfig().getBoolean(ExecConstants.IMPERSONATION_ENABLED);
+    } catch (StoreException e) {
+      throw new DrillRuntimeException(
+        "Failure while reading and loading alias table.");
+    }
+  }
+
+  public PersistentStore<PersistentAliasesTable> getStore() {
+    return store;
+  }
+
+  private ResolvedAliases getResolvedAliases(String key) {
+    // for the case when impersonation is disabled, use public aliases only
+    PersistentAliasesTable userAliases = useUserAliases ? store.get(key) : null;
+    return userAliases != null
+      ? new ResolvedAliases(userAliases, this::getPublicAliases)
+      : new ResolvedAliases(EmptyAliases.INSTANCE, this::getPublicAliases);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public Iterator<Map.Entry<String, Aliases>> getAllAliases() {
+    return (Iterator) store.getAll();
+  }
+
+  @Override
+  public Aliases getUserAliases(String userName) {
+    return getResolvedAliases(userName);
+  }
+
+  @Override
+  public void createUserAliases(String userName) {
+    if (!store.contains(userName)) {
+      PersistentAliasesTable aliasesTable =
+        new PersistentAliasesTable(new HashMap<>(), userName, new StoreProvider(this::getStore));
+      store.put(userName, aliasesTable);
+    }
+  }
+
+  @Override
+  public void createPublicAliases() {
+    if (!store.contains(PUBLIC_ALIASES_KEY)) {
+      PersistentAliasesTable publicAliases =
+        new PersistentAliasesTable(new HashMap<>(), PUBLIC_ALIASES_KEY, new StoreProvider(this::getStore));
+      store.put(PUBLIC_ALIASES_KEY, publicAliases);
+    }
+  }
+
+  @Override
+  public void deleteUserAliases(String userName) {
+    store.delete(userName);
+  }
+
+  @Override
+  public void deletePublicAliases() {
+    store.delete(PUBLIC_ALIASES_KEY);
+  }
+
+  @Override
+  public Aliases getPublicAliases() {
+    return Optional.<Aliases>ofNullable(store.get(PUBLIC_ALIASES_KEY))
+      .orElse(EmptyAliases.INSTANCE);
+  }
+
+  @Override
+  public void close() throws Exception {
+    store.close();
+  }
+
+  public static class StoreProvider {
+    private final Supplier<PersistentStore<PersistentAliasesTable>> supplier;
+
+    public StoreProvider(Supplier<PersistentStore<PersistentAliasesTable>> supplier) {
+      this.supplier = supplier;
+    }
+
+    public PersistentStore<PersistentAliasesTable> getStore() {
+      return supplier.get();
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/PersistentAliasesTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/PersistentAliasesTable.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.drill.exec.store.sys.PersistentStore;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Implementation of aliases table that updates its version in persistent store after modifications.
+ */
+public class PersistentAliasesTable implements Aliases {
+  private final Map<String, String> aliases;
+
+  private final String key;
+
+  private final PersistentStore<PersistentAliasesTable> store;
+
+  @JsonCreator
+  public PersistentAliasesTable(
+    @JsonProperty("aliases") Map<String, String> aliases,
+    @JsonProperty("key") String key,
+    @JacksonInject PersistentAliasRegistry.StoreProvider storeProvider) {
+    this.aliases = aliases != null ? aliases : new HashMap<>();
+    this.key = key;
+    this.store = storeProvider.getStore();
+  }
+
+  @Override
+  @JsonProperty("key")
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public String get(String alias) {
+    return aliases.get(alias);
+  }
+
+  @Override
+  public boolean put(String alias, String value, boolean replace) {
+    if (replace || !aliases.containsKey(alias)) {
+      aliases.put(alias, value);
+      store.put(key, this);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean remove(String alias) {
+    boolean isRemoved = aliases.remove(alias) != null;
+    store.put(key, this);
+    return isRemoved;
+  }
+
+  @Override
+  @JsonIgnore
+  public Iterator<Map.Entry<String, String>> getAllAliases() {
+    return aliases.entrySet().iterator();
+  }
+
+  @JsonProperty("aliases")
+  public Map<String, String> getAliases() {
+    return aliases;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/alias/ResolvedAliases.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/alias/ResolvedAliases.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.alias;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Aliases table that fallback user aliases calls to public aliases
+ * if alias not found in user aliases table.
+ */
+@AllArgsConstructor
+public class ResolvedAliases implements Aliases {
+  private final Aliases userAliases;
+
+  private final Supplier<Aliases> publicAliases;
+
+  @Override
+  public String getKey() {
+    return userAliases.getKey();
+  }
+
+  @Override
+  public String get(String alias) {
+    String value = userAliases.get(alias);
+    return value != null ? value : publicAliases.get().get(alias);
+  }
+
+  @Override
+  public boolean put(String alias, String value, boolean replace) {
+    return userAliases.put(alias, value, replace);
+  }
+
+  @Override
+  public boolean remove(String alias) {
+    return userAliases.remove(alias);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> getAllAliases() {
+    return userAliases.getAllAliases();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/PathUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/PathUtils.java
@@ -21,6 +21,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.parquet.Strings;
 
 import java.net.URL;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * A convenience class used to expedite zookeeper paths manipulations.
@@ -33,18 +35,11 @@ public final class PathUtils {
    * @param parts  path segments to combine
    * @see #normalize(String)
    */
-  public static final String join(final String... parts) {
-    final StringBuilder sb = new StringBuilder();
-    for (final String part:parts) {
-      Preconditions.checkNotNull(part, "parts cannot contain null");
-      if (!Strings.isNullOrEmpty(part)) {
-        sb.append(part).append("/");
-      }
-    }
-    if (sb.length() > 0) {
-      sb.deleteCharAt(sb.length() - 1);
-    }
-    final String path = sb.toString();
+  public static String join(final String... parts) {
+    String path = Arrays.stream(parts)
+        .peek(part -> Preconditions.checkNotNull(part, "parts cannot contain null"))
+        .filter(part -> !Strings.isNullOrEmpty(part))
+        .collect(Collectors.joining("/"));
     return normalize(path);
   }
 
@@ -53,7 +48,7 @@ public final class PathUtils {
    *
    * @return  normalized path
    */
-  public static final String normalize(final String path) {
+  public static String normalize(final String path) {
     if (Strings.isNullOrEmpty(Preconditions.checkNotNull(path))) {
       return path;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.metastore.MetastoreRegistry;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.calcite.schema.SchemaPlus;
@@ -197,6 +198,13 @@ public interface FragmentContext extends UdfUtilities, AutoCloseable {
    * @return Metastore registry
    */
   MetastoreRegistry getMetastoreRegistry();
+
+  /**
+   * Get an instance of alias registry provider for obtaining aliases.
+   *
+   * @return alias registry provider
+   */
+  AliasRegistryProvider getAliasRegistryProvider();
 
   /**
    * An operator is experiencing memory pressure. Asks the fragment

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -37,6 +37,7 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.exception.OutOfMemoryException;
@@ -652,6 +653,11 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   @Override
   public MetastoreRegistry getMetastoreRegistry() {
     return context.getMetastoreRegistry();
+  }
+
+  @Override
+  public AliasRegistryProvider getAliasRegistryProvider() {
+    return context.getAliasRegistryProvider();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -27,6 +27,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.LogicalPlanPersistence;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.expr.fn.registry.RemoteFunctionRegistry;
 import org.apache.drill.exec.expr.holders.ValueHolder;
@@ -392,5 +393,9 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
 
   public MetastoreRegistry getMetastoreRegistry() {
     return drillbitContext.getMetastoreRegistry();
+  }
+
+  public AliasRegistryProvider getAliasRegistryProvider() {
+    return drillbitContext.getAliasRegistryProvider();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/BaseAliasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/BaseAliasHandler.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.alias.AliasTarget;
+import org.apache.drill.exec.server.options.QueryOptionManager;
+import org.apache.drill.exec.util.ImpersonationUtil;
+
+import java.util.Optional;
+
+@Slf4j
+public class BaseAliasHandler extends DefaultSqlHandler {
+
+  public BaseAliasHandler(SqlHandlerConfig config) {
+    super(config);
+  }
+
+  /**
+   * Checks whether aliases support is enabled.
+   */
+  protected void checkAliasesEnabled() {
+    if (!context.getOption(ExecConstants.ENABLE_ALIASES).bool_val) {
+      throw UserException.validationError()
+        .message("Aliases support is disabled.")
+        .build(logger);
+    }
+  }
+
+  /**
+   * Admin privileges checker.
+   *
+   * @param options Options object
+   */
+  protected void checkAdminPrivileges(QueryOptionManager options) {
+    if (context.isUserAuthenticationEnabled() && !hasAdminPrivileges(options)) {
+      throw UserException
+        .permissionError()
+        .message("Not authorized to perform operations on public aliases.")
+        .build(logger);
+    }
+  }
+
+  /**
+   * Returns {@code true} if query user has admin privileges.
+   *
+   * @param options Options object
+   * @return {@code true} if query user has admin privileges
+   */
+  protected boolean hasAdminPrivileges(QueryOptionManager options) {
+    return ImpersonationUtil.hasAdminPrivileges(
+      context.getQueryUserName(),
+      ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(options),
+      ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(options));
+  }
+
+  /**
+   * Obtains userName from specified node and ensures that specified user has admin privileges
+   * for the case when it is different from the query user.
+   * If no user specified, query user will be returned.
+   *
+   * @param user source for userName
+   * @return userName
+   */
+  protected String resolveUserName(SqlNode user) {
+    String queryUserName = context.getQueryUserName();
+    return Optional.ofNullable(user)
+      .map(SqlLiteral.class::cast)
+      .map(SqlLiteral::toValue)
+      .filter(provided -> !queryUserName.equals(provided))
+      .map(provided -> {
+        // check whether current user is admin before performing alias operation for another user
+        if (!hasAdminPrivileges(context.getOptions())) {
+          throw UserException.permissionError()
+            .message("Not authorized to perform operations on aliases for other users.")
+            .build(logger);
+        }
+        return provided;
+      })
+      .orElse(queryUserName);
+  }
+
+  protected AliasRegistry getAliasRegistry(String aliasTarget) {
+    switch (AliasTarget.valueOf(aliasTarget)) {
+      case TABLE: {
+        return config.getContext().getAliasRegistryProvider().getTableAliasesRegistry();
+      }
+      case STORAGE: {
+        return config.getContext().getAliasRegistryProvider().getStorageAliasesRegistry();
+      }
+      default:
+        throw UserException.validationError()
+          .message("Unsupported alias target: [%s]", aliasTarget)
+          .build(logger);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/BaseAliasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/BaseAliasHandler.java
@@ -40,7 +40,7 @@ public class BaseAliasHandler extends DefaultSqlHandler {
    * Checks whether aliases support is enabled.
    */
   protected void checkAliasesEnabled() {
-    if (!context.getOption(ExecConstants.ENABLE_ALIASES).bool_val) {
+    if (!context.getOptions().getBoolean(ExecConstants.ENABLE_ALIASES)) {
       throw UserException.validationError()
         .message("Aliases support is disabled.")
         .build(logger);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateAliasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateAliasHandler.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.alias.AliasTarget;
+import org.apache.drill.exec.alias.Aliases;
+import org.apache.drill.exec.physical.PhysicalPlan;
+import org.apache.drill.exec.planner.sql.DirectPlan;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.parser.SqlCreateAlias;
+import org.apache.drill.exec.work.foreman.ForemanSetupException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Handler for handling CREATE ALIAS statements.
+ */
+@Slf4j
+public class CreateAliasHandler extends BaseAliasHandler {
+
+  public CreateAliasHandler(SqlHandlerConfig config) {
+    super(config);
+  }
+
+  @Override
+  public PhysicalPlan getPlan(SqlNode sqlNode) throws ForemanSetupException, IOException {
+    checkAliasesEnabled();
+
+    SqlCreateAlias node = unwrap(sqlNode, SqlCreateAlias.class);
+    String alias = SchemaPath.getCompoundPath(node.getAlias().names.toArray(new String[0])).toExpr();
+
+    String aliasTarget = ((SqlLiteral) node.getAliasKind()).toValue();
+    AliasRegistry aliasRegistry = getAliasRegistry(aliasTarget);
+    String value = getValue(node, aliasTarget);
+
+    boolean replace = ((SqlLiteral) node.getReplace()).booleanValue();
+    Aliases aliases = getAliases(node, aliasRegistry);
+    if (!aliases.put(alias, value, replace)) {
+      throw UserException.validationError()
+        .message("Alias with given name [%s] already exists", alias)
+        .build(logger);
+    }
+    return DirectPlan.createDirectPlan(context, true, String.format("%s alias '%s' for '%s' created successfully",
+      StringUtils.capitalize(aliasTarget.toLowerCase(Locale.ROOT)), alias, value));
+  }
+
+  private String getValue(SqlCreateAlias node, String aliasTarget) {
+    switch (AliasTarget.valueOf(aliasTarget)) {
+      case TABLE: {
+        return getTableQualifier(node.getSource());
+      }
+      case STORAGE: {
+        return getStorageQualifier(node.getSource().names);
+      }
+      default:
+        throw UserException.validationError()
+          .message("Unsupported alias target: [%s]", aliasTarget)
+          .build(logger);
+    }
+  }
+
+  private String getStorageQualifier(List<String> path) {
+    SchemaUtilites.resolveToDrillSchema(
+      config.getConverter().getDefaultSchema(), path);
+    if (path.size() > 1) {
+      throw UserException.validationError()
+        .message("Storage name expected, but provided [%s]",
+          SchemaUtilites.getSchemaPath(path))
+        .build(logger);
+    }
+    return SchemaPath.getCompoundPath(path.get(0)).toExpr();
+  }
+
+  private String getTableQualifier(SqlNode tableRef) {
+    DrillTableInfo drillTableInfo = DrillTableInfo.getTableInfoHolder(tableRef, config);
+
+    if (drillTableInfo.drillTable() == null) {
+      throw UserException.validationError()
+        .message("No table with given name [%s] exists in schema [%s]", drillTableInfo.tableName(),
+          SchemaUtilites.getSchemaPath(drillTableInfo.schemaPath()))
+        .build(logger);
+    }
+    String[] paths = new String[drillTableInfo.schemaPath().size() + 1];
+    System.arraycopy(drillTableInfo.schemaPath().toArray(new String[0]), 0,
+      paths, 0, drillTableInfo.schemaPath().size());
+    paths[drillTableInfo.schemaPath().size()] = drillTableInfo.tableName();
+
+    return SchemaPath.getCompoundPath(paths).toExpr();
+  }
+
+  private Aliases getAliases(SqlCreateAlias node, AliasRegistry aliasRegistry) {
+    return ((SqlLiteral) node.getIsPublic()).booleanValue()
+      ? getPublicAliases(node, aliasRegistry)
+      : getUserAliases(node, aliasRegistry);
+  }
+
+  private Aliases getUserAliases(SqlCreateAlias node, AliasRegistry aliasRegistry) {
+    if (!context.isImpersonationEnabled()) {
+      throw UserException.validationError()
+        .message("Cannot create user alias when user impersonation is disabled")
+        .build(logger);
+    }
+    String userName = resolveUserName(node.getUser());
+    aliasRegistry.createUserAliases(userName);
+
+    return aliasRegistry.getUserAliases(userName);
+  }
+
+  private Aliases getPublicAliases(SqlCreateAlias node, AliasRegistry aliasRegistry) {
+    if (node.getUser() != null) {
+      throw UserException.validationError()
+        .message("Cannot create public alias for specific user")
+        .build(logger);
+    }
+    checkAdminPrivileges(context.getOptions());
+    aliasRegistry.createPublicAliases();
+
+    return aliasRegistry.getPublicAliases();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
@@ -155,16 +155,17 @@ public class DrillTableInfo {
 
     switch (tableFromSchema.getJdbcTableType()) {
       case TABLE:
+      case SYSTEM_TABLE:
         if (tableFromSchema instanceof DrillTable) {
           return (DrillTable) tableFromSchema;
         } else {
           throw UserException.validationError()
-              .message("ANALYZE does not support [%s] table kind", tableFromSchema.getClass().getSimpleName())
+              .message("[%s] table kind is not supported", tableFromSchema.getClass().getSimpleName())
               .build(logger);
         }
       default:
         throw UserException.validationError()
-            .message("ANALYZE does not support [%s] object type", tableFromSchema.getJdbcTableType())
+            .message("[%s] object type is not supported", tableFromSchema.getJdbcTableType())
             .build(logger);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropAliasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropAliasHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.alias.Aliases;
+import org.apache.drill.exec.physical.PhysicalPlan;
+import org.apache.drill.exec.planner.sql.DirectPlan;
+import org.apache.drill.exec.planner.sql.parser.SqlDropAlias;
+import org.apache.drill.exec.work.foreman.ForemanSetupException;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Handler for handling DROP ALIAS statements.
+ */
+@Slf4j
+public class DropAliasHandler extends BaseAliasHandler {
+
+  public DropAliasHandler(SqlHandlerConfig config) {
+    super(config);
+  }
+
+  @Override
+  public PhysicalPlan getPlan(SqlNode sqlNode) throws ForemanSetupException, IOException {
+    checkAliasesEnabled();
+
+    SqlDropAlias node = unwrap(sqlNode, SqlDropAlias.class);
+    String alias = SchemaPath.getCompoundPath(node.getAlias().names.toArray(new String[0])).toExpr();
+
+    String aliasTarget = ((SqlLiteral) node.getAliasKind()).toValue();
+    AliasRegistry aliasRegistry = getAliasRegistry(aliasTarget);
+
+    Aliases aliases = getAliases(node, aliasRegistry);
+    boolean checkIfExists = ((SqlLiteral) node.getIfExists()).booleanValue();
+    boolean removed = aliases.remove(alias);
+    if (!removed && !checkIfExists) {
+      throw UserException.validationError()
+        .message("No alias found with given name [%s]", alias)
+        .build(logger);
+    }
+    String message = removed
+      ? String.format("%s alias '%s' dropped successfully", StringUtils.capitalize(aliasTarget.toLowerCase(Locale.ROOT)), alias)
+      : String.format("No %s alias found with given name [%s]", aliasTarget.toLowerCase(Locale.ROOT), alias);
+    return DirectPlan.createDirectPlan(context, removed, message);
+  }
+
+  private Aliases getAliases(SqlDropAlias dropAlias, AliasRegistry aliasRegistry) {
+    boolean isPublicAlias = ((SqlLiteral) dropAlias.getIsPublic()).booleanValue();
+    return isPublicAlias
+      ? getPublicAliases(dropAlias, aliasRegistry)
+      : getUserAliases(dropAlias, aliasRegistry);
+  }
+
+  private Aliases getUserAliases(SqlDropAlias dropAlias, AliasRegistry aliasRegistry) {
+    if (!context.isImpersonationEnabled()) {
+      throw UserException.validationError()
+        .message("Cannot drop user alias when user impersonation is disabled")
+        .build(logger);
+    }
+    String userName = resolveUserName(dropAlias.getUser());
+    return aliasRegistry.getUserAliases(userName);
+  }
+
+  private Aliases getPublicAliases(SqlDropAlias dropAlias, AliasRegistry aliasRegistry) {
+    if (dropAlias.getUser() != null) {
+      throw UserException.validationError()
+        .message("Cannot drop public alias for specific user")
+        .build(logger);
+    }
+    checkAdminPrivileges(context.getOptions());
+    return aliasRegistry.getPublicAliases();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropAllAliasesHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropAllAliasesHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.physical.PhysicalPlan;
+import org.apache.drill.exec.planner.sql.DirectPlan;
+import org.apache.drill.exec.planner.sql.parser.SqlDropAllAliases;
+import org.apache.drill.exec.work.foreman.ForemanSetupException;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Handler for handling DROP ALL ALIASES statements.
+ */
+@Slf4j
+public class DropAllAliasesHandler extends BaseAliasHandler {
+
+  public DropAllAliasesHandler(SqlHandlerConfig config) {
+    super(config);
+  }
+
+  @Override
+  public PhysicalPlan getPlan(SqlNode sqlNode) throws ForemanSetupException, IOException {
+    checkAliasesEnabled();
+
+    SqlDropAllAliases node = unwrap(sqlNode, SqlDropAllAliases.class);
+
+    String aliasTarget = ((SqlLiteral) node.getAliasKind()).toValue();
+    AliasRegistry aliasRegistry = getAliasRegistry(aliasTarget);
+
+    boolean isPublicAlias = ((SqlLiteral) node.getIsPublic()).booleanValue();
+    if (isPublicAlias) {
+      deletePublicAliases(node.getUser(), aliasRegistry);
+    } else {
+      deleteUserAliases(node.getUser(), aliasRegistry);
+    }
+    return DirectPlan.createDirectPlan(context, true, String.format("%s aliases dropped successfully",
+      StringUtils.capitalize(aliasTarget.toLowerCase(Locale.ROOT))));
+  }
+
+  private void deleteUserAliases(SqlNode user, AliasRegistry aliasRegistry) {
+    if (!context.isImpersonationEnabled()) {
+      throw UserException.validationError()
+        .message("Cannot drop user aliases when user impersonation is disabled")
+        .build(logger);
+    }
+    String userName = resolveUserName(user);
+    aliasRegistry.deleteUserAliases(userName);
+  }
+
+  private void deletePublicAliases(SqlNode user, AliasRegistry aliasRegistry) {
+    if (user != null) {
+      throw UserException.validationError()
+        .message("Cannot drop public aliases for specific user")
+        .build(logger);
+    }
+    checkAdminPrivileges(context.getOptions());
+    aliasRegistry.deletePublicAliases();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateAlias.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateAlias.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.val;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
+import org.apache.drill.exec.planner.sql.handlers.CreateAliasHandler;
+import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class SqlCreateAlias extends DrillSqlCall {
+
+  private final SqlIdentifier alias;
+  private final SqlIdentifier source;
+  private final SqlNode aliasKind;
+  private final SqlNode replace;
+  private final SqlNode isPublic;
+  private final SqlNode user;
+
+  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE_ALIAS", SqlKind.OTHER_DDL) {
+    @Override
+    public SqlCall createCall(SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+      return SqlCreateAlias.builder()
+        .pos(pos)
+        .alias((SqlIdentifier) operands[0])
+        .source((SqlIdentifier) operands[1])
+        .aliasKind(operands[2])
+        .replace(operands[3])
+        .isPublic(operands[4])
+        .user(operands[5])
+        .build();
+    }
+  };
+
+  @Builder
+  private SqlCreateAlias(SqlParserPos pos, SqlIdentifier alias, SqlIdentifier source,
+    SqlNode replace, SqlNode isPublic, SqlNode aliasKind, SqlNode user) {
+    super(pos);
+    this.alias = alias;
+    this.source = source;
+    this.replace = replace;
+    this.isPublic = isPublic;
+    this.aliasKind = aliasKind;
+    this.user = user;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    val opList = new ArrayList<SqlNode>();
+    opList.add(alias);
+    opList.add(source);
+    opList.add(aliasKind);
+    opList.add(replace);
+    opList.add(isPublic);
+    opList.add(user);
+    return opList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE");
+    if (((SqlLiteral) replace).booleanValue()) {
+      writer.keyword("OR");
+      writer.keyword("REPLACE");
+    }
+    if (((SqlLiteral) isPublic).booleanValue()) {
+      writer.keyword("PUBLIC");
+    }
+    writer.keyword("ALIAS");
+    alias.unparse(writer, leftPrec, rightPrec);
+
+    writer.keyword("FOR");
+    writer.keyword(((SqlLiteral) aliasKind).toValue());
+    source.unparse(writer, leftPrec, rightPrec);
+
+    if (user != null) {
+      writer.keyword("AS");
+      writer.keyword("USER");
+      user.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config) {
+    return new CreateAliasHandler(config);
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropAlias.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropAlias.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.val;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
+import org.apache.drill.exec.planner.sql.handlers.DropAliasHandler;
+import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class SqlDropAlias extends DrillSqlCall {
+
+  private final SqlNode isPublic;
+  private final SqlNode ifExists;
+  private final SqlIdentifier alias;
+  private final SqlNode aliasKind;
+  private final SqlNode user;
+
+  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DROP_ALIAS", SqlKind.OTHER_DDL) {
+    @Override
+    public SqlCall createCall(SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+      return SqlDropAlias.builder()
+        .pos(pos)
+        .alias((SqlIdentifier) operands[0])
+        .aliasKind(operands[1])
+        .ifExists(operands[2])
+        .isPublic(operands[3])
+        .user(operands[4])
+        .build();
+    }
+  };
+
+  @Builder
+  private SqlDropAlias(SqlParserPos pos, SqlIdentifier alias,
+    SqlNode ifExists, SqlNode isPublic, SqlNode aliasKind, SqlNode user) {
+    super(pos);
+    this.alias = alias;
+    this.ifExists = ifExists;
+    this.isPublic = isPublic;
+    this.aliasKind = aliasKind;
+    this.user = user;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    val opList = new ArrayList<SqlNode>();
+    opList.add(alias);
+    opList.add(aliasKind);
+    opList.add(ifExists);
+    opList.add(isPublic);
+    opList.add(user);
+    return opList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DROP");
+    if (((SqlLiteral) isPublic).booleanValue()) {
+      writer.keyword("PUBLIC");
+    }
+    writer.keyword("ALIAS");
+    if (((SqlLiteral) ifExists).booleanValue()) {
+      writer.keyword("IF");
+      writer.keyword("EXISTS");
+    }
+    alias.unparse(writer, leftPrec, rightPrec);
+
+    writer.keyword("FOR");
+    writer.keyword(((SqlLiteral) aliasKind).toValue());
+
+    if (user != null) {
+      writer.keyword("AS");
+      writer.keyword("USER");
+      user.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config) {
+    return new DropAliasHandler(config);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropAllAliases.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropAllAliases.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.val;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
+import org.apache.drill.exec.planner.sql.handlers.DropAllAliasesHandler;
+import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class SqlDropAllAliases extends DrillSqlCall {
+
+  private final SqlNode isPublic;
+  private final SqlNode aliasKind;
+  private final SqlNode user;
+
+  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DROP_ALIAS", SqlKind.OTHER_DDL) {
+    @Override
+    public SqlCall createCall(SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+      return SqlDropAllAliases.builder()
+        .pos(pos)
+        .aliasKind(operands[0])
+        .isPublic(operands[1])
+        .user(operands[2])
+        .build();
+    }
+  };
+
+  @Builder
+  private SqlDropAllAliases(SqlParserPos pos, SqlNode isPublic, SqlNode aliasKind, SqlNode user) {
+    super(pos);
+    this.isPublic = isPublic;
+    this.aliasKind = aliasKind;
+    this.user = user;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    val opList = new ArrayList<SqlNode>();
+    opList.add(aliasKind);
+    opList.add(isPublic);
+    opList.add(user);
+    return opList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DROP");
+    writer.keyword("ALL");
+    if (((SqlLiteral) isPublic).booleanValue()) {
+      writer.keyword("PUBLIC");
+    }
+    writer.keyword("ALIASES");
+
+    writer.keyword("FOR");
+    writer.keyword(((SqlLiteral) aliasKind).toValue());
+
+    if (user != null) {
+      writer.keyword("AS");
+      writer.keyword("USER");
+      user.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config) {
+    return new DropAllAliasesHandler(config);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -23,6 +23,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.LogicalPlanPersistence;
 import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
@@ -63,6 +64,7 @@ public class DrillbitContext implements AutoCloseable {
   private final DataConnectionCreator connectionsPool;
   private final DrillbitEndpoint endpoint;
   private final StoragePluginRegistry storagePlugins;
+  private final AliasRegistryProvider aliasRegistryProvider;
   private final OperatorCreatorRegistry operatorCreatorRegistry;
   private final Controller controller;
   private final WorkEventBus workBus;
@@ -126,6 +128,7 @@ public class DrillbitContext implements AutoCloseable {
     //This profile store context is built from the profileStoreProvider
     profileStoreContext = new QueryProfileStoreContext(config, profileStoreProvider, coord);
     this.metastoreRegistry = new MetastoreRegistry(config);
+    this.aliasRegistryProvider = new AliasRegistryProvider(this);
 
     this.counters = DrillCounters.getInstance();
   }
@@ -212,6 +215,10 @@ public class DrillbitContext implements AutoCloseable {
 
   public StoragePluginRegistry getStorage() {
     return this.storagePlugins;
+  }
+
+  public AliasRegistryProvider getAliasRegistryProvider() {
+    return aliasRegistryProvider;
   }
 
   public EventLoopGroup getBitLoopGroup() {
@@ -304,6 +311,7 @@ public class DrillbitContext implements AutoCloseable {
     getRemoteFunctionRegistry().close();
     getCompiler().close();
     getMetastoreRegistry().close();
+    getAliasRegistryProvider().close();
   }
 
   public ResourceManager getResourceManager() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -318,7 +318,8 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.METASTORE_FALLBACK_TO_FILE_METADATA_VALIDATOR),
       new OptionDefinition(ExecConstants.METASTORE_RETRIEVAL_RETRY_ATTEMPTS_VALIDATOR),
       new OptionDefinition(ExecConstants.PARQUET_READER_ENABLE_MAP_SUPPORT_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, false, false)),
-      new OptionDefinition(ExecConstants.ENABLE_DYNAMIC_CREDIT_BASED_FC_VALIDATOR)
+      new OptionDefinition(ExecConstants.ENABLE_DYNAMIC_CREDIT_BASED_FC_VALIDATOR),
+      new OptionDefinition(ExecConstants.ENABLE_ALIASES_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false))
     };
 
     CaseInsensitiveMap<OptionDefinition> map = Arrays.stream(definitions)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaTreeProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaTreeProvider.java
@@ -107,7 +107,8 @@ public class SchemaTreeProvider implements AutoCloseable {
    * @return
    */
   public SchemaPlus createRootSchema(SchemaConfig schemaConfig) {
-      final SchemaPlus rootSchema = DynamicSchema.createRootSchema(dContext.getStorage(), schemaConfig);
+      SchemaPlus rootSchema = DynamicSchema.createRootSchema(dContext.getStorage(), schemaConfig,
+        dContext.getAliasRegistryProvider());
       schemaTreesToClose.add(rootSchema);
       return rootSchema;
   }
@@ -132,7 +133,8 @@ public class SchemaTreeProvider implements AutoCloseable {
    */
   public SchemaPlus createFullRootSchema(SchemaConfig schemaConfig) {
     try {
-      final SchemaPlus rootSchema = DynamicSchema.createRootSchema(dContext.getStorage(), schemaConfig);
+      SchemaPlus rootSchema = DynamicSchema.createRootSchema(dContext.getStorage(), schemaConfig,
+        dContext.getAliasRegistryProvider());
       dContext.getSchemaFactory().registerSchemas(schemaConfig, rootSchema);
       schemaTreesToClose.add(rootSchema);
       return rootSchema;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/AliasesIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/AliasesIterator.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.alias.AliasTarget;
+import org.apache.drill.exec.alias.Aliases;
+import org.apache.drill.exec.alias.PersistentAliasRegistry;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.store.pojo.NonNullable;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+/**
+ * List aliases as a System Table
+ */
+public class AliasesIterator implements Iterator<Object> {
+
+  private final Iterator<AliasInfo> iterator;
+
+  public AliasesIterator(FragmentContext context, AliasTarget aliasTarget, int maxRecords) {
+    AliasRegistry storageAliasesRegistry;
+    switch (aliasTarget) {
+      case STORAGE:
+        storageAliasesRegistry = context.getAliasRegistryProvider().getStorageAliasesRegistry();
+        break;
+      case TABLE:
+        storageAliasesRegistry = context.getAliasRegistryProvider().getTableAliasesRegistry();
+        break;
+      default:
+        iterator = Collections.emptyIterator();
+        return;
+    }
+    Iterable<Map.Entry<String, Aliases>> allAliases = storageAliasesRegistry::getAllAliases;
+
+    iterator = StreamSupport.stream(allAliases.spliterator(), false)
+      .flatMap(aliasesTable -> StreamSupport.stream(getAllAliases(aliasesTable).spliterator(), false)
+        .map(entry -> getAliasInfo(entry.getKey(), entry.getValue(), aliasesTable.getKey())))
+      .limit(maxRecords)
+      .iterator();
+  }
+
+  private AliasInfo getAliasInfo(String alias, String value, String key) {
+    boolean isPublic = key.equals(PersistentAliasRegistry.PUBLIC_ALIASES_KEY);
+    return new AliasInfo(alias, value, isPublic ? null : key, isPublic);
+  }
+
+  private Iterable<Map.Entry<String, String>> getAllAliases(Map.Entry<String, Aliases> aliasesTable) {
+    return () -> aliasesTable.getValue().getAllAliases();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  @Override
+  public AliasInfo next() {
+    return iterator.next();
+  }
+
+  /**
+   * Representation of an entry in the System table - Aliases
+   */
+  public static class AliasInfo {
+    @NonNullable
+    public final String alias;
+
+    @NonNullable
+    public final String name;
+
+    @NonNullable
+    public final String user;
+
+    @NonNullable
+    public final boolean isPublic;
+
+    public AliasInfo(String alias, String name, String user, boolean isPublic) {
+      this.name = name;
+      this.alias = alias;
+      this.user = user;
+      this.isPublic = isPublic;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ExtendedOptionIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ExtendedOptionIterator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.sys;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -58,7 +57,7 @@ public class ExtendedOptionIterator implements Iterator<Object> {
 
   private final OptionManager fragmentOptions;
   private final Iterator<OptionValue> mergedOptions;
-  private Map<OptionValue.Kind, String> typeMapping;
+  private final Map<OptionValue.Kind, String> typeMapping;
   private static final int SHORT_DESCRIP_MAX_SIZE = 110;
 
   public ExtendedOptionIterator(FragmentContext context, boolean internal) {
@@ -106,12 +105,7 @@ public class ExtendedOptionIterator implements Iterator<Object> {
       optionslist.add(optionsmap.get(name));
     }
 
-    Collections.sort(optionslist, new Comparator<OptionValue>() {
-      @Override
-      public int compare(OptionValue v1, OptionValue v2) {
-        return v1.name.compareTo(v2.name);
-      }
-    });
+    optionslist.sort(Comparator.comparing(OptionValue::getName));
 
     return optionslist.iterator();
   }
@@ -175,7 +169,7 @@ public class ExtendedOptionIterator implements Iterator<Object> {
     if (optionDescription == null) {
       return "";
     }
-    String description = null;
+    String description;
     if (optionDescription.hasShortDescription()) {
       description = optionDescription.getShortDescription();
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.sys;
 
 import java.util.Iterator;
 
+import org.apache.drill.exec.alias.AliasTarget;
 import org.apache.drill.exec.ops.ExecutorFragmentContext;
 import org.apache.drill.exec.store.sys.OptionIterator.OptionValueWrapper;
 
@@ -121,6 +122,20 @@ public enum SystemTable {
     @Override
     public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new FunctionsIterator(context);
+    }
+  },
+
+  STORAGE_ALIASES("storage_aliases", false, AliasesIterator.AliasInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(ExecutorFragmentContext context, int maxRecords) {
+      return new AliasesIterator(context, AliasTarget.STORAGE, maxRecords);
+    }
+  },
+
+  TABLE_ALIASES("table_aliases", false, AliasesIterator.AliasInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(ExecutorFragmentContext context, int maxRecords) {
+      return new AliasesIterator(context, AliasTarget.TABLE, maxRecords);
     }
   };
 

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -589,6 +589,7 @@ drill.exec.options: {
     exec.query_profile.save: true,
     exec.query_profile.alter_session.skip: true,
     exec.enable_dynamic_fc: false,
+    exec.enable_aliases: true,
     exec.queue.enable: false,
     # Default queue values for an 8 GB direct memory default
     # Drill install. Users are expected to adjust these based

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -20,9 +20,10 @@ package org.apache.drill;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.calcite.jdbc.DynamicSchema;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import io.netty.buffer.DrillBuf;
-import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.LogicalPlanPersistence;
@@ -105,8 +106,9 @@ public class PlanningBase extends ExecTest {
     registry.init();
     final FunctionImplementationRegistry functionRegistry = new FunctionImplementationRegistry(config);
     final DrillOperatorTable table = new DrillOperatorTable(functionRegistry, systemOptions);
-    final SchemaPlus root = CalciteSchema.createRootSchema(false, false).plus();
-    registry.getSchemaFactory().registerSchemas(SchemaConfig.newBuilder("foo", context).build(), root);
+    SchemaConfig schemaConfig = SchemaConfig.newBuilder("foo", context).build();
+    SchemaPlus root = DynamicSchema.createRootSchema(registry, schemaConfig, new AliasRegistryProvider(dbContext));
+    registry.getSchemaFactory().registerSchemas(schemaConfig, root);
 
     when(context.getNewDefaultSchema()).thenReturn(root);
     when(context.getLpPersistence()).thenReturn(new LogicalPlanPersistence(config, ClassPathScanner.fromPrescan(config)));

--- a/exec/java-exec/src/test/java/org/apache/drill/alias/TestAliasCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/alias/TestAliasCommands.java
@@ -1,0 +1,717 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.alias;
+
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.hamcrest.MatcherAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_GROUP;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2_PASSWORD;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TestAliasCommands extends ClusterTest {
+  private static AliasRegistry storageAliasesRegistry;
+  private static AliasRegistry tableAliasesRegistry;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    cluster = ClusterFixture.bareBuilder(dirTestWatcher)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .configProperty(DrillProperties.USER, PROCESS_USER)
+      .configProperty(DrillProperties.PASSWORD, PROCESS_USER_PASSWORD)
+      .build();
+
+    ClientFixture admin = cluster.clientBuilder()
+      .property(DrillProperties.USER, PROCESS_USER)
+      .property(DrillProperties.PASSWORD, PROCESS_USER_PASSWORD)
+      .build();
+    admin.alterSystem(ExecConstants.ADMIN_USERS_KEY, ADMIN_USER + "," + PROCESS_USER);
+    admin.alterSystem(ExecConstants.ADMIN_USER_GROUPS_KEY, ADMIN_GROUP);
+
+    client = cluster.clientBuilder()
+      .property(DrillProperties.USER, ADMIN_USER)
+      .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+      .build();
+
+    storageAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getStorageAliasesRegistry();
+    tableAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getTableAliasesRegistry();
+  }
+
+  @Test
+  public void testCreateStoragePublicAlias() throws Exception {
+    try {
+      String sql = "CREATE PUBLIC ALIAS abc for storage dfs";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' for '`dfs`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`abc`");
+      List<String> expectedValues = Collections.singletonList("`dfs`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      storageAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreateTablePublicAlias() throws Exception {
+    try {
+      String sql = "CREATE PUBLIC ALIAS tpch_lineitem for table cp.`tpch/lineitem.parquet`";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table alias '`tpch_lineitem`' for '`cp`.`default`.`tpch/lineitem.parquet`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`tpch_lineitem`");
+      List<String> expectedValues = Collections.singletonList("`cp`.`default`.`tpch/lineitem.parquet`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      tableAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreateDuplicatedStoragePublicAlias() throws Exception {
+    try {
+      String sql = "CREATE PUBLIC ALIAS abc for storage dfs";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' for '`dfs`' created successfully")
+        .go();
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("VALIDATION ERROR: Alias with given name [`abc`] already exists"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreateOrReplaceStoragePublicAlias() throws Exception {
+    try {
+      String sql = "CREATE OR REPLACE PUBLIC ALIAS abc for storage dfs";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' for '`dfs`' created successfully")
+        .go();
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' for '`dfs`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`abc`");
+      List<String> expectedValues = Collections.singletonList("`dfs`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      storageAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreateAliasWithDisabledSupport() throws Exception {
+    try {
+      client.alterSystem(ExecConstants.ENABLE_ALIASES, false);
+      String sql = "CREATE OR REPLACE PUBLIC ALIAS abc for storage dfs";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("Aliases support is disabled."));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+      client.resetSystem(ExecConstants.ENABLE_ALIASES);
+    }
+  }
+
+  @Test
+  public void testCreatePublicAliasWithNonAdminUser() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "CREATE OR REPLACE PUBLIC ALIAS abc for storage dfs";
+
+      client.queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("PERMISSION ERROR: Not authorized to perform operations on public aliases"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreateUserStorageAliasWithPublic() throws Exception {
+    try {
+      String sql = "CREATE PUBLIC ALIAS abc for storage dfs AS USER 'user1'";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("VALIDATION ERROR: Cannot create public alias for specific user"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreatePublicAliasForNonExistingStorage() throws Exception {
+    try {
+      String sql = "CREATE PUBLIC ALIAS abc for storage non_existing_storage";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("VALIDATION ERROR: Schema [non_existing_storage] is not valid " +
+          "with respect to either root schema or current default schema"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testCreatePublicAliasForNonExistingTable() throws Exception {
+    try {
+      String sql = "CREATE PUBLIC ALIAS abc FOR TABLE cp.`tpch/non_existing_table.parquet`";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("VALIDATION ERROR: No table with given name " +
+          "[tpch/non_existing_table.parquet] exists in schema [cp.default]"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropStoragePublicAlias() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`abc`", "`cp`", true);
+      String sql = "DROP PUBLIC ALIAS abc FOR STORAGE";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' dropped successfully")
+        .go();
+
+      storageAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropTablePublicAlias() throws Exception {
+    try {
+      tableAliasesRegistry.createPublicAliases();
+      tableAliasesRegistry.getPublicAliases().put("`tpch_lineitem`", "`cp`.`default`.`tpch/lineitem.parquet`", true);
+      String sql = "DROP PUBLIC ALIAS tpch_lineitem FOR TABLE";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table alias '`tpch_lineitem`' dropped successfully")
+        .go();
+
+      tableAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropStoragePublicAliasIfExists() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`abc`", "`cp`", true);
+      String sql = "DROP PUBLIC ALIAS IF EXISTS abc FOR STORAGE";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' dropped successfully")
+        .go();
+
+      storageAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropAbsentStoragePublicAlias() throws Exception {
+    try {
+      String sql = "DROP PUBLIC ALIAS abc FOR STORAGE";
+
+      queryBuilder().sql(sql).run();
+
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("VALIDATION ERROR: No alias found with given name [`abc`]"));
+    }
+  }
+
+  @Test
+  public void testDropAbsentStoragePublicAliasIfExists() throws Exception {
+    String sql = "DROP PUBLIC ALIAS IF EXISTS abc FOR STORAGE";
+
+    testBuilder()
+      .sqlQuery(sql)
+      .unOrdered()
+      .baselineColumns("ok", "summary")
+      .baselineValues(false, "No storage alias found with given name [`abc`]")
+      .go();
+
+    storageAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> fail());
+  }
+
+  @Test
+  public void testDropUserStorageAliasWithPublic() throws Exception {
+    try {
+      String sql = "DROP PUBLIC ALIAS IF EXISTS abc FOR STORAGE AS USER 'user1'";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("VALIDATION ERROR: Cannot drop public alias for specific user"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropAliasWithDisabledSupport() throws Exception {
+    try {
+      client.alterSystem(ExecConstants.ENABLE_ALIASES, false);
+      String sql = "DROP PUBLIC ALIAS abc for storage";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("Aliases support is disabled."));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+      client.resetSystem(ExecConstants.ENABLE_ALIASES);
+    }
+  }
+
+  @Test
+  public void testDropPublicAliasWithNonAdminUser() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "DROP PUBLIC ALIAS abc for storage";
+
+      client.queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("PERMISSION ERROR: Not authorized to perform operations on public aliases."));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropAllStoragePublicAliases() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`abc`", "`cp`", true);
+      String sql = "DROP ALL PUBLIC ALIASES FOR STORAGE";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage aliases dropped successfully")
+        .go();
+
+      storageAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropAllTablePublicAliases() throws Exception {
+    try {
+      tableAliasesRegistry.createPublicAliases();
+      tableAliasesRegistry.getPublicAliases().put("`tpch_lineitem`", "`cp`.`default`.`tpch/lineitem.parquet`", true);
+      String sql = "DROP ALL PUBLIC ALIASES FOR TABLE";
+
+      testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table aliases dropped successfully")
+        .go();
+
+      tableAliasesRegistry.getPublicAliases().getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropAllUserStorageAliasWithPublic() throws Exception {
+    try {
+      String sql = "DROP ALL PUBLIC ALIASES FOR STORAGE AS USER 'user1'";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("VALIDATION ERROR: Cannot drop public aliases for specific user"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDropAllAliasesWithDisabledSupport() throws Exception {
+    try {
+      client.alterSystem(ExecConstants.ENABLE_ALIASES, false);
+      String sql = "DROP ALL PUBLIC ALIASES for storage";
+
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(), containsString("Aliases support is disabled."));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+      client.resetSystem(ExecConstants.ENABLE_ALIASES);
+    }
+  }
+
+  @Test
+  public void testDropAllPublicAliasesWithNonAdminUser() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "DROP ALL PUBLIC ALIASES for storage";
+
+      client.queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("PERMISSION ERROR: Not authorized to perform operations on public aliases."));
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testCreateStorageUserAlias() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "CREATE ALIAS abc for storage dfs";
+
+      client.testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' for '`dfs`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`abc`");
+      List<String> expectedValues = Collections.singletonList("`dfs`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testCreateTableUserAlias() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "CREATE ALIAS tpch_lineitem for table cp.`tpch/lineitem.parquet`";
+
+      client.testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table alias '`tpch_lineitem`' for '`cp`.`default`.`tpch/lineitem.parquet`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`tpch_lineitem`");
+      List<String> expectedValues = Collections.singletonList("`cp`.`default`.`tpch/lineitem.parquet`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testDropStorageUserAlias() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`abc`", "`cp`", true);
+      String sql = "DROP ALIAS abc FOR STORAGE";
+
+      client.testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Storage alias '`abc`' dropped successfully")
+        .go();
+
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testDropAllTableUserAliases() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      tableAliasesRegistry.createUserAliases(TEST_USER_2);
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).put("`tpch_lineitem`", "`cp`.`default`.`tpch/lineitem.parquet`", true);
+      String sql = "DROP ALL ALIASES FOR TABLE";
+
+      client.testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table aliases dropped successfully")
+        .go();
+
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).getAllAliases().forEachRemaining(entry -> fail());
+
+    } finally {
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testCreateTableAliasAsTheSameUser() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "CREATE ALIAS tpch_lineitem for table cp.`tpch/lineitem.parquet` AS USER '%s'";
+
+      client.testBuilder()
+        .sqlQuery(sql, TEST_USER_2)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table alias '`tpch_lineitem`' for '`cp`.`default`.`tpch/lineitem.parquet`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`tpch_lineitem`");
+      List<String> expectedValues = Collections.singletonList("`cp`.`default`.`tpch/lineitem.parquet`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testAdminCreateTableAliasAsAnotherUser() throws Exception {
+    try {
+      String sql = "CREATE ALIAS tpch_lineitem for table cp.`tpch/lineitem.parquet` AS USER '%s'";
+
+      testBuilder()
+        .sqlQuery(sql, TEST_USER_2)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, "Table alias '`tpch_lineitem`' for '`cp`.`default`.`tpch/lineitem.parquet`' created successfully")
+        .go();
+
+      List<String> expectedAliases = Collections.singletonList("`tpch_lineitem`");
+      List<String> expectedValues = Collections.singletonList("`cp`.`default`.`tpch/lineitem.parquet`");
+
+      List<String> actualAliases = new ArrayList<>();
+      List<String> actualValues = new ArrayList<>();
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).getAllAliases().forEachRemaining(entry -> {
+        actualAliases.add(entry.getKey());
+        actualValues.add(entry.getValue());
+      });
+
+      assertEquals(expectedAliases, actualAliases);
+      assertEquals(expectedValues, actualValues);
+
+    } finally {
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testNonAdminCreateTableAliasAsAnotherUser() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      String sql = "CREATE ALIAS tpch_lineitem for table cp.`tpch/lineitem.parquet` AS USER '%s'";
+
+      client.queryBuilder().sql(sql, TEST_USER_1).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("PERMISSION ERROR: Not authorized to perform operations on aliases for other users."));
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_1);
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/alias/TestAliasSubstitution.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/alias/TestAliasSubstitution.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.alias;
+
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.hamcrest.MatcherAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_GROUP;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2_PASSWORD;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TestAliasSubstitution extends ClusterTest {
+  private static AliasRegistry storageAliasesRegistry;
+  private static AliasRegistry tableAliasesRegistry;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    cluster = ClusterFixture.bareBuilder(dirTestWatcher)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .configProperty(DrillProperties.USER, PROCESS_USER)
+      .configProperty(DrillProperties.PASSWORD, PROCESS_USER_PASSWORD)
+      .build();
+
+    ClientFixture admin = cluster.clientBuilder()
+      .property(DrillProperties.USER, PROCESS_USER)
+      .property(DrillProperties.PASSWORD, PROCESS_USER_PASSWORD)
+      .build();
+    admin.alterSystem(ExecConstants.ADMIN_USERS_KEY, ADMIN_USER + "," + PROCESS_USER);
+    admin.alterSystem(ExecConstants.ADMIN_USER_GROUPS_KEY, ADMIN_GROUP);
+
+    client = cluster.clientBuilder()
+      .property(DrillProperties.USER, ADMIN_USER)
+      .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+      .build();
+    storageAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getStorageAliasesRegistry();
+    tableAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getTableAliasesRegistry();
+  }
+
+  @Test
+  public void testStoragePublicAlias() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar`", "`cp`", false);
+
+      String sql = "SELECT * FROM foobar.`tpch/lineitem.parquet` limit 1";
+      long recordCount = queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testUseStoragePublicAlias() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar`", "`dfs`", false);
+
+      String sql = "use foobar";
+      long recordCount = queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testStoragePublicAliasWithRealNameClash() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`dfs`", "`cp`", false);
+
+      String sql = "SELECT * FROM `dfs`.`tpch/lineitem.parquet` limit 1";
+      long recordCount = queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testTablePublicAlias() throws Exception {
+    try {
+      tableAliasesRegistry.createPublicAliases();
+      tableAliasesRegistry.getPublicAliases().put("`tpch_lineitem`", "`cp`.`tpch/lineitem.parquet`", false);
+
+      String sql = "SELECT * FROM tpch_lineitem limit 1";
+      long recordCount = queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testSchemaAndTablePublicAliases() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar`", "`cp`", false);
+      tableAliasesRegistry.createPublicAliases();
+      // table alias refers to plugin alias, not the actual plugin name
+      tableAliasesRegistry.getPublicAliases().put("`tpch_lineitem`", "`foobar`.`tpch/lineitem.parquet`", false);
+
+      String sql = "SELECT * FROM tpch_lineitem limit 1";
+      long recordCount = queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testDisableStoragePublicAlias() throws Exception {
+    try {
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar`", "`cp`", false);
+      client.alterSystem(ExecConstants.ENABLE_ALIASES, false);
+
+      String sql = "SELECT * FROM foobar.`tpch/lineitem.parquet` limit 1";
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("VALIDATION ERROR: Schema [[foobar]] is not valid with respect to either root schema or current default schema"));
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+      client.resetSystem(ExecConstants.ENABLE_ALIASES);
+    }
+  }
+
+  @Test
+  public void testDisableTablePublicAlias() throws Exception {
+    try {
+      tableAliasesRegistry.createPublicAliases();
+      tableAliasesRegistry.getPublicAliases().put("`tpch_lineitem`", "`cp`.`tpch/lineitem.parquet`", false);
+
+      client.alterSystem(ExecConstants.ENABLE_ALIASES, false);
+
+      String sql = "SELECT * FROM tpch_lineitem limit 1";
+      queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("Object 'tpch_lineitem' not found"));
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+      client.resetSystem(ExecConstants.ENABLE_ALIASES);
+    }
+  }
+
+  @Test
+  public void testStorageUserAlias() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`foobar`", "`cp`", false);
+
+      String sql = "SELECT * FROM foobar.`tpch/lineitem.parquet` limit 1";
+      long recordCount = client.queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testNonSharingStorageUserAlias() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_1)
+        .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+        .build();
+
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`foobar`", "`cp`", false);
+
+      String sql = "SELECT * FROM foobar.`tpch/lineitem.parquet` limit 1";
+      client.queryBuilder().sql(sql).run().recordCount();
+      fail();
+    } catch (UserRemoteException e) {
+      MatcherAssert.assertThat(e.getVerboseMessage(),
+        containsString("VALIDATION ERROR: Schema [[foobar]] is not valid with respect to either root schema or current default schema."));
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testStorageUserAliasFallbackToPublic() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`foobar`", "`cp`", false);
+
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar1`", "`cp`", false);
+
+      String sql = "SELECT * FROM foobar1.`tpch/lineitem.parquet` limit 1";
+      long recordCount = client.queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testStorageUserAndPublicAliasPriority() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`foobar`", "`cp`", false);
+
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar`", "`dfs`", false);
+
+      // user alias wins
+      String sql = "SELECT * FROM foobar.`tpch/lineitem.parquet` limit 1";
+      long recordCount = client.queryBuilder().sql(sql).run().recordCount();
+      assertEquals(1, recordCount);
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/alias/TestAliasSystemTables.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/alias/TestAliasSystemTables.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.alias;
+
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2_PASSWORD;
+
+public class TestAliasSystemTables extends ClusterTest {
+  private static AliasRegistry storageAliasesRegistry;
+
+  private static AliasRegistry tableAliasesRegistry;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    cluster = ClusterFixture.bareBuilder(dirTestWatcher)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .build();
+    storageAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getStorageAliasesRegistry();
+    tableAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getTableAliasesRegistry();
+  }
+
+  @Test
+  public void testStorageAliasesTable() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+      storageAliasesRegistry.createPublicAliases();
+      storageAliasesRegistry.getPublicAliases().put("`foobar`", "`cp`", false);
+      storageAliasesRegistry.getPublicAliases().put("`abc`", "`def`", false);
+      storageAliasesRegistry.createUserAliases(TEST_USER_1);
+      storageAliasesRegistry.getUserAliases(TEST_USER_1).put("`ghi`", "`jkl`", false);
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`mno`", "`pqr`", false);
+
+      String sql = "SELECT * FROM sys.storage_aliases";
+      client.testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("alias", "name", "user", "isPublic")
+        .baselineValues("`foobar`", "`cp`", null, true)
+        .baselineValues("`abc`", "`def`", null, true)
+        .baselineValues("`ghi`", "`jkl`", TEST_USER_1, false)
+        .baselineValues("`mno`", "`pqr`", TEST_USER_2, false)
+        .go();
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_1);
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testTableAliasesTable() throws Exception {
+    try {
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_1)
+        .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+        .build();
+      tableAliasesRegistry.createPublicAliases();
+      tableAliasesRegistry.getPublicAliases().put("`t1`", "`cp`.`tpch/lineitem.parquet`", false);
+      tableAliasesRegistry.getPublicAliases().put("`t2`", "`cp`.`tpch/lineitem.parquet`", false);
+      tableAliasesRegistry.createUserAliases(TEST_USER_1);
+      tableAliasesRegistry.getUserAliases(TEST_USER_1).put("`t3`", "`cp`.`tpch/lineitem.parquet`", false);
+      tableAliasesRegistry.createUserAliases(TEST_USER_2);
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).put("`t3`", "`cp`.`tpch/lineitem.parquet`", false);
+
+      String sql = "SELECT * FROM sys.table_aliases";
+      client.testBuilder()
+        .sqlQuery(sql)
+        .unOrdered()
+        .baselineColumns("alias", "name", "user", "isPublic")
+        .baselineValues("`t1`", "`cp`.`tpch/lineitem.parquet`", null, true)
+        .baselineValues("`t2`", "`cp`.`tpch/lineitem.parquet`", null, true)
+        .baselineValues("`t3`", "`cp`.`tpch/lineitem.parquet`", TEST_USER_1, false)
+        .baselineValues("`t3`", "`cp`.`tpch/lineitem.parquet`", TEST_USER_2, false)
+        .go();
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_1);
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -149,7 +149,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(20, tables.size());
+    assertEquals(22, tables.size());
 
     verifyTable("information_schema", "CATALOGS", tables);
     verifyTable("information_schema", "COLUMNS", tables);
@@ -183,7 +183,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(20, tables.size());
+    assertEquals(22, tables.size());
 
     verifyTable("information_schema", "CATALOGS", tables);
     verifyTable("information_schema", "COLUMNS", tables);
@@ -208,7 +208,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(11, tables.size());
+    assertEquals(12, tables.size());
 
     //Verify System Tables
     for (SystemTable sysTbl : SystemTable.values()) {
@@ -242,7 +242,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(162, columns.size());
+    assertEquals(170, columns.size());
     // too many records to verify the output.
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.test;
 
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.metastore.MetastoreRegistry;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
@@ -343,6 +344,11 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
 
     @Override
     public MetastoreRegistry getMetastoreRegistry() {
+      return null;
+    }
+
+    @Override
+    public AliasRegistryProvider getAliasRegistryProvider() {
       return null;
     }
 


### PR DESCRIPTION
# [DRILL-8073](https://issues.apache.org/jira/browse/DRILL-8073): Add support for persistent table and storage aliases

## Description
Please see https://github.com/apache/drill/pull/2398/files#diff-1c56ad716a549e46dc751a9fb5b01a8790af9165c104deea62664bd2d4e00822 for details.

## Documentation
Please see the section above 👆

## Testing
Added UT, checked manually.
