### PR TITLE
DRILL-8126: Ignore OAuth Parameter in Storage Plugin

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.server.rest;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.logical.AbstractSecuredStoragePluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -63,6 +64,7 @@ public class PluginConfigWrapper {
    * 3. The credentialsProvider must contain a client_id and client_secret
    * @return true if the plugin uses OAuth, false if not.
    */
+  @JsonIgnore
   public boolean isOauth() {
     if (! (config instanceof AbstractSecuredStoragePluginConfig)) {
       return false;


### PR DESCRIPTION
# [DRILL-8126](https://issues.apache.org/jira/browse/DRILL-8126): Ignore OAuth Parameter in Storage Plugin

## Description
This PR fixes a minor bug with the storage plugin configuration by marking the `oauth` parameter as ignorable. This parameter is actually derived by the config and used to hide the `authorize` button when not needed.

## Documentation
No user facing changes

## Testing
Ran unit tests & manually tested