### PR TITLE
DRILL-8115: Adds LIMIT pushdown support in the scan framework

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/RowBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/RowBatchReader.java
@@ -36,7 +36,7 @@ import org.apache.drill.exec.record.VectorContainer;
  * vectors across batches, etc.
  * <p>
  * Note that this interface reads a <b>batch</b> of rows, not
- * a single row. (The original <tt>RecordReader</tt> could be
+ * a single row. (The original {@code RecordReader} could be
  * confusing in this aspect.)
  * <p>
  * The expected lifecycle is:
@@ -49,15 +49,15 @@ import org.apache.drill.exec.record.VectorContainer;
  * is late-schema), return null for the output and -1 for the schema
  * version. Else, return non-negative for the version number and
  * an empty batch with a schema.</li>
- * <li>{@link #next()}</tt> to retrieve the next record batch.
+ * <li>{@link #next()}} to retrieve the next record batch.
  * Return true if a batch is available, false if EOF. There is no
- * requirement to return a batch; the first call to <tt>next()</tt>
- * can return <tt>false</tt> if no data is available.</tt>
+ * requirement to return a batch; the first call to {@code next()}
+ * can return {@code false} if no data is available.}
  * <li>{@link #output()} and {@link #schemaVersion()} to obtain the
  * batch of records read, and to detect if the version of the schema
  * is different from the previous batch.</li>
  * <li>{@link #close()} when the reader is no longer needed. This
- * may occur before <tt>next()</tt> returns <tt>false</tt> if an
+ * may occur before {@code next()} returns {@code false} if an
  * error occurs or a limit is reached.</li>
  * </ul>
  * Although the reader should not care, the scanner must return an
@@ -65,8 +65,8 @@ import org.apache.drill.exec.record.VectorContainer;
  * The scan operator handles this transparently:
  * <ul>
  * <li>If the reader is early-schema, then the reader itself returns
- * an empty batch (via <tt>output()</tt), with only schema after the call
- * to <tt>open()</tt>. The scanner sends this empty batch downstream
+ * an empty batch (via {@code output()</tt), with only schema after the call
+ * to {@code open()}. The scanner sends this empty batch downstream
  * directly.</li>
  * <li>If the reader is late-schema, then the reader will read the first
  * batch from the reader. It will save that batch, extract the schema,
@@ -81,7 +81,6 @@ import org.apache.drill.exec.record.VectorContainer;
  * from any method. A {@link UserException} is preferred to provide
  * detailed information about the source of the problem.
  */
-
 public interface RowBatchReader {
 
   /**
@@ -89,12 +88,11 @@ public interface RowBatchReader {
    *
    * @return display name for errors
    */
-
   String name();
 
   /**
    * Setup the record reader. Called just before the first call
-   * to <tt>next()</tt>. Allocate resources here, not in the constructor.
+   * to {@code next()}. Allocate resources here, not in the constructor.
    * Example: open files, allocate buffers, etc.
    *
    * @return true if the reader is open and ready to read (possibly no)
@@ -102,10 +100,9 @@ public interface RowBatchReader {
    * but the scanner should not fail, it should move onto another reader
    *
    * @throws RuntimeException for "hard" errors that should terminate
-   * the query. <tt>UserException</tt> preferred to explain the problem
+   * the query. {@code UserException} preferred to explain the problem
    * better than the scan operator can by guessing at the cause
    */
-
   boolean open();
 
   /**
@@ -121,17 +118,16 @@ public interface RowBatchReader {
    * @return true if this reader can (and has) defined an empty batch
    * to describe the schema, false otherwise
    */
-
   boolean defineSchema();
 
   /**
    * Read the next batch. Reading continues until either EOF,
    * or until the mutator indicates that the batch is full.
    * The batch is considered valid if it is non-empty. Returning
-   * <tt>true</tt> with an empty batch is valid, and is helpful on
+   * {@code true} with an empty batch is valid, and is helpful on
    * the very first batch (returning schema only.) An empty batch
-   * with a <tt>false</tt> return code indicates EOF and the batch
-   * will be discarded. A non-empty batch along with a <tt>false</tt>
+   * with a {@code false} return code indicates EOF and the batch
+   * will be discarded. A non-empty batch along with a {@code false}
    * return result indicates a final, valid batch, but that EOF was
    * reached and no more data is available.
    * <p>
@@ -139,14 +135,13 @@ public interface RowBatchReader {
    * final batch just to find out that no more data is available;
    * it allows EOF to be returned along with the final batch.
    *
-   * @return <tt>true</tt> if more data may be available (and so
-   * <tt>next()</tt> should be called again, <tt>false</tt> to indicate
+   * @return {@code true} if more data may be available (and so
+   * {@code next()} should be called again, {@code false} to indicate
    * that EOF was reached
    *
-   * @throws RuntimeException (<tt>UserException</tt> preferred) if an
+   * @throws RuntimeException ({@code UserException} preferred) if an
    * error occurs that should fail the query.
    */
-
   boolean next();
 
   /**
@@ -158,7 +153,7 @@ public interface RowBatchReader {
    * empty batch with the schema set. The scanner will return this schema
    * downstream to inform other operators of the schema.</li>
    * <li>Directly after a successful call to {@link next()} to retrieve
-   * the batch produced by that call. (No call is made if <tt>next()</tt>
+   * the batch produced by that call. (No call is made if {@code next()}
    * returns false.</li>
    * </ul>
    * Note that most operators require the same vectors be present in
@@ -166,10 +161,9 @@ public interface RowBatchReader {
    * container, and same set of vectors, on each call.
    *
    * @return a vector container, with the record count and schema
-   * set, that announces the schema after <tt>open()</tt> (optional)
-   * or returns rows read after <tt>next()</tt> (required)
+   * set, that announces the schema after {@code open()} (optional)
+   * or returns rows read after {@code next()} (required)
    */
-
   VectorContainer output();
 
   /**
@@ -183,8 +177,8 @@ public interface RowBatchReader {
    * <li>The number increases if a batch has a different schema than the
    * previous batch.</li>
    * </ul>
-   * Numbers increment (or not) on calls to <tt>next()</tt>. Thus Two successive
-   * calls to this method should return the same number if no <tt>next()</tt>
+   * Numbers increment (or not) on calls to {@code next()}. Thus Two successive
+   * calls to this method should return the same number if no {@code next()}
    * call lies between.
    * <p>
    * If the reader can return a schema on open (so-called "early-schema), then
@@ -192,29 +186,27 @@ public interface RowBatchReader {
    * happens to be empty (such as reading an empty file.)
    * <p>
    * However, if the reader cannot return a schema on open (so-called "late
-   * schema"), then this method must return -1 (and <tt>output()</tt> must
+   * schema"), then this method must return -1 (and {@code output()} must
    * return null) to indicate now schema is available when called before the
-   * first call to <tt>next()</tt>.
+   * first call to {@code next()}.
    * <p>
-   * No calls will be made to this method before <tt>open()</tt> after
-   * <tt>close()<tt> or after <tt>next()</tt> returns false. The implementation
+   * No calls will be made to this method before {@code open()} after
+   * {@code close(){@code  or after {@code next()} returns false. The implementation
    * is thus not required to handle these cases.
    *
    * @return the schema version, or -1 if no schema version is yet available
    */
-
   int schemaVersion();
 
   /**
    * Release resources. Called just after a failure, when the scanner
-   * is cancelled, or after <tt>next()</tt> returns EOF. Release
+   * is cancelled, or after {@code next()} returns EOF. Release
    * all resources and close files. Guaranteed to be called if
-   * <tt>open()</tt> returns normally; will not be called if <tt>open()</tt>
+   * {@code open()} returns normally; will not be called if {@code open()}
    * throws an exception.
    *
-   * @throws RutimeException (<tt>UserException</tt> preferred) if an
+   * @throws RutimeException ({@code UserException} preferred) if an
    * error occurs that should fail the query.
    */
-
   void close();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/ScanOperatorEvents.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/ScanOperatorEvents.java
@@ -38,7 +38,6 @@ import org.apache.drill.exec.ops.OperatorContext;
  * across scanners. See {@link ScanSchemaOrchestrator} for the managed
  * framework.
  */
-
 public interface ScanOperatorEvents {
 
   /**
@@ -51,7 +50,6 @@ public interface ScanOperatorEvents {
    *
    * @param context the operator context for the scan operator
    */
-
   void bind(OperatorContext context);
 
   /**
@@ -67,13 +65,11 @@ public interface ScanOperatorEvents {
    * @return a batch reader for one of the scan elements within the
    * scan physical plan for this scan operator
    */
-
   RowBatchReader nextReader();
 
   /**
    * Called when the scan operator itself is closed. Indicates that no more
    * readers are available.
    */
-
   void close();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ManagedScanFramework.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ManagedScanFramework.java
@@ -193,6 +193,9 @@ public class ManagedScanFramework implements ScanOperatorEvents {
 
   @Override
   public RowBatchReader nextReader() {
+    if (scanOrchestrator.atLimit()) {
+      return null;
+    }
     ManagedReader<? extends SchemaNegotiator> reader = readerFactory.next();
     return reader == null ? null : new ShimBatchReader(this, reader);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiator.java
@@ -165,6 +165,12 @@ public interface SchemaNegotiator {
   void batchSize(int maxRecordsPerBatch);
 
   /**
+   * Push down a LIMIT into the scan. This is a per-reader limit,
+   * not an overall scan limit.
+   */
+  void limit(long limit);
+
+  /**
    * Build the schema, plan the required projections and static
    * columns and return a loader used to populate value vectors.
    * If the select list includes a subset of table columns, then

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
@@ -64,6 +64,7 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
   protected TupleMetadata tableSchema;
   protected boolean isSchemaComplete;
   protected int batchSize = ValueVector.MAX_ROW_COUNT;
+  protected long limit = -1;
 
   public SchemaNegotiatorImpl(ManagedScanFramework framework) {
     this.framework = framework;
@@ -136,6 +137,11 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
   @Override
   public String userName() {
     return framework.builder.userName;
+  }
+
+  @Override
+  public void limit(long limit) {
+    this.limit = limit;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ScanLifecycleBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ScanLifecycleBuilder.java
@@ -153,6 +153,11 @@ public class ScanLifecycleBuilder {
    */
   protected CustomErrorContext errorContext;
 
+  /**
+   * Pushed-down scan LIMIT.
+   */
+  private long limit = Long.MAX_VALUE;
+
   public void options(OptionSet options) {
     this.options = options;
   }
@@ -287,6 +292,18 @@ public class ScanLifecycleBuilder {
   }
 
   public SchemaValidator schemaValidator() { return schemaValidator; }
+
+  public void limit(long limit) {
+    // Operator definitions use -1 for "no limit", this mechanism
+    // uses a very big number for "no limit."
+    if (limit < 0) {
+      this.limit = Long.MAX_VALUE;
+    } else {
+      this.limit = limit;
+    }
+  }
+
+  public long limit() { return limit; }
 
   public ScanLifecycle build(OperatorContext context) {
     return new ScanLifecycle(context, this);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/SchemaNegotiatorImpl.java
@@ -53,6 +53,11 @@ import org.apache.drill.exec.vector.ValueVector;
  * a vector written by the reader, in the second, it is a null column
  * filled in by the scan projector (assuming, of course, that "c"
  * is nullable or an array.)
+ * <p>
+ * Pushes limits into the result set loader. The caller must
+ * either check the return value from {#code startBatch()}, or
+ * call {@code atLimit()} after {@code harvest()} to detect when the scan
+ * has reached the limit. Treat the limit condition the same as EOF.
  */
 public class SchemaNegotiatorImpl implements SchemaNegotiator {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/AbstractSchemaTracker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/AbstractSchemaTracker.java
@@ -127,6 +127,7 @@ public abstract class AbstractSchemaTracker implements ScanSchemaTracker {
     TupleMetadata implicitCols = new TupleSchema();
     for (ColumnHandle handle : schema.columns()) {
       if (handle.isImplicit()) {
+        handle.setIndex(implicitCols.size());
         implicitCols.addColumn(handle.column());
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/AbstractSchemaTracker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/AbstractSchemaTracker.java
@@ -127,7 +127,6 @@ public abstract class AbstractSchemaTracker implements ScanSchemaTracker {
     TupleMetadata implicitCols = new TupleSchema();
     for (ColumnHandle handle : schema.columns()) {
       if (handle.isImplicit()) {
-        handle.setIndex(implicitCols.size());
         implicitCols.addColumn(handle.column());
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/MutableTupleSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/MutableTupleSchema.java
@@ -98,6 +98,7 @@ public class MutableTupleSchema {
 
     public ColumnMetadata column() { return col; }
     public boolean isImplicit() { return marker != null; }
+    public void setIndex(int index) { marker.setIndex(index); }
 
     @Override
     public String toString() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/MutableTupleSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/MutableTupleSchema.java
@@ -98,7 +98,6 @@ public class MutableTupleSchema {
 
     public ColumnMetadata column() { return col; }
     public boolean isImplicit() { return marker != null; }
-    public void setIndex(int index) { marker.setIndex(index); }
 
     @Override
     public String toString() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/RowSetLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/RowSetLoader.java
@@ -114,6 +114,7 @@ public interface RowSetLoader extends TupleWriter {
    * @param maxRecords Maximum rows to be returned. (From the limit clause of the query)
    * @return True if the row count exceeds the maxRecords, false if not.
    */
+  @Deprecated() // use the limit in options instead
   boolean limitReached(int maxRecords);
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetOptionBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetOptionBuilder.java
@@ -38,6 +38,7 @@ public class ResultSetOptionBuilder {
   protected ProjectionFilter projectionFilter;
   protected TupleMetadata readerSchema;
   protected long maxBatchSize;
+  protected long scanLimit = Long.MAX_VALUE;
 
   /**
    * Error message context
@@ -111,6 +112,15 @@ public class ResultSetOptionBuilder {
 
   public ResultSetOptionBuilder projectionFilter(ProjectionFilter projectionFilter) {
     this.projectionFilter = projectionFilter;
+    return this;
+  }
+
+  public ResultSetOptionBuilder limit(long limit) {
+    if (limit < 0) {
+      this.scanLimit = Long.MAX_VALUE;
+    } else {
+      this.scanLimit = limit;
+    }
     return this;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/RowSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/RowSetLoaderImpl.java
@@ -74,6 +74,9 @@ public class RowSetLoaderImpl extends AbstractTupleWriter implements RowSetLoade
 
   @Override
   public boolean start() {
+    if (rsLoader.atLimit()) {
+      return false;
+    }
     if (rsLoader.isFull()) {
 
       // Full batch? Return false.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/WriterIndexImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/WriterIndexImpl.java
@@ -89,7 +89,7 @@ class WriterIndexImpl implements ColumnWriterIndex {
     return rowIndex;
   }
 
-  public boolean valid() { return rowIndex < rsLoader.targetRowCount(); }
+  public boolean valid() { return rowIndex < rsLoader.maxBatchSize(); }
 
   @Override
   public void rollover() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/BaseScanOperatorExecTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/BaseScanOperatorExecTest.java
@@ -35,6 +35,8 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
 import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test of the scan operator framework. Here the focus is on the
@@ -46,9 +48,8 @@ import org.apache.drill.test.rowSet.RowSetUtilities;
  * details of another, supporting class, then tests for that class
  * appear elsewhere.
  */
-
 public class BaseScanOperatorExecTest extends SubOperatorTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseScanOperatorExecTest.class);
+  static final Logger logger = LoggerFactory.getLogger(BaseScanOperatorExecTest.class);
 
   /**
    * Base class for the "mock" readers used in this test. The mock readers
@@ -57,7 +58,6 @@ public class BaseScanOperatorExecTest extends SubOperatorTest {
    * They also expose internal state such as identifying which methods
    * were actually called.
    */
-
   protected static abstract class BaseMockBatchReader implements ManagedReader<SchemaNegotiator> {
     protected boolean openCalled;
     protected boolean closeCalled;
@@ -94,7 +94,6 @@ public class BaseScanOperatorExecTest extends SubOperatorTest {
    * Mock reader that pretends to have a schema at open time
    * like an HBase or JDBC reader.
    */
-
   protected static class MockEarlySchemaReader extends BaseMockBatchReader {
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecBasics.java
@@ -378,7 +378,6 @@ public class TestScanOperExecBasics extends BaseScanOperatorExecTest {
    * early schema. Results in an empty (rather than null)
    * result set.
    */
-
   @Test
   public void testMultiEOFOnFirstBatch() {
     MockEarlySchemaReader reader1 = new MockEarlySchemaReader();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecEarlySchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecEarlySchema.java
@@ -41,7 +41,6 @@ public class TestScanOperExecEarlySchema extends BaseScanOperatorExecTest {
   /**
    * Mock reader that returns no schema and no records.
    */
-
   private static class MockNullEarlySchemaReader extends BaseMockBatchReader {
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecLimit.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.protocol.BatchAccessor;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.junit.Test;
+
+/**
+ * Verifies that the V1 scan framework properly pushes the LIMIT
+ * into the scan by stopping the scan once any reader produces
+ * the rows up to the limit. Verifies that the result set loader
+ * enforces the limit at the batch level, that the reader lifecycle
+ * enforces limits at the reader level, and that the scan framework
+ * enforces limits at by skipping over unneeded readers.
+ */
+public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
+
+  /**
+   * Mock reader that returns two 50-row batches.
+   */
+  protected static class Mock50RowReader implements ManagedReader<SchemaNegotiator> {
+    protected boolean openCalled;
+    protected ResultSetLoader tableLoader;
+
+    @Override
+    public boolean open(SchemaNegotiator negotiator) {
+      openCalled = true;
+      negotiator.tableSchema(new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .build(), true);
+        tableLoader = negotiator.build();
+      return true;
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 2) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      int base = tableLoader.batchCount() * 50 + 1;
+      for (int i = 0; i < 50; i++) {
+        if (rowSet.isFull()) {
+          break;
+        }
+        rowSet.addSingleCol(base + i);
+      }
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  /**
+   * LIMIT 0, to obtain only the schema.
+   */
+  @Test
+  public void testLimit0() {
+    Mock50RowReader reader1 = new Mock50RowReader();
+    Mock50RowReader reader2 = new Mock50RowReader();
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.builder.limit(0);
+    ScanFixture scanFixture =  builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(0, batch.rowCount());
+    assertEquals(1, batch.schema().getFieldCount());
+    batch.release();
+
+    // No second batch or second reader
+    assertFalse(scan.next());
+
+    scanFixture.close();
+
+    assertTrue(reader1.openCalled);
+    assertFalse(reader2.openCalled);
+  }
+
+  /**
+   * LIMIT 1, simplest case
+   */
+  @Test
+  public void testLimit1() {
+    Mock50RowReader reader1 = new Mock50RowReader();
+    Mock50RowReader reader2 = new Mock50RowReader();
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.builder.limit(1);
+    ScanFixture scanFixture =  builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(1, batch.rowCount());
+    batch.release();
+
+    // No second batch or second reader
+    assertFalse(scan.next());
+
+    scanFixture.close();
+
+    assertTrue(reader1.openCalled);
+    assertFalse(reader2.openCalled);
+  }
+
+  /**
+   * LIMIT 50, same as batch size, to check boundary conditions.
+   */
+  @Test
+  public void testLimitOnBatchEnd() {
+    Mock50RowReader reader1 = new Mock50RowReader();
+    Mock50RowReader reader2 = new Mock50RowReader();
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.builder.limit(50);
+    ScanFixture scanFixture =  builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    // No second batch or second reader
+    assertFalse(scan.next());
+
+    scanFixture.close();
+
+    assertTrue(reader1.openCalled);
+    assertFalse(reader2.openCalled);
+  }
+
+  /**
+   * LIMIT 75, halfway through second batch.
+   */
+  @Test
+  public void testLimitOnScondBatch() {
+    Mock50RowReader reader1 = new Mock50RowReader();
+    Mock50RowReader reader2 = new Mock50RowReader();
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.builder.limit(75);
+    ScanFixture scanFixture =  builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(25, batch.rowCount());
+    batch.release();
+
+    // No second reader
+    assertFalse(scan.next());
+
+    scanFixture.close();
+
+    assertTrue(reader1.openCalled);
+    assertFalse(reader2.openCalled);
+  }
+
+  /**
+   * LIMIT 100, at EOF of the first reader.
+   */
+  @Test
+  public void testLimitOnEOF() {
+    Mock50RowReader reader1 = new Mock50RowReader();
+    Mock50RowReader reader2 = new Mock50RowReader();
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.builder.limit(100);
+    ScanFixture scanFixture =  builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    // No second reader
+    assertFalse(scan.next());
+
+    scanFixture.close();
+
+    assertTrue(reader1.openCalled);
+    assertFalse(reader2.openCalled);
+  }
+
+  /**
+   * LIMIT 125: full first reader, limit on second
+   */
+  @Test
+  public void testLimitOnSecondReader() {
+    Mock50RowReader reader1 = new Mock50RowReader();
+    Mock50RowReader reader2 = new Mock50RowReader();
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.builder.limit(125);
+    ScanFixture scanFixture =  builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    // First batch, second reader
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(25, batch.rowCount());
+    batch.release();
+
+    // No second batch
+    assertFalse(scan.next());
+
+    scanFixture.close();
+
+    assertTrue(reader1.openCalled);
+    assertTrue(reader2.openCalled);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecLimit.java
@@ -88,7 +88,7 @@ public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
 
     BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
     builder.builder.limit(0);
-    ScanFixture scanFixture =  builder.build();
+    ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
     assertTrue(scan.buildSchema());
@@ -117,7 +117,7 @@ public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
 
     BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
     builder.builder.limit(1);
-    ScanFixture scanFixture =  builder.build();
+    ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
     assertTrue(scan.buildSchema());
@@ -145,7 +145,7 @@ public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
 
     BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
     builder.builder.limit(50);
-    ScanFixture scanFixture =  builder.build();
+    ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
     assertTrue(scan.buildSchema());
@@ -173,7 +173,7 @@ public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
 
     BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
     builder.builder.limit(75);
-    ScanFixture scanFixture =  builder.build();
+    ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
     assertTrue(scan.buildSchema());
@@ -206,7 +206,7 @@ public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
 
     BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
     builder.builder.limit(100);
-    ScanFixture scanFixture =  builder.build();
+    ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
     assertTrue(scan.buildSchema());
@@ -239,7 +239,7 @@ public class TestScanOperExecLimit extends BaseScanOperatorExecTest {
 
     BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
     builder.builder.limit(125);
-    ScanFixture scanFixture =  builder.build();
+    ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
     assertTrue(scan.buildSchema());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecOverflow.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecOverflow.java
@@ -44,7 +44,6 @@ public class TestScanOperExecOverflow extends BaseScanOperatorExecTest {
    * Mock reader that produces "jumbo" batches that cause a vector to
    * fill and a row to overflow from one batch to the next.
    */
-
   private static class OverflowReader extends BaseMockBatchReader {
 
     private final String value;
@@ -111,7 +110,6 @@ public class TestScanOperExecOverflow extends BaseScanOperatorExecTest {
    * that overflow. Specifically, test a corner case. A batch ends right
    * at file EOF, but that last batch overflowed.
    */
-
   @Test
   public void testMultipleReadersWithOverflow() {
     runOverflowTest(false);
@@ -191,5 +189,4 @@ public class TestScanOperExecOverflow extends BaseScanOperatorExecTest {
     assertEquals(0, scan.batchAccessor().rowCount());
     scanFixture.close();
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanLimit.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.protocol.BatchAccessor;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.junit.Test;
+
+/**
+ * Verifies that the V2 scan framework properly pushes the LIMIT
+ * into the scan by stopping the scan once any reader produces
+ * the rows up to the limit. Verifies that the result set loader
+ * enforces the limit at the batch level, that the reader lifecycle
+ * enforces limits at the reader level, and that the scan framework
+ * enforces limits at by skipping over unneeded readers.
+ * <p>
+ * This test is from the outside: at the scan operator level.
+ */
+public class TestScanLimit extends BaseScanTest {
+
+  /**
+   * Mock reader that returns two 50-row batches.
+   */
+  protected static class Mock50RowReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+
+    public Mock50RowReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .build());
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 1) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      int base = tableLoader.batchCount() * 50 + 1;
+      for (int i = 0; i < 50; i++) {
+        if (rowSet.isFull()) {
+          break;
+        }
+        rowSet.addSingleCol(base + i);
+      }
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  private static class TestFixture {
+    ObservableCreator creator1;
+    ObservableCreator creator2;
+    ScanFixture scanFixture;
+    ScanOperatorExec scan;
+
+    public TestFixture(long limit) {
+      creator1 = new ObservableCreator() {
+        @Override
+        public ManagedReader create(SchemaNegotiator negotiator) {
+          return new Mock50RowReader(negotiator);
+        }
+      };
+      creator2 = new ObservableCreator() {
+        @Override
+        public ManagedReader create(SchemaNegotiator negotiator) {
+          return new Mock50RowReader(negotiator);
+        }
+      };
+      BaseScanFixtureBuilder builder = simpleBuilder(creator1, creator2);
+      builder.builder.limit(limit);
+      scanFixture = builder.build();
+      scan = scanFixture.scanOp;
+    }
+
+    public void close() { scanFixture.close(); }
+
+    public int createCount() {
+      if (creator1.reader == null) {
+        return 0;
+      }
+      if (creator2.reader == null) {
+        return 1;
+      }
+      return 2;
+    }
+  }
+
+  /**
+   * LIMIT 0, to obtain only the schema.
+   */
+  @Test
+  public void testLimit0() {
+    TestFixture fixture = new TestFixture(0);
+    ScanOperatorExec scan = fixture.scan;
+
+    assertTrue(scan.buildSchema());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(0, batch.rowCount());
+    assertEquals(1, batch.schema().getFieldCount());
+    batch.release();
+
+    // No second batch or second reader
+    assertFalse(scan.next());
+
+    fixture.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, fixture.createCount());
+  }
+
+  /**
+   * LIMIT 1, simplest case
+   */
+  @Test
+  public void testLimit1() {
+    TestFixture fixture = new TestFixture(1);
+    ScanOperatorExec scan = fixture.scan;
+
+    // Reader builds schema, and stops after one row, though the reader
+    // itself is happy to provide more.
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(1, batch.rowCount());
+    batch.release();
+
+    // No second batch or second reader
+    assertFalse(scan.next());
+
+    fixture.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, fixture.createCount());
+  }
+
+  /**
+   * LIMIT 50, same as batch size, to check boundary conditions.
+   */
+  @Test
+  public void testLimitOnBatchEnd() {
+    TestFixture fixture = new TestFixture(50);
+    ScanOperatorExec scan = fixture.scan;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    // No second batch or second reader
+    assertFalse(scan.next());
+
+    fixture.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, fixture.createCount());
+  }
+
+  /**
+   * LIMIT 75, halfway through second batch.
+   */
+  @Test
+  public void testLimitOnScondBatch() {
+    TestFixture fixture = new TestFixture(75);
+    ScanOperatorExec scan = fixture.scan;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(25, batch.rowCount());
+    batch.release();
+
+    // No second reader
+    assertFalse(scan.next());
+
+    fixture.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, fixture.createCount());
+  }
+
+  /**
+   * LIMIT 100, at EOF of the first reader.
+   */
+  @Test
+  public void testLimitOnEOF() {
+    TestFixture fixture = new TestFixture(100);
+    ScanOperatorExec scan = fixture.scan;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    // No second reader
+    assertFalse(scan.next());
+
+    fixture.close();
+    scan.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, fixture.createCount());
+  }
+
+  /**
+   * LIMIT 125: full first reader, limit on second
+   */
+  @Test
+  public void testLimitOnSecondReader() {
+    TestFixture fixture = new TestFixture(125);
+    ScanOperatorExec scan = fixture.scan;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    BatchAccessor batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(50, batch.rowCount());
+    batch.release();
+
+    // First batch, second reader
+    assertTrue(scan.next());
+    batch = scan.batchAccessor();
+    assertEquals(25, batch.rowCount());
+    batch.release();
+
+    // No second batch
+    assertFalse(scan.next());
+
+    fixture.close();
+
+    // Both readers were created.
+    assertEquals(2, fixture.createCount());
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanLimit.java
@@ -188,7 +188,7 @@ public class TestScanLimit extends BaseScanTest {
    * LIMIT 75, halfway through second batch.
    */
   @Test
-  public void testLimitOnScondBatch() {
+  public void testLimitOnSecondBatch() {
     TestFixture fixture = new TestFixture(75);
     ScanOperatorExec scan = fixture.scan;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/BaseTestScanLifecycle.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/BaseTestScanLifecycle.java
@@ -89,6 +89,8 @@ public class BaseTestScanLifecycle extends SubOperatorTest {
     public boolean hasNext() {
       return counter < 2;
     }
+
+    public int count() { return counter; }
   }
 
   public static final TupleMetadata SCHEMA = new SchemaBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleLimit.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.junit.Test;
+
+/**
+ * Verifies that the V2 scan framework properly pushes the LIMIT
+ * into the scan by stopping the scan once any reader produces
+ * the rows up to the limit. Verifies that the result set loader
+ * enforces the limit at the batch level, that the reader lifecycle
+ * enforces limits at the reader level, and that the scan framework
+ * enforces limits at by skipping over unneeded readers.
+ * <p>
+ * This test is at the level of the scan framework, stripping away
+ * the outer scan operator level.
+ */
+public class TestScanLifecycleLimit extends BaseTestScanLifecycle {
+
+  /**
+   * Mock reader that returns two 50-row batches.
+   */
+  protected static class Mock50RowReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+
+    public Mock50RowReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .build());
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 1) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      int base = tableLoader.batchCount() * 50 + 1;
+      for (int i = 0; i < 50; i++) {
+        if (rowSet.isFull()) {
+          break;
+        }
+        rowSet.addSingleCol(base + i);
+      }
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  private Pair<TwoReaderFactory, ScanLifecycle> setupScan(long limit) {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a"));
+    TwoReaderFactory factory = new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new Mock50RowReader(negotiator);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new Mock50RowReader(negotiator);
+      }
+    };
+    builder.readerFactory(factory);
+
+    builder.limit(limit);
+    return Pair.of(factory, buildScan(builder));
+  }
+
+  /**
+   * LIMIT 0, to obtain only the schema.
+   */
+  @Test
+  public void testLimit0() {
+    Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(0);
+    TwoReaderFactory factory = pair.getLeft();
+    ScanLifecycle scan = pair.getRight();
+
+    // Reader builds schema, but returns no data, though the reader
+    // itself is happy to provide data.
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet result = fixture.wrap(reader.output());
+    assertEquals(0, result.rowCount());
+    assertEquals(1, result.schema().size());
+    result.clear();
+
+    // No second batch
+    assertFalse(reader.next());
+    reader.close();
+
+    // No next reader, despite there being two, since we hit the limit.
+    assertNull(scan.nextReader());
+
+    scan.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, factory.count());
+  }
+
+  /**
+   * LIMIT 1, simplest case
+   */
+  @Test
+  public void testLimit1() {
+    Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(1);
+    TwoReaderFactory factory = pair.getLeft();
+    ScanLifecycle scan = pair.getRight();
+
+    // Reader builds schema, and stops after one row, though the reader
+    // itself is happy to provide more.
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet result = fixture.wrap(reader.output());
+    assertEquals(1, result.rowCount());
+    assertEquals(1, result.schema().size());
+    result.clear();
+
+    // No second batch
+    assertFalse(reader.next());
+    reader.close();
+
+    // No next reader, despite there being two, since we hit the limit.
+    assertNull(scan.nextReader());
+
+    scan.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, factory.count());
+  }
+
+  /**
+   * LIMIT 50, same as batch size, to check boundary conditions.
+   */
+  @Test
+  public void testLimitOnBatchEnd() {
+    Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(50);
+    TwoReaderFactory factory = pair.getLeft();
+    ScanLifecycle scan = pair.getRight();
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet result = fixture.wrap(reader.output());
+    assertEquals(50, result.rowCount());
+    result.clear();
+
+    // No second batch
+    assertFalse(reader.next());
+    reader.close();
+
+    // No next reader, despite there being two, since we hit the limit.
+    assertNull(scan.nextReader());
+
+    scan.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, factory.count());
+  }
+
+  /**
+   * LIMIT 75, halfway through second batch.
+   */
+  @Test
+  public void testLimitOnScondBatch() {
+    Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(75);
+    TwoReaderFactory factory = pair.getLeft();
+    ScanLifecycle scan = pair.getRight();
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // First batch
+    assertTrue(reader.next());
+    RowSet result = fixture.wrap(reader.output());
+    assertEquals(50, result.rowCount());
+    result.clear();
+
+    // Second batch
+    assertTrue(reader.next());
+    result = fixture.wrap(reader.output());
+    assertEquals(25, result.rowCount());
+    result.clear();
+
+    // No third batch
+    assertFalse(reader.next());
+    reader.close();
+
+    // No next reader, despite there being two, since we hit the limit.
+    assertNull(scan.nextReader());
+
+    scan.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, factory.count());
+  }
+
+  /**
+   * LIMIT 100, at EOF of the first reader.
+   */
+  @Test
+  public void testLimitOnEOF() {
+    Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(100);
+    TwoReaderFactory factory = pair.getLeft();
+    ScanLifecycle scan = pair.getRight();
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // First batch
+    assertTrue(reader.next());
+    RowSet result = fixture.wrap(reader.output());
+    assertEquals(50, result.rowCount());
+    result.clear();
+
+    // Second batch
+    assertTrue(reader.next());
+    result = fixture.wrap(reader.output());
+    assertEquals(50, result.rowCount());
+    result.clear();
+
+    // No third batch
+    assertFalse(reader.next());
+    reader.close();
+
+    // No next reader, despite there being two, since we hit the limit.
+    assertNull(scan.nextReader());
+
+    scan.close();
+
+    // Only the first of the two readers were created.
+    assertEquals(1, factory.count());
+  }
+
+  /**
+   * LIMIT 125: full first reader, limit on second
+   */
+  @Test
+  public void testLimitOnSecondReader() {
+    Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(125);
+    TwoReaderFactory factory = pair.getLeft();
+    ScanLifecycle scan = pair.getRight();
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // First batch
+    assertTrue(reader.next());
+    RowSet result = fixture.wrap(reader.output());
+    assertEquals(50, result.rowCount());
+    result.clear();
+
+    // Second batch
+    assertTrue(reader.next());
+    result = fixture.wrap(reader.output());
+    assertEquals(50, result.rowCount());
+    result.clear();
+
+    // No third batch
+    assertFalse(reader.next());
+    reader.close();
+
+    // Move to second reader.
+    reader = scan.nextReader();
+    assertNotNull(reader);
+    assertTrue(reader.open());
+
+    // First is limited
+    assertTrue(reader.next());
+    result = fixture.wrap(reader.output());
+    assertEquals(25, result.rowCount());
+    result.clear();
+
+    // No second batch
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+
+    // Both readers were created.
+    assertEquals(2, factory.count());
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleLimit.java
@@ -200,7 +200,7 @@ public class TestScanLifecycleLimit extends BaseTestScanLifecycle {
    * LIMIT 75, halfway through second batch.
    */
   @Test
-  public void testLimitOnScondBatch() {
+  public void testLimitOnSecondBatch() {
     Pair<TwoReaderFactory, ScanLifecycle> pair = setupScan(75);
     TwoReaderFactory factory = pair.getLeft();
     ScanLifecycle scan = pair.getRight();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderProtocol.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderProtocol.java
@@ -77,7 +77,6 @@ import org.junit.experimental.categories.Category;
  * the structure. The object tree will show all the components and their
  * current state.
  */
-
 @Category(RowSetTests.class)
 public class TestResultSetLoaderProtocol extends SubOperatorTest {
 
@@ -317,7 +316,6 @@ public class TestResultSetLoaderProtocol extends SubOperatorTest {
    * additional information. The code here simply uses the <tt>MaterializedField</tt>
    * to create a <tt>ColumnMetadata</tt> implicitly.
    */
-
   @Test
   public void testCaseInsensitiveSchema() {
     ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
@@ -573,7 +571,6 @@ public class TestResultSetLoaderProtocol extends SubOperatorTest {
    * Also verifies the test-time method to set a row of values using
    * a single method.
    */
-
   @Test
   public void testInitialSchema() {
     TupleMetadata schema = new SchemaBuilder()
@@ -606,7 +603,7 @@ public class TestResultSetLoaderProtocol extends SubOperatorTest {
 
   /**
    * The writer protocol allows a client to write to a row any number of times
-   * before invoking <tt>save()</tt>. In this case, each new value simply
+   * before invoking {@code save()}. In this case, each new value simply
    * overwrites the previous value. Here, we test the most basic case: a simple,
    * flat tuple with no arrays. We use a very large Varchar that would, if
    * overwrite were not working, cause vector overflow.
@@ -628,7 +625,6 @@ public class TestResultSetLoaderProtocol extends SubOperatorTest {
    * Note that there is no explicit method to discard a row. Instead,
    * the rule is that a row is not saved until <tt>save()</tt> is called.
    */
-
   @Test
   public void testOverwriteRow() {
     TupleMetadata schema = new SchemaBuilder()
@@ -685,7 +681,6 @@ public class TestResultSetLoaderProtocol extends SubOperatorTest {
    * Test that memory is released if the loader is closed with an active
    * batch (that is, before the batch is harvested.)
    */
-
   @Test
   public void testCloseWithoutHarvest() {
     TupleMetadata schema = new SchemaBuilder()

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/WriterEvents.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/WriterEvents.java
@@ -39,7 +39,6 @@ import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
  * array. Instead, the order of calls, or selectively making or not making
  * calls, can change.
  */
-
 public interface WriterEvents extends WriterPosition {
 
   /**
@@ -47,7 +46,6 @@ public interface WriterEvents extends WriterPosition {
    * operations to newly-added columns to synchronize them with the rest
    * of the writers.
    */
-
   enum State {
 
     /**
@@ -57,20 +55,18 @@ public interface WriterEvents extends WriterPosition {
     IDLE,
 
     /**
-     * <tt>startWrite()</tt> has been called to start a write operation
-     * (start a batch), but <tt>startValue()</tt> has not yet been called
-     * to start a row (or value within an array). <tt>startWrite()</tt> must
+     * {@code startWrite()} has been called to start a write operation
+     * (start a batch), but {@code startValue()} has not yet been called
+     * to start a row (or value within an array). {@code startWrite()} must
      * be called on newly added columns.
      */
-
     IN_WRITE,
 
     /**
-     * Both <tt>startWrite()</tt> and <tt>startValue()</tt> has been called on
+     * Both {@code startWrite()} and {@code startValue()} has been called on
      * the tuple to prepare for writing values, and both must be called on
      * newly-added vectors.
      */
-
     IN_ROW
   }
 
@@ -80,7 +76,6 @@ public interface WriterEvents extends WriterPosition {
    * listener is bound, and a vector overflows, then an exception is
    * thrown.
    */
-
   interface ColumnWriterListener {
 
     /**
@@ -90,7 +85,6 @@ public interface WriterEvents extends WriterPosition {
      *
      * @param writer the writer that triggered the overflow
      */
-
     void overflowed(ScalarWriter writer);
 
     /**
@@ -102,9 +96,8 @@ public interface WriterEvents extends WriterPosition {
      * @param delta the amount by which the vector is to grow
      * @return true if the vector can be grown, false if the writer
      * should instead trigger an overflow by calling
-     * <tt>overflowed()</tt>
+     * {@code overflowed()}
      */
-
     boolean canExpand(ScalarWriter writer, int delta);
   }
 
@@ -114,7 +107,6 @@ public interface WriterEvents extends WriterPosition {
    * @param index the writer index (top level or nested for
    * arrays)
    */
-
   void bindIndex(ColumnWriterIndex index);
 
   /**
@@ -127,21 +119,18 @@ public interface WriterEvents extends WriterPosition {
    * @param listener
    *          the vector event listener to bind
    */
-
   void bindListener(ColumnWriterListener listener);
 
   /**
    * Start a write (batch) operation. Performs any vector initialization
    * required at the start of a batch (especially for offset vectors.)
    */
-
   void startWrite();
 
   /**
    * Start a new row. To be called only when a row is not active. To
    * restart a row, call {@link #restartRow()} instead.
    */
-
   void startRow();
 
   /**
@@ -152,7 +141,6 @@ public interface WriterEvents extends WriterPosition {
    * offset vector based on the cumulative value saves is done when
    * saving the row.
    */
-
   void endArrayValue();
 
   /**
@@ -161,27 +149,23 @@ public interface WriterEvents extends WriterPosition {
    * Done when abandoning the current row, such as when filtering out
    * a row at read time.
    */
-
   void restartRow();
 
   /**
    * Saves a row. Commits offset vector locations and advances each to
    * the next position. Can be called only when a row is active.
    */
-
   void saveRow();
 
   /**
    * End a batch: finalize any vector values.
    */
-
   void endWrite();
 
   /**
    * The vectors backing this vector are about to roll over. Finish
    * the current batch up to, but not including, the current row.
    */
-
   void preRollover();
 
   /**
@@ -191,7 +175,6 @@ public interface WriterEvents extends WriterPosition {
    * for the current row now resides at the start of a new vector instead
    * of its previous location elsewhere in an old vector.
    */
-
   void postRollover();
 
   abstract void dump(HierarchicalFormatter format);


### PR DESCRIPTION
# [DRILL-8115](https://issues.apache.org/jira/browse/DRILL-8115): Adds LIMIT pushdown support in the scan framework

## Description

Subset of the [DRILL-8085 PR](https://github.com/apache/drill/pull/2419) which includes only the LIMIT pushdown support in EVF, but no integration of that support with any reader.

Modifies EVF and the scan framework to enforce LIMIT pushdown across readers. Adds tests to demonstrate that the limit is applied correctly.

## Documentation

N/A

## Testing

Added unit tests. Ran Github-based tests since the Drill tests no longer run on my machine, and I can't change my machine's time zone to UTC so that the will run.