### PR TITLE
DRILL-8118: Add Option to Allow Disk Use on Mongo Queries

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -199,7 +199,7 @@ public class MongoRecordReader extends AbstractRecordReader {
           operations.add(Aggregates.project(fields));
         }
         if (plugin.getConfig().allowDiskUse()) {
-          projection  = collection.aggregate(operations).allowDiskUse(true);
+          projection = collection.aggregate(operations).allowDiskUse(true);
         } else {
           projection = collection.aggregate(operations);
         }

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -198,7 +198,11 @@ public class MongoRecordReader extends AbstractRecordReader {
         if (!fields.isEmpty()) {
           operations.add(Aggregates.project(fields));
         }
-        projection = collection.aggregate(operations);
+        if (plugin.getConfig().allowDiskUse()) {
+          projection  = collection.aggregate(operations).allowDiskUse(true);
+        } else {
+          projection = collection.aggregate(operations);
+        }
       } else {
         projection = collection.find(filters).projection(fields);
       }

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
@@ -40,6 +40,8 @@ public class MongoStoragePluginConfig extends AbstractSecuredStoragePluginConfig
 
   private final String connection;
 
+  private final boolean allowDiskUse;
+
   @JsonIgnore
   private final ConnectionString clientURI;
 
@@ -51,12 +53,14 @@ public class MongoStoragePluginConfig extends AbstractSecuredStoragePluginConfig
   public MongoStoragePluginConfig(@JsonProperty("connection") String connection,
     @JsonProperty("pluginOptimizations") MongoPluginOptimizations pluginOptimizations,
     @JsonProperty("batchSize") Integer batchSize,
+    @JsonProperty("allowDiskUse") Boolean allowDiskUse,
     @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider) {
     super(getCredentialsProvider(credentialsProvider), credentialsProvider == null);
     this.connection = connection;
     this.clientURI = new ConnectionString(connection);
     this.pluginOptimizations = ObjectUtils.defaultIfNull(pluginOptimizations, new MongoPluginOptimizations());
     this.batchSize = batchSize != null ? batchSize : 100;
+    this.allowDiskUse = allowDiskUse != null && allowDiskUse;
   }
 
   public MongoPluginOptimizations getPluginOptimizations() {
@@ -74,6 +78,10 @@ public class MongoStoragePluginConfig extends AbstractSecuredStoragePluginConfig
 
   public int getBatchSize() {
     return batchSize;
+  }
+
+  public boolean allowDiskUse() {
+    return allowDiskUse;
   }
 
   private static CredentialsProvider getCredentialsProvider(CredentialsProvider credentialsProvider) {

--- a/contrib/storage-mongo/src/main/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-mongo/src/main/resources/bootstrap-storage-plugins.json
@@ -3,6 +3,7 @@
     "mongo" : {
       "type":"mongo",
       "connection":"mongodb://localhost:27017/",
+      "allowDiskUse": false,
       "enabled": false
     }
   }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestBase.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestBase.java
@@ -39,7 +39,7 @@ public class MongoTestBase extends ClusterTest implements MongoTestConstants {
 
   private static void initMongoStoragePlugin(String connectionURI) throws Exception {
     MongoStoragePluginConfig storagePluginConfig = new MongoStoragePluginConfig(connectionURI,
-        null, 100, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
+        null, 100, false, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     storagePluginConfig.setEnabled(true);
     pluginRegistry.put(MongoStoragePluginConfig.NAME, storagePluginConfig);
 

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoStoragePluginUsesCredentialsStore.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoStoragePluginUsesCredentialsStore.java
@@ -35,7 +35,7 @@ public class TestMongoStoragePluginUsesCredentialsStore extends BaseTest {
 
   private void test(String expectedUserName, String expectedPassword, String connection, String name) throws ExecutionSetupException {
     MongoStoragePlugin plugin = new MongoStoragePlugin(
-        new MongoStoragePluginConfig(connection, null, 100, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER),
+        new MongoStoragePluginConfig(connection, null, 100, false, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER),
         null, name);
     MongoClientImpl client = (MongoClientImpl) plugin.getClient();
     MongoCredential cred = client.getSettings().getCredential();


### PR DESCRIPTION
# [DRILL-8118](https://issues.apache.org/jira/browse/DRILL-8118): Add Option to Allow Disk Use on Mongo Queries

## Description
MongoDB has a strange feature  whereby queries which use more than 100MB of memory will by default fail.  Mongo allows the user to specify whether they want the query to spill to disk which allows larger queries but at a performance cost.
This minor PR adds the ability for a user to specify whether they want this option included in Mongo queries.  This only affects aggregate queries in Mongo. 

## Documentation
This adds a new config option to the mongo config: `allowDiskUse` which, when set to `true`, will pass that parameter down to MongoDB during aggregate queries.  

## Testing
Ran unit tests