### PR TITLE
DRILL-7994: Dependency version updates for severe vulnerabilities

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -34,7 +34,7 @@
     <mysql.connector.version>8.0.25</mysql.connector.version>
     <clickhouse.jdbc.version>0.3.1</clickhouse.jdbc.version>
     <h2.version>2.1.210</h2.version>
-    <postgresql.version>42.3.1</postgresql.version>
+    <postgresql.version>42.3.2</postgresql.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# [DRILL-7994](https://issues.apache.org/jira/browse/DRILL-7994): Dependency version updates for severe vulnerabilities

## Description

Postgresql: 42.3.1 -> 42.3.2

## Documentation
N/A

## Testing
Existing unit tests.
