### PR TITLE
DRILL-8092: Add Auto Pagination to HTTP Storage Plugin

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -251,7 +251,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     if (paginator != null &&
       maxRecords < 0 && (resultSetLoader.totalRowCount()) < paginator.getPageSize()) {
       logger.debug("Partially filled page received, ending pagination");
-      paginator.endPagination();
+      paginator.notifyPartialPage();
     }
     return result;
   }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
@@ -179,8 +179,7 @@ public class HttpCSVBatchReader extends HttpBatchReader {
 
       if (paginator != null &&
         maxRecords < 0 && (resultLoader.totalRowCount()) < paginator.getPageSize()) {
-        logger.debug("Ending CSV pagination: Pages too small");
-        paginator.endPagination();
+        paginator.notifyPartialPage();
       }
       return false;
     }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -165,7 +165,7 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
         * a new batch reader for each URL.  In the future, this could be parallelized in
         * the group scan such that the calls could be sent to different drillbits.
         */
-        if (!paginator.hasMore()) {
+        if (!paginator.hasNext()) {
           return null;
         }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
@@ -133,8 +133,7 @@ public class HttpXMLBatchReader extends HttpBatchReader {
 
     if (paginator != null &&
       maxRecords < 0 && (resultLoader.totalRowCount()) < paginator.getPageSize()) {
-      logger.debug("Ending XML pagination: Pages too small");
-      paginator.endPagination();
+      paginator.notifyPartialPage();
     }
 
     return result;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -244,7 +244,7 @@ public class SimpleHttp {
       if (paginator != null && (
         response.code() != 200 || response.body() == null ||
         response.body().contentLength() == 0)) {
-        paginator.endPagination();
+        paginator.notifyPartialPage();
       }
 
       // If the request is unsuccessful, throw a UserException

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPaginator.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPaginator.java
@@ -23,11 +23,8 @@ import org.apache.drill.exec.store.http.paginator.OffsetPaginator;
 import org.apache.drill.exec.store.http.paginator.PagePaginator;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class tests the functionality of the various paginator classes as it pertains
@@ -41,39 +38,11 @@ public class TestPaginator {
     HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
 
     OffsetPaginator op = new OffsetPaginator(urlBuilder, 25, 5, "limit", "offset");
-    List<HttpUrl> urls = op.buildPaginatedURLs();
-    assertEquals(5, urls.size());
 
-    List<HttpUrl> expected = new ArrayList<>();
-    expected.add( HttpUrl.parse("https://myapi.com/?offset=0&limit=5"));
-    expected.add( HttpUrl.parse("https://myapi.com/?offset=5&limit=5"));
-    expected.add( HttpUrl.parse("https://myapi.com/?offset=10&limit=5"));
-    expected.add( HttpUrl.parse("https://myapi.com/?offset=15&limit=5"));
-    expected.add( HttpUrl.parse("https://myapi.com/?offset=20&limit=5"));
-
-    assertEquals(expected, urls);
-  }
-
-  @Test
-  public void TestOffsetPaginatorIterator() {
-    String baseUrl = "https://myapi.com";
-    HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
-
-    OffsetPaginator op = new OffsetPaginator(urlBuilder, 25, 5, "limit", "offset");
-    assertEquals(5, op.count());
-
-    String next = op.next();
-    assertEquals(next, "https://myapi.com/?offset=0&limit=5");
-    next = op.next();
-    assertEquals(next, "https://myapi.com/?offset=5&limit=5");
-    next = op.next();
-    assertEquals(next, "https://myapi.com/?offset=10&limit=5");
-    next = op.next();
-    assertEquals(next, "https://myapi.com/?offset=15&limit=5");
-    next = op.next();
-    assertEquals(next, "https://myapi.com/?offset=20&limit=5");
-    next = op.next();
-    assertNull(next);
+    for (int i = 0; i < 25; i += 5) {
+      assertEquals(String.format("%s/?offset=%d&limit=5", baseUrl, i), op.next());
+    }
+    assertFalse(op.hasNext());
   }
 
   @Test
@@ -82,11 +51,13 @@ public class TestPaginator {
     HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
 
     PagePaginator pp = new PagePaginator(urlBuilder, 10, 2, "page", "per_page");
-    List<HttpUrl> urls = pp.getPaginatedUrls();
-    assertEquals(5, urls.size());
+    for (int i = 1; i <= 5; i++) {
+      assertEquals(String.format("%s?page=%d&per_page=%d", baseUrl, i, 2), pp.next());
+    }
+    assertFalse(pp.hasNext());
 
     PagePaginator pp2 = new PagePaginator(urlBuilder, 10, 100, "page", "per_page");
-    List<HttpUrl> urls2 = pp2.getPaginatedUrls();
-    assertEquals(1, urls2.size());
+    assertEquals(String.format("%s?page=%d&per_page=%d", baseUrl, 1, 100), pp2.next());
+    assertFalse(pp.hasNext());
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoader.java
@@ -48,9 +48,9 @@ public interface JsonLoader {
   String JSON_LITERAL_MODE = "json";
 
   /**
-   * Read one record of data.
+   * Read one batch of row data.
    *
-   * @return {@code true} if a record was loaded, {@code false} if EOF.
+   * @return {@code true} if at least one record was loaded, {@code false} if EOF.
    * @throws {org.apache.drill.common.exceptions.UserException
    * for most errors
    * @throws RuntimeException for unexpected errors, most often due


### PR DESCRIPTION
# [DRILL-8092](https://issues.apache.org/jira/browse/DRILL-8092): Add Auto Pagination to HTTP Storage Plugin

## Description

This PR is a follow-up to #2414 and refactors the Paginator classes in that PR.  No functionality is changed.  The main goal is to base the Paginators on java.util.Iterator but some extra simplification was also possible. 
 
## Documentation
See #2414.

## Testing
See #2414.
