### PR TITLE
DRILL-8074: Second upgrade of log4j (2.16 now) because of CVE-2021-44228

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -57,12 +57,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.15.0</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-      <version>2.15.0</version>
+      <version>2.16.0</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
# [DRILL-8074](https://issues.apache.org/jira/browse/DRILL-8074): Second upgrade of log4j (2.16 now) because of CVE-2021-44228.

## Description

Refer to DRILL-8074, #2403 and CVE 2021-45046.  This PR updates log4j-api and log4j-to-slf4j again, this time to 2.16.  Note that we do not  believe these components are actually vulnerable, this is just overzealous caution.

## Documentation
None

## Testing
Full set of unit tests
