### PR TITLE
DRILL-8114: Prevent applying Iceberg project on non-Iceberg tables

### DIFF
--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
-import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Util;
@@ -30,12 +29,9 @@ import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.planner.common.DrillLimitRelBase;
-import org.apache.drill.exec.planner.common.DrillRelOptUtil;
 import org.apache.drill.exec.planner.logical.DrillOptiq;
 import org.apache.drill.exec.planner.logical.DrillParseContext;
-import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.planner.physical.PrelUtil;
-import org.apache.drill.exec.store.SubsetRemover;
 import org.apache.drill.exec.store.iceberg.IcebergGroupScan;
 import org.apache.drill.exec.store.plan.AbstractPluginImplementor;
 import org.apache.drill.exec.store.plan.rel.PluginFilterRel;
@@ -97,9 +93,7 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
 
     if (expression != null) {
       try {
-        TableScan tableScan = DrillRelOptUtil.findScan(filter.accept(SubsetRemover.INSTANCE));
-        DrillTable drillTable = DrillRelOptUtil.getDrillTable(tableScan);
-        GroupScan scan = drillTable.getGroupScan();
+        GroupScan scan = findGroupScan(filter);
         if (scan instanceof IcebergGroupScan) {
           IcebergGroupScan groupScan = (IcebergGroupScan) scan;
           // ensures that expression compatible with table schema
@@ -107,7 +101,7 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
         } else {
           return false;
         }
-      } catch (ValidationException | IOException e) {
+      } catch (ValidationException e) {
         return false;
       }
     }
@@ -125,11 +119,14 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(DrillLimitRelBase limit) {
-    FirstLimitFinder finder = new FirstLimitFinder();
-    limit.getInput().accept(finder);
-    int oldLimit = getArtificialLimit(finder.getFetch(), finder.getOffset());
-    int newLimit = getArtificialLimit(limit);
-    return newLimit >= 0 && (oldLimit < 0 || newLimit < oldLimit);
+    if (hasIcebergGroupScan(limit)) {
+      FirstLimitFinder finder = new FirstLimitFinder();
+      limit.getInput().accept(finder);
+      int oldLimit = getArtificialLimit(finder.getFetch(), finder.getOffset());
+      int newLimit = getArtificialLimit(limit);
+      return newLimit >= 0 && (oldLimit < 0 || newLimit < oldLimit);
+    }
+    return false;
   }
 
   @Override
