### PR TITLE
DRILL-8116: Upgrade Apache Xerces because of CVE-2022-23437

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <commons.codec.version>1.14</commons.codec.version>
     <metadata.extractor.version>2.13.0</metadata.extractor.version>
     <xalan.version>2.7.2</xalan.version>
-    <xerces.version>2.12.0</xerces.version>
+    <xerces.version>2.12.2</xerces.version>
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <httpdlog-parser.version>5.7</httpdlog-parser.version>


### PR DESCRIPTION
# [DRILL-8116](https://issues.apache.org/jira/browse/DRILL-8116): Upgrade Apache Xerces because of CVE-2022-23437

## Description

Upgrade Apache Xerces because of CVE-2022-23437

## Documentation

please refer to https://github.com/advisories/GHSA-h65f-jvqw-m9fj

## Testing

Check dependency by "mvn dependency:tree" and all dependencies which related to Xerces have been upgraded to 2.12.2
