### PR TITLE
DRILL-8074: Upgrade log4j because of CVE-2021-44228

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -56,8 +56,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-      <version>2.14.1</version>
+      <version>2.15.0</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
# [DRILL-8074](https://issues.apache.org/jira/browse/DRILL-8074): Upgrade log4j because of CVE-2021-44228

## Description

Both format-excel and poi referred to Log4j 2.14.1
Due to Log4j 2.14.1 has a severe vulnerability, upgrade version to 2.15.0 for permanent mitigation.

poi also referred to log4j-api 2.14.1.
A commit of poi upgraded the dependency to 2.15.0, but still not release.
So override log4j-api dependency to 2.15.0

## Documentation

Please refer to https://www.lunasec.io/docs/blog/log4j-zero-day/

## Testing

tested dependency by maven tree.

Before changed dependency of log4j-api to 2.15.0:

![image](https://user-images.githubusercontent.com/15710469/145593827-1ff0e236-1d46-4359-83a5-3ca3b25db022.png)

after changed dependency of log4j-api to 2.15.0:

![image](https://user-images.githubusercontent.com/15710469/145593987-577385bd-5b68-4196-896c-c556ae298081.png)