@@ -144,12 +141,16 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(Project project) {
-    return true;
+    return hasIcebergGroupScan(project);
   }
 
   @Override
   public GroupScan getPhysicalOperator() {
     return groupScan;
+  }
+
+  private boolean hasIcebergGroupScan(RelNode node) {
+    return findGroupScan(node) instanceof IcebergGroupScan;
   }
 
   private int rexLiteralIntValue(RexLiteral offset) {

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
@@ -119,7 +119,7 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(DrillLimitRelBase limit) {
-    if (hasIcebergGroupScan(limit)) {
+    if (hasPluginGroupScan(limit)) {
       FirstLimitFinder finder = new FirstLimitFinder();
       limit.getInput().accept(finder);
       int oldLimit = getArtificialLimit(finder.getFetch(), finder.getOffset());
@@ -141,7 +141,7 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(Project project) {
-    return hasIcebergGroupScan(project);
+    return hasPluginGroupScan(project);
   }
 
   @Override
@@ -149,7 +149,8 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
     return groupScan;
   }
 
-  private boolean hasIcebergGroupScan(RelNode node) {
+  @Override
+  protected boolean hasPluginGroupScan(RelNode node) {
     return findGroupScan(node) instanceof IcebergGroupScan;
   }
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/MongoPluginImplementor.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/MongoPluginImplementor.java
@@ -231,7 +231,8 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(Aggregate aggregate) {
-    return aggregate.getGroupType() == Aggregate.Group.SIMPLE
+    return hasMongoGroupScan(aggregate)
+      && aggregate.getGroupType() == Aggregate.Group.SIMPLE
       && aggregate.getAggCallList().stream()
       .noneMatch(AggregateCall::isDistinct)
       && aggregate.getAggCallList().stream()
@@ -240,41 +241,45 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(Filter filter) {
-    LogicalExpression conditionExp = DrillOptiq.toDrill(
-      new DrillParseContext(PrelUtil.getPlannerSettings(filter.getCluster().getPlanner())),
-      filter.getInput(),
-      filter.getCondition());
-    MongoFilterBuilder filterBuilder = new MongoFilterBuilder(conditionExp);
-    filterBuilder.parseTree();
-    return filterBuilder.isAllExpressionsConverted();
+    if (hasMongoGroupScan(filter)) {
+      LogicalExpression conditionExp = DrillOptiq.toDrill(
+        new DrillParseContext(PrelUtil.getPlannerSettings(filter.getCluster().getPlanner())),
+        filter.getInput(),
+        filter.getCondition());
+      MongoFilterBuilder filterBuilder = new MongoFilterBuilder(conditionExp);
+      filterBuilder.parseTree();
+      return filterBuilder.isAllExpressionsConverted();
+    }
+    return false;
   }
 
   @Override
   public boolean canImplement(DrillLimitRelBase limit) {
-    return true;
+    return hasMongoGroupScan(limit);
   }
 
   @Override
   public boolean canImplement(Project project) {
-    return project.getProjects().stream()
-      .allMatch(RexToMongoTranslator::supportsExpression);
+    return hasMongoGroupScan(project) &&
+      project.getProjects().stream()
+        .allMatch(RexToMongoTranslator::supportsExpression);
   }
 
   @Override
   public boolean canImplement(Sort sort) {
-    return true;
+    return hasMongoGroupScan(sort);
   }
 
   @Override
   public boolean canImplement(Union union) {
     // allow converting for union all only, since Drill adds extra aggregation for union distinct,
     // so we will convert both union all and aggregation later
-    return union.all;
+    return union.all && hasMongoGroupScan(union);
   }
 
   @Override
   public boolean canImplement(TableScan scan) {
-    return true;
+    return hasMongoGroupScan(scan);
   }
 
   @Override
@@ -292,7 +297,11 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
       newSpec, columns, runAggregate);
   }
 
-  public static int direction(RelFieldCollation fieldCollation) {
+  private boolean hasMongoGroupScan(RelNode node) {
+    return findGroupScan(node) instanceof MongoGroupScan;
+  }
+
+  private static int direction(RelFieldCollation fieldCollation) {
     switch (fieldCollation.getDirection()) {
       case DESCENDING:
       case STRICTLY_DESCENDING:

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/MongoPluginImplementor.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/MongoPluginImplementor.java
@@ -231,7 +231,7 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(Aggregate aggregate) {
-    return hasMongoGroupScan(aggregate)
+    return hasPluginGroupScan(aggregate)
       && aggregate.getGroupType() == Aggregate.Group.SIMPLE
       && aggregate.getAggCallList().stream()
       .noneMatch(AggregateCall::isDistinct)
@@ -241,7 +241,7 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(Filter filter) {
-    if (hasMongoGroupScan(filter)) {
+    if (hasPluginGroupScan(filter)) {
       LogicalExpression conditionExp = DrillOptiq.toDrill(
         new DrillParseContext(PrelUtil.getPlannerSettings(filter.getCluster().getPlanner())),
         filter.getInput(),
@@ -255,31 +255,31 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
 
   @Override
   public boolean canImplement(DrillLimitRelBase limit) {
-    return hasMongoGroupScan(limit);
+    return hasPluginGroupScan(limit);
   }
 
   @Override
   public boolean canImplement(Project project) {
-    return hasMongoGroupScan(project) &&
+    return hasPluginGroupScan(project) &&
       project.getProjects().stream()
         .allMatch(RexToMongoTranslator::supportsExpression);
   }
 
   @Override
   public boolean canImplement(Sort sort) {
-    return hasMongoGroupScan(sort);
+    return hasPluginGroupScan(sort);
   }
 
   @Override
   public boolean canImplement(Union union) {
     // allow converting for union all only, since Drill adds extra aggregation for union distinct,
     // so we will convert both union all and aggregation later
-    return union.all && hasMongoGroupScan(union);
+    return union.all && hasPluginGroupScan(union);
   }
 
   @Override
   public boolean canImplement(TableScan scan) {
-    return hasMongoGroupScan(scan);
+    return hasPluginGroupScan(scan);
   }
 
   @Override
@@ -297,7 +297,8 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
       newSpec, columns, runAggregate);
   }
 
-  private boolean hasMongoGroupScan(RelNode node) {
+  @Override
+  protected boolean hasPluginGroupScan(RelNode node) {
     return findGroupScan(node) instanceof MongoGroupScan;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
@@ -325,6 +325,9 @@ public abstract class DrillRelOptUtil {
     for (RelNode rel : rels) {
       if (rel instanceof TableScan) {
         return (TableScan) rel;
+      } else if (rel instanceof RelSubset) {
+        RelSubset relSubset = (RelSubset) rel;
+        return findScan(Util.first(relSubset.getBest(), relSubset.getOriginal()));
       } else {
         return findScan(rel.getInputs().toArray(new RelNode[0]));
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
@@ -155,4 +155,6 @@ public abstract class AbstractPluginImplementor implements PluginImplementor {
       .map(groupScanFunction)
       .orElse(null);
   }
+
+  protected abstract boolean hasPluginGroupScan(RelNode node);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.plan;
 
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Join;
@@ -25,7 +26,11 @@ import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.util.function.CheckedFunction;
+import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.planner.common.DrillLimitRelBase;
+import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.store.plan.rel.PluginAggregateRel;
 import org.apache.drill.exec.store.plan.rel.PluginFilterRel;
 import org.apache.drill.exec.store.plan.rel.PluginJoinRel;
@@ -38,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Abstract base implementation of {@link PluginImplementor} that can be used by
@@ -140,5 +146,13 @@ public abstract class AbstractPluginImplementor implements PluginImplementor {
     return UserException.unsupportedError()
         .message("Plugin implementor doesn't support push down for %s", rel)
         .build(logger);
+  }
+
+  protected GroupScan findGroupScan(RelNode node) {
+    CheckedFunction<DrillTable, GroupScan, IOException> groupScanFunction = DrillTable::getGroupScan;
+    return Optional.ofNullable(DrillRelOptUtil.findScan(node))
+      .map(DrillRelOptUtil::getDrillTable)
+      .map(groupScanFunction)
+      .orElse(null);
   }
 }


### PR DESCRIPTION
# [DRILL-8114](https://issues.apache.org/jira/browse/DRILL-8114): Prevent applying Iceberg project on non-Iceberg tables

## Description
Added checks to ensure that table has iceberg group scan when matching iceberg rules (the same for mongo).

## Documentation
NA

## Testing
Added unit tests.
