### PR TITLE
DRILL-8071: upgrade log4j to 2.17.0

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -52,17 +52,17 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>3.2.4</version>
+      <version>3.2.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
# [DRILL-8071](https://issues.apache.org/jira/browse/DRILL-8071): upgrade log4j to 2.17.0

## Description

Drill's format-excel has only gained log4j dependencies recently (and this is not in any Drill release yet).

Log4J have released 2.17.0 with another CVE fix. These CVEs don't affect Drill because it does not yet use log4j-core but for optics, it is better to update all log4j jars.

https://logging.apache.org/log4j/2.x/security.html

## Documentation
No changes

## Testing
Unit tests
