### PR TITLE
DRILL-8089: Separate the setup time for some operators

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
@@ -619,7 +619,7 @@ public class MergingRecordBatch extends AbstractRecordBatch<MergingReceiverPOP> 
    * @throws SchemaChangeException
    */
   private MergingReceiverGeneratorBase createMerger() {
-
+    stats.startSetup();
     final CodeGenerator<MergingReceiverGeneratorBase> cg =
         CodeGenerator.get(MergingReceiverGeneratorBase.TEMPLATE_DEFINITION,
             context.getOptions());
@@ -651,6 +651,8 @@ public class MergingRecordBatch extends AbstractRecordBatch<MergingReceiverPOP> 
       return merger;
     } catch (SchemaChangeException e) {
       throw schemaChangeException(e, logger);
+    } finally {
+      stats.stopSetup();
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
@@ -185,7 +185,12 @@ public class PartitionSenderRootExec extends BaseRootExec {
             partitioner.flushOutgoingBatches(false, true);
             partitioner.clear();
           }
-          createPartitioner();
+          try {
+            stats.startSetup();
+            createPartitioner();
+          } finally {
+            stats.stopSetup();
+          }
 
           if (first) {
             // Send an empty batch for fast schema

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -123,7 +123,12 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
           } else if (next != IterOutcome.OK && next != IterOutcome.OK_NEW_SCHEMA && next != EMIT) {
             return next;
           } else if (next == IterOutcome.OK_NEW_SCHEMA) {
-            setupNewSchema();
+            try {
+              stats.startSetup();
+              setupNewSchema();
+            } finally {
+              stats.stopSetup();
+            }
           }
           incomingRecordCount = incoming.getRecordCount();
           memoryManager.update();


### PR DESCRIPTION
# [DRILL-8089](https://issues.apache.org/jira/browse/DRILL-8089): Separate the setup time for some operators

## Description
Calculate setup time separately for some operators

## Documentation
No need

## Testing
By existed ut