### PR TITLE
[MINOR UPDATE] Remove bogus copy paste test of log dir env var.

### DIFF
--- a/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/TestScripts.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/TestScripts.java
@@ -273,34 +273,6 @@ public class TestScripts extends BaseTest {
   }
 
   /**
-   * Create a custom Java lib path. This uses the new DRILL_JAVA_LIB_PATH
-   * variable.
-   */
-
-  @Test
-  public void testLibPath() throws IOException {
-    context.createMockDistrib();
-    File siteDir = new File(context.testDrillHome, "conf");
-    context.createMockConf(siteDir);
-    File logsDir = context.createDir(new File(context.testDir, "logs"));
-    context.removeDir(new File(context.testDrillHome, "log"));
-
-    {
-      String logPath = logsDir.getAbsolutePath();
-      RunResult result = new DrillbitRun(DrillbitRun.DRILLBIT_RUN)
-          .addEnv("DRILL_LOG_DIR", logPath).withLogDir(logsDir).run();
-      assertEquals(0, result.returnCode);
-      result.validateArgs(
-          new String[] { "-Dlog.path=" + logPath + "/drillbit.log",
-              "-Dlog.query.path=" + logPath + "/drillbit_queries.json", });
-      result.validateStdOut();
-      result.validateStdErr();
-      result.validateDrillLog();
-    }
-
-  }
-
-  /**
    * Try setting custom environment variable values in drill-env.sh in the
    * $DRILL_HOME/conf location.
    */


### PR DESCRIPTION
## Description

The removed test is a copy pasta of [the log dir test directly above it](https://github.com/apache/drill/blob/4aefcef2b665c5737471664912a26ef6ed9a6cfc/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/TestScripts.java#L253) so does not test
the native lib dir variables it claims to at all.  There is a legitimate test of the native lib 
dir env vars present in the same test class.

## Documentation
N/A

## Testing
N/A
