### PR TITLE
DRILL-8090: LIMIT clause is pushed down to an invalid OFFSET-FETCH clause for MS SQL Server

### DIFF
--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcLimitRule.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcLimitRule.java
@@ -37,6 +37,10 @@ public class JdbcLimitRule extends DrillJdbcRuleBase.DrillJdbcLimitRule {
   public boolean matches(RelOptRuleCall call) {
     DrillLimitRelBase limit = call.rel(0);
     if (super.matches(call)) {
+      // MS SQL doesn't support either OFFSET or FETCH without ORDER BY.
+      // But for the case of FETCH without OFFSET, Calcite generates TOP N
+      // instead of FETCH, and it is supported by MS SQL.
+      // So do not push down only the limit with both OFFSET and FETCH but without ORDER BY.
       return limit.getOffset() == null
         || !limit.getTraitSet().contains(RelCollations.EMPTY)
         || !(convention.getPlugin().getDialect() instanceof MssqlSqlDialect);

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcLimitRule.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcLimitRule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.jdbc.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.sql.dialect.MssqlSqlDialect;
+import org.apache.drill.exec.planner.common.DrillLimitRelBase;
+import org.apache.drill.exec.store.enumerable.plan.DrillJdbcRuleBase;
+import org.apache.drill.exec.store.jdbc.DrillJdbcConvention;
+
+public class JdbcLimitRule extends DrillJdbcRuleBase.DrillJdbcLimitRule {
+  private final DrillJdbcConvention convention;
+
+  public JdbcLimitRule(RelTrait in, DrillJdbcConvention out) {
+    super(in, out);
+    this.convention = out;
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    DrillLimitRelBase limit = call.rel(0);
+    if (super.matches(call)) {
+      return limit.getOffset() == null
+        || !limit.getTraitSet().contains(RelCollations.EMPTY)
+        || !(convention.getPlugin().getDialect() instanceof MssqlSqlDialect);
+    }
+    return false;
+  }
+}

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcSortRule.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcSortRule.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.jdbc.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.sql.dialect.MssqlSqlDialect;
+import org.apache.drill.exec.store.enumerable.plan.DrillJdbcRuleBase;
+import org.apache.drill.exec.store.jdbc.DrillJdbcConvention;
+
+public class JdbcSortRule extends DrillJdbcRuleBase.DrillJdbcSortRule {
+  private final DrillJdbcConvention convention;
+
+  public JdbcSortRule(RelTrait in, DrillJdbcConvention out) {
+    super(in, out);
+    this.convention = out;
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    Sort sort = call.rel(0);
+    if (super.matches(call)) {
+      return sort.offset == null
+        || !sort.getCollation().getFieldCollations().isEmpty()
+        || !(convention.getPlugin().getDialect() instanceof MssqlSqlDialect);
+    }
+    return false;
+  }
+}

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcSortRule.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/rules/JdbcSortRule.java
@@ -36,6 +36,10 @@ public class JdbcSortRule extends DrillJdbcRuleBase.DrillJdbcSortRule {
   public boolean matches(RelOptRuleCall call) {
     Sort sort = call.rel(0);
     if (super.matches(call)) {
+      // MS SQL doesn't support either OFFSET or FETCH without ORDER BY.
+      // But for the case of FETCH without OFFSET, Calcite generates TOP N
+      // instead of FETCH, and it is supported by MS SQL.
+      // So do not push down only the limit with both OFFSET and FETCH but without ORDER BY.
       return sort.offset == null
         || !sort.getCollation().getFieldCollations().isEmpty()
         || !(convention.getPlugin().getDialect() instanceof MssqlSqlDialect);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
@@ -54,7 +54,7 @@ public abstract class DrillJdbcRuleBase extends ConverterRule {
 
   protected final JdbcConvention out;
 
-  private DrillJdbcRuleBase(Class<? extends RelNode> clazz, RelTrait in, JdbcConvention out, String description) {
+  protected DrillJdbcRuleBase(Class<? extends RelNode> clazz, RelTrait in, JdbcConvention out, String description) {
     super(clazz, (Predicate<RelNode>) input -> true, in, out, DrillRelFactories.LOGICAL_BUILDER, description);
     this.out = out;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       avoid_bad_dependencies plugin found in the file.
     -->
     <calcite.groupId>com.github.vvysotskyi.drill-calcite</calcite.groupId>
-    <calcite.version>1.21.0-drill-r5</calcite.version>
+    <calcite.version>1.21.0-drill-r7</calcite.version>
     <avatica.version>1.17.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.12.0</sqlline.version>


### PR DESCRIPTION
# [DRILL-8090](https://issues.apache.org/jira/browse/DRILL-8090): LIMIT clause is pushed down to an invalid OFFSET-FETCH clause for MS SQL Server

## Description
- Updated Calcite fork version to include https://github.com/apache/calcite/commit/cc40a48cb8ca16f91bfdc66eaed6151805355d4b, so now regular limit can be pushed down to MS SQL as `TOP N` instead of `FETCH`.
- Updated `JdbcLimitRule` and `JdbcSortRule` to prevent pushing down `FETCH` with `OFFSET` and without `ORDER BY`. 
For such a case, some rules at the physical stage will generate a limit on top of the scan that includes `FETCH` only and another limit with `FETCH` and `OFFSET` above, so the limit will be pushed down.
- Allowed matching JDBC rules for physical rel nodes.
- Fixed issue with ClassCastException for Phoenix plugin (issue similar to [DRILL-7972](https://github.com/apache/drill/pull/2275)).

## Documentation
NA

## Testing
Checked manually.
