### PR TITLE
DRILL-8077: Prefer IPv4Stack over IPv6Addresses

### DIFF
--- a/distribution/src/main/resources/drill-config.sh
+++ b/distribution/src/main/resources/drill-config.sh
@@ -213,6 +213,9 @@ fi
 # Set Drill-provided defaults here. Do not put Drill defaults
 # in the distribution or user environment config files.
 
+# Prefer IPv4 over IPv6
+export DRILL_JAVA_OPTS=${$DRILL_JAVA_OPTS:-" -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"}
+
 # The SQLline client does not need the code cache.
 
 export SQLLINE_JAVA_OPTS=${SQLLINE_JAVA_OPTS:-""}

--- a/distribution/src/main/resources/drill-config.sh
+++ b/distribution/src/main/resources/drill-config.sh
@@ -213,9 +213,6 @@ fi
 # Set Drill-provided defaults here. Do not put Drill defaults
 # in the distribution or user environment config files.
 
-# Prefer IPv4 over IPv6
-export DRILL_JAVA_OPTS=${$DRILL_JAVA_OPTS:-" -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"}
-
 # The SQLline client does not need the code cache.
 
 export SQLLINE_JAVA_OPTS=${SQLLINE_JAVA_OPTS:-""}
@@ -304,6 +301,8 @@ export DRILLBIT_CODE_CACHE_SIZE=${DRILLBIT_CODE_CACHE_SIZE:-"1G"}
 
 export DRILLBIT_OPTS="-Xms$DRILL_HEAP -Xmx$DRILL_HEAP -XX:MaxDirectMemorySize=$DRILL_MAX_DIRECT_MEMORY"
 export DRILLBIT_OPTS="$DRILLBIT_OPTS -XX:ReservedCodeCacheSize=$DRILLBIT_CODE_CACHE_SIZE -Ddrill.exec.enable-epoll=false"
+# Prefer IPv4 over IPv6
+export DRILLBIT_OPTS="$DRILLBIT_OPTS -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"
 
 # Check that java is newer than 1.8
 "$JAVA" -version 2>&1 | grep "version" | egrep -e "1\.8" > /dev/null

--- a/distribution/src/main/resources/drill-env.sh
+++ b/distribution/src/main/resources/drill-env.sh
@@ -99,9 +99,9 @@
 #export DRILLBIT_CGROUP=${DRILLBIT_CGROUP:-"drillcpu"}
 
 # Custom JVM arguments to pass to the both the Drillbit and sqlline. Typically
-# used to override system properties as shown below. Empty by default.
+# used to override system properties as shown below.
 
-#export DRILL_JAVA_OPTS="$DRILL_JAVA_OPTS -Dproperty=value"
+export DRILL_JAVA_OPTS="$DRILL_JAVA_OPTS -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"
 
 # As above, but only for the Drillbit. Empty by default.
 

--- a/distribution/src/main/resources/drill-env.sh
+++ b/distribution/src/main/resources/drill-env.sh
@@ -99,9 +99,9 @@
 #export DRILLBIT_CGROUP=${DRILLBIT_CGROUP:-"drillcpu"}
 
 # Custom JVM arguments to pass to the both the Drillbit and sqlline. Typically
-# used to override system properties as shown below.
+# used to override system properties as shown below. Empty by default.
 
-export DRILL_JAVA_OPTS="$DRILL_JAVA_OPTS -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"
+#export DRILL_JAVA_OPTS="$DRILL_JAVA_OPTS -Dproperty=value"
 
 # As above, but only for the Drillbit. Empty by default.
 


### PR DESCRIPTION
# [DRILL-8077](https://issues.apache.org/jira/browse/DRILL-8077): Thousand of CLOSE_WAIT connections to HDFS Datanode 

## Description

When Drill runs in an IPv6 environment, it tries to reach the HDFS Datanode over IPv6, but the Datanode does not close the connection correctly. This leads to thousands of CLOSE_WAIT ipv6 connections from Drillbit to Datanode and after a while the Machine runs out of ports and stop working.

To avoid this situation, we can prever IPv4 over IPv6 in drill-env.sh

## Documentation
Code is self-explaining

## Testing
local build was successful
