### PR TITLE
DRILL-8078: Add WEEK to Date Extract

### DIFF
--- a/exec/java-exec/src/main/codegen/data/ExtractTypes.tdd
+++ b/exec/java-exec/src/main/codegen/data/ExtractTypes.tdd
@@ -17,6 +17,6 @@
 #
 
 {
-  toTypes: [Second, Minute, Hour, Day, Month, Year],
+  toTypes: [Second, Minute, Hour, Day, Week, Month, Year],
   fromTypes: [Date, Time, TimeStamp, Interval, IntervalDay, IntervalYear]
 }

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
@@ -38,7 +38,7 @@ public class ${className} {
 <#list extract.fromTypes as fromUnit>
 <#list extract.toTypes as toUnit>
 <#if fromUnit == "Date" || fromUnit == "Time" || fromUnit == "TimeStamp">
-<#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Month" || toUnit == "Day"))>
+<#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Month" || toUnit == "Week" || toUnit == "Day"))>
   @FunctionTemplate(name = "extract${toUnit}", scope = FunctionTemplate.FunctionScope.SIMPLE,
       nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class ${toUnit}From${fromUnit} implements DrillSimpleFunc {
@@ -67,6 +67,8 @@ public class ${className} {
       out.value = dateTime.getHourOfDay();
     <#elseif toUnit = "Day">
       out.value = dateTime.getDayOfMonth();
+    <#elseif toUnit = "Week">
+      out.value = dateTime.getWeekOfWeekyear();
     <#elseif toUnit = "Month">
       out.value = dateTime.getMonthOfYear();
     <#elseif toUnit = "Year">
@@ -95,6 +97,8 @@ public class ${className} {
       out.value = (in.months / org.apache.drill.exec.vector.DateUtilities.yearsToMonths);
     <#elseif toUnit == "Month">
       out.value = (in.months % org.apache.drill.exec.vector.DateUtilities.yearsToMonths);
+    <#elseif toUnit == "Week">
+      out.value = (in.days / org.apache.drill.exec.vector.DateUtilities.daysToWeeks);
     <#elseif toUnit == "Day">
       out.value = in.days;
     <#elseif toUnit == "Hour">
@@ -108,6 +112,8 @@ public class ${className} {
     </#if>
   <#elseif fromUnit == "IntervalDay">
     <#if toUnit == "Year" || toUnit == "Month">
+      out.value = 0;
+    <#elseif toUnit == "Week">
       out.value = 0;
     <#elseif toUnit == "Day">
       out.value = in.days;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -560,6 +560,7 @@ public class DrillOptiq {
           switch (timeUnit) {
             case YEAR:
             case MONTH:
+            case WEEK:
             case DAY:
             case HOUR:
             case MINUTE:
@@ -568,7 +569,7 @@ public class DrillOptiq {
               functionName += functionPostfix;
               return FunctionCallFactory.createExpression(functionName, args.subList(1, 2));
             default:
-              throw new UnsupportedOperationException("extract function supports the following time units: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND");
+              throw new UnsupportedOperationException("extract function supports the following time units: YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND");
           }
         }
         case "timestampdiff": {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
@@ -926,6 +926,7 @@ public class TypeInferenceUtils {
     switch (timeUnit) {
       case YEAR:
       case MONTH:
+      case WEEK:
       case DAY:
       case HOUR:
       case MINUTE:
@@ -935,7 +936,7 @@ public class TypeInferenceUtils {
       default:
         throw UserException
             .functionError()
-            .message("extract function supports the following time units: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND")
+            .message("extract function supports the following time units: YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND")
             .build(logger);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewDateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewDateFunctions.java
@@ -132,6 +132,16 @@ public class TestNewDateFunctions extends BaseTestQuery {
   }
 
   @Test
+  public void testExtractWeek() throws Exception {
+    testBuilder()
+      .sqlQuery("SELECT EXTRACT(WEEK FROM hire_date) AS col FROM cp.`employee.json` WHERE last_name='Nowmer'")
+      .unOrdered()
+      .baselineColumns("col")
+      .baselineValues(48L)
+      .go();
+  }
+
+  @Test
   public void testLocalTimestamp() throws Exception {
     testBuilder()
         .sqlQuery("select extract(day from localtimestamp) = extract(day from current_date) as col from cp.`employee.json` limit 1")

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/DateUtilities.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/DateUtilities.java
@@ -36,6 +36,7 @@ import org.joda.time.Period;
 public class DateUtilities {
 
   public static final int yearsToMonths = 12;
+  public static final int daysToWeeks = 7;
   public static final int hoursToMillis = 60 * 60 * 1000;
   public static final int minutesToMillis = 60 * 1000;
   public static final int secondsToMillis = 1000;


### PR DESCRIPTION
# [DRILL-8078](https://issues.apache.org/jira/browse/DRILL-XXXX): Add WEEK to Date Extract

## Description
This PR adds the possibility of extracting the `WEEK` from a date `EXTRACT` function. 

## Documentation
See above.  `WEEK` is now an option for date extract. 

## Testing
Manually tested and added UT. 
