### PR TITLE
DRILL-8112: Excel Reader Ignores HeaderRow Config Param

### DIFF
--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -325,6 +325,12 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
       }
       builder.buildSchema();
     } else if (rowIterator.hasNext()) {
+
+      // Advance first row to header row, if defined.
+      if (readerConfig.headerRow > 0) {
+        skipToRow(readerConfig.headerRow);
+      }
+
       //Get the header row and column count
       totalColumnCount = currentRow.getLastCellNum();
 


### PR DESCRIPTION
# [DRILL-8112](https://issues.apache.org/jira/browse/DRILL-8112): Excel Reader Ignores HeaderRow Config Param

## Description
Drill was ignoring the `headerRow` parameter in the Excel reader, which allowed Drill to skip to the first row of actual data.  This PR fixes that.

## Documentation
N/A

## Testing
Ran unit tests, and tested manually. 
