### PR TITLE
DRILL-8076: Remove unneeded Vault token BOOT opt

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestVaultUserAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestVaultUserAuthenticator.java
@@ -74,7 +74,6 @@ public class TestVaultUserAuthenticator extends ClusterTest {
       .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
       .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, "vault")
       .configProperty(VaultUserAuthenticator.VAULT_ADDRESS, vaultAddr)
-      .configProperty(VaultUserAuthenticator.VAULT_TOKEN, ROOT_TOKEN_VALUE)
       .configProperty(
         VaultUserAuthenticator.VAULT_AUTH_METHOD,
         VaultUserAuthenticator.VaultAuthMethod.USER_PASS
@@ -110,7 +109,6 @@ public class TestVaultUserAuthenticator extends ClusterTest {
       .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
       .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, "vault")
       .configProperty(VaultUserAuthenticator.VAULT_ADDRESS, vaultAddr)
-      // test without any VAULT_TOKEN boot option for token auth method
       .configProperty(
         VaultUserAuthenticator.VAULT_AUTH_METHOD,
         VaultUserAuthenticator.VaultAuthMethod.VAULT_TOKEN


### PR DESCRIPTION
# [DRILL-8076](https://issues.apache.org/jira/browse/DRILL-8076): Remove unused Vault token BOOT opt

## Description

The Vault token config option for the Vault user authenticator is pointless since none of the auth operations require Drill to have its own Vault token.  Functionality is unaffected but a pointless option confuses users and adds cruft.  This PR removes the BOOT opt.

## Documentation
Description of the BOOT opt to be removed from the doc page.

## Testing
Existing Vault unit tests 
