### PR TITLE
DRILL-8123: Revise scan limit pushdown

### DIFF
--- a/contrib/format-excel/src/test/java/org/apache/drill/exec/store/excel/TestExcelFormat.java
+++ b/contrib/format-excel/src/test/java/org/apache/drill/exec/store/excel/TestExcelFormat.java
@@ -621,7 +621,7 @@ public class TestExcelFormat extends ClusterTest {
     queryBuilder()
       .sql(sql)
       .planMatcher()
-      .include("Limit", "maxRecords=5")
+      .include("Limit", "limit=5")
       .match();
   }
 

--- a/contrib/format-httpd/src/test/java/org/apache/drill/exec/store/httpd/TestHTTPDLogReader.java
+++ b/contrib/format-httpd/src/test/java/org/apache/drill/exec/store/httpd/TestHTTPDLogReader.java
@@ -131,7 +131,6 @@ public class TestHTTPDLogReader extends ClusterTest {
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
 
-
   @Test
   public void testLimitPushdown() throws Exception {
     String sql = "SELECT * FROM cp.`httpd/hackers-access-small.httpd` LIMIT 5";
@@ -139,7 +138,7 @@ public class TestHTTPDLogReader extends ClusterTest {
     queryBuilder()
       .sql(sql)
       .planMatcher()
-      .include("Limit", "maxRecords=5")
+      .include("Limit", "limit=5")
       .match();
   }
 
@@ -242,7 +241,6 @@ public class TestHTTPDLogReader extends ClusterTest {
 
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
-
 
   @Test
   public void testExplicitSomeQueryWithCompressedFile() throws Exception {

--- a/contrib/format-sas/src/test/java/org/apache/drill/exec/store/sas/TestSasReader.java
+++ b/contrib/format-sas/src/test/java/org/apache/drill/exec/store/sas/TestSasReader.java
@@ -191,7 +191,7 @@ public class TestSasReader extends ClusterTest {
     queryBuilder()
       .sql(sql)
       .planMatcher()
-      .include("Limit", "maxRecords=5")
+      .include("Limit", "limit=5")
       .match();
   }
 }

--- a/contrib/format-syslog/src/test/java/org/apache/drill/exec/store/syslog/TestSyslogFormat.java
+++ b/contrib/format-syslog/src/test/java/org/apache/drill/exec/store/syslog/TestSyslogFormat.java
@@ -341,7 +341,7 @@ public class TestSyslogFormat extends ClusterTest {
     queryBuilder()
       .sql(sql)
       .planMatcher()
-      .include("Limit", "maxRecords=5")
+      .include("Limit", "limit=5")
       .match();
   }
 

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -121,7 +121,7 @@ public class TestXMLReader extends ClusterTest {
         .build();
 
     RowSet expected = client.rowSetBuilder(expectedSchema)
-      .addRow((Object)strArray("Seattle, WA", "Seattle WA", "", "", "2011-09-29", "2011-09-29 17:53:00 +0000", "US", "Clear", "62", "17", "Humidity: 62%", "/ig/images/weather" +
+      .addRow(strArray("Seattle, WA", "Seattle WA", "", "", "2011-09-29", "2011-09-29 17:53:00 +0000", "US", "Clear", "62", "17", "Humidity: 62%", "/ig/images/weather" +
         "/sunny.gif", "Wind: N at 4 mph"), null, null, null, null, null, null, null, null, null, null, null, null, null)
       .build();
 
@@ -540,7 +540,7 @@ public class TestXMLReader extends ClusterTest {
     queryBuilder()
       .sql(sql)
       .planMatcher()
-      .include("Limit", "maxRecords=2")
+      .include("Limit", "limit=2")
       .match();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractBase.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 public abstract class AbstractBase implements PhysicalOperator {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractBase.class);
 
   public static long INIT_ALLOCATION = 1_000_000L;
   public static long MAX_ALLOCATION = 10_000_000_000L;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
@@ -345,8 +345,8 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
 
     final double estimatedRowSize = settings.getOptions().getOption(ExecConstants.TEXT_ESTIMATED_ROW_SIZE);
 
-    if (scan.supportsLimitPushdown() && scan.getMaxRecords() > 0) {
-      return new ScanStats(GroupScanProperty.EXACT_ROW_COUNT, (long)scan.getMaxRecords(), 1, data);
+    if (scan.supportsLimitPushdown() && scan.getLimit() > 0) {
+      return new ScanStats(GroupScanProperty.EXACT_ROW_COUNT, (long)scan.getLimit(), 1, data);
     } else {
       final double estRowCount = data / estimatedRowSize;
       return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, (long) estRowCount, 1, data);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/AbstractParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/AbstractParquetGroupScan.java
@@ -538,7 +538,7 @@ public abstract class AbstractParquetGroupScan extends AbstractGroupScanWithMeta
       newScan.rowGroups = rowGroups;
       newScan.matchAllMetadata = matchAllMetadata;
       newScan.nonInterestingColumnsMetadata = nonInterestingColumnsMetadata;
-      newScan.maxRecords = maxRecords;
+      newScan.limit = limit;
       // since builder is used when pruning happens, entries and fileSet should be expanded
       if (!newScan.getFilesMetadata().isEmpty()) {
         newScan.entries = newScan.getFilesMetadata().keySet().stream()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetWriterBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetWriterBatchCreator.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.physical.impl.WriterRecordBatch;
 import org.apache.drill.exec.record.RecordBatch;
 
 public class ParquetWriterBatchCreator implements BatchCreator<ParquetWriter>{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ParquetWriterBatchCreator.class);
 
   @Override
   public WriterRecordBatch getBatch(ExecutorFragmentContext context, ParquetWriter config, List<RecordBatch> children)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/metastore/TestMetastoreWithEasyFormatPlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/metastore/TestMetastoreWithEasyFormatPlugin.java
@@ -1079,14 +1079,14 @@ public class TestMetastoreWithEasyFormatPlugin extends ClusterTest {
       queryBuilder()
           .sql("select * from dfs.tmp.`%s` limit 1", tableName)
           .planMatcher()
-          .include("Limit", "numFiles=1", "maxRecords=1")
+          .include("Limit", "numFiles=1", "limit=1")
           .match();
 
       // each file has 10 records, so 3 files should be picked
       queryBuilder()
           .sql("select * from dfs.tmp.`%s` limit 21", tableName)
           .planMatcher()
-          .include("Limit", "numFiles=3", "maxRecords=21")
+          .include("Limit", "numFiles=3", "limit=21")
           .match();
     } finally {
       run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);


### PR DESCRIPTION
# [DRILL-8123](https://issues.apache.org/jira/browse/DRILL-8123): Revise scan limit pushdown

## Description

Recent work added a push down of the limit into a scan. The work had a few holes, one of which was plugged by the recent update of EVF to manage the limit. Another hole is that the physical plan uses a value of 0 to indicate no limit, but 0 is a perfectly valid limit, it means "no data, only schema." The field name is "maxRecords", but should be "limit" to indicate the purpose.

## Documentation

N/A

## Testing

Reran unit tests.
