### PR TITLE
DRILL-8118: Add Option to Allow Disk Use on Mongo Queries

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
@@ -53,14 +53,14 @@ public class MongoStoragePluginConfig extends AbstractSecuredStoragePluginConfig
   public MongoStoragePluginConfig(@JsonProperty("connection") String connection,
     @JsonProperty("pluginOptimizations") MongoPluginOptimizations pluginOptimizations,
     @JsonProperty("batchSize") Integer batchSize,
-    @JsonProperty("allowDiskUse") Boolean allowDiskUse,
+    @JsonProperty("allowDiskUse") boolean allowDiskUse,
     @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider) {
     super(getCredentialsProvider(credentialsProvider), credentialsProvider == null);
     this.connection = connection;
     this.clientURI = new ConnectionString(connection);
     this.pluginOptimizations = ObjectUtils.defaultIfNull(pluginOptimizations, new MongoPluginOptimizations());
     this.batchSize = batchSize != null ? batchSize : 100;
-    this.allowDiskUse = allowDiskUse != null && allowDiskUse;
+    this.allowDiskUse = allowDiskUse;
   }
 
   public MongoPluginOptimizations getPluginOptimizations() {
@@ -80,6 +80,7 @@ public class MongoStoragePluginConfig extends AbstractSecuredStoragePluginConfig
     return batchSize;
   }
 
+  @JsonProperty("allowDiskUse")
   public boolean allowDiskUse() {
     return allowDiskUse;
   }


### PR DESCRIPTION
# [DRILL-8118](https://issues.apache.org/jira/browse/DRILL-8118): Add Option to Allow Disk Use on Mongo Queries

## Description
See previous PR, but this PR fixes a small bug and allows the user's config to be preserved.

## Documentation
N/A

## Testing
Manual testing.