### PR TITLE
DRILL-8080: Enable the describe Case-Insensitive for Phoenix

### DIFF
--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -85,6 +85,10 @@
           <groupId>javax.servlet</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -109,6 +113,10 @@
          <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixSchemaFactory.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixSchemaFactory.java
@@ -119,5 +119,10 @@ public class PhoenixSchemaFactory extends AbstractSchemaFactory {
     public void addSchemas(Map<String, PhoenixSchema> schemas) {
       schemaMap.putAll(schemas);
     }
+
+    @Override
+    public boolean areTableNamesCaseSensitive() {
+      return false;
+    }
   }
 }

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixCommandTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixCommandTest.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.QueryBuilder;
 import org.apache.drill.test.rowSet.RowSetComparison;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.MethodSorters;
@@ -65,10 +64,30 @@ public class PhoenixCommandTest extends PhoenixBaseTest {
     new RowSetComparison(expected).verifyAndClearAll(sets);
   }
 
-  @Ignore
   @Test
   public void testDescribe() throws Exception {
-    run("USE phoenix123.v1");
-    assertEquals(4, queryBuilder().sql("DESCRIBE NATION").run().recordCount());
+    assertEquals(4, queryBuilder().sql("DESCRIBE phoenix123.v1.NATION").run().recordCount());
+  }
+
+  @Test
+  public void testDescribeCaseInsensitive() throws Exception {
+    String sql = "DESCRIBE phoenix123.v1.nation"; // use lowercase
+    QueryBuilder builder = client.queryBuilder().sql(sql);
+    RowSet sets = builder.rowSet();
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("COLUMN_NAME", MinorType.VARCHAR)
+        .addNullable("DATA_TYPE", MinorType.VARCHAR)
+        .addNullable("IS_NULLABLE", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), schema)
+        .addRow("N_NATIONKEY", "BIGINT", "NO")
+        .addRow("N_NAME", "CHARACTER VARYING", "YES")
+        .addRow("N_REGIONKEY", "BIGINT", "YES")
+        .addRow("N_COMMENT", "CHARACTER VARYING", "YES")
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(sets);
   }
 }


### PR DESCRIPTION
# [DRILL-8080](https://issues.apache.org/jira/browse/DRILL-8080): Enable the describe Case-Insensitive for Phoenix

## Description
Rewrite the `areTableNamesCaseSensitive()` method to support this feature.

## Documentation
N/A

## Testing
Added two unit tests.

<pre>
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.drill.exec.store.phoenix.PhoenixTestSuite
[INFO] Running org.apache.drill.exec.store.phoenix.PhoenixDataTypeTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.575 s - in org.apache.drill.exec.store.phoenix.PhoenixDataTypeTest
[INFO] Running org.apache.drill.exec.store.phoenix.PhoenixSQLTest
[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4.101 s - in org.apache.drill.exec.store.phoenix.PhoenixSQLTest
[INFO] Running org.apache.drill.exec.store.phoenix.PhoenixCommandTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.528 s - in org.apache.drill.exec.store.phoenix.PhoenixCommandTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
</pre>