### PR TITLE
DRILL-8079: Upgrade logback to 1.2.9 because of CVE-2021-42550

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <curator.version>5.2.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
-    <logback.version>1.2.3</logback.version>
+    <logback.version>1.2.9</logback.version>
     <mockito.version>3.11.2</mockito.version>
     <!--
       Currently Hive storage plugin only supports Apache Hive 3.1.2 or vendor specific variants of the


### PR DESCRIPTION
# [DRILL-8079](https://issues.apache.org/jira/browse/DRILL-8079): Upgrade logback to 1.2.9 because of CVE-2021-42550

## Description

Due to the CVE-2021-42550, Upgraded logback from 1.2.3 to 1.2.9.

## Documentation

Logback 1.2.9 fixed the vulnerability, please refer to: http://logback.qos.ch/news.html

## Testing

Tested by  mvn dependency:tree, all dependency of logback upgraded to 1.2.9 already.

![image](https://user-images.githubusercontent.com/15710469/146630830-a2f27b4d-3604-4098-a48f-8e5deb1635c8.png)