### PR TITLE
DRILL-8127: add iceberg format to bootstrap-storage-plugins.json

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -652,6 +652,12 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.drill.contrib</groupId>
+      <artifactId>drill-iceberg-format</artifactId>
+      <version>1.20.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/exec/java-exec/src/main/resources/bootstrap-storage-plugins.json
+++ b/exec/java-exec/src/main/resources/bootstrap-storage-plugins.json
@@ -16,6 +16,9 @@
         }
       },
       "formats" : {
+        "iceberg" : {
+          "type": "iceberg"
+        },
         "psv" : {
           "type" : "text",
           "extensions" : [ "tbl" ],
@@ -73,6 +76,9 @@
         }
       },
       "formats" : {
+        "iceberg" : {
+          "type": "iceberg"
+        },
         "psv" : {
           "type" : "text",
           "extensions" : [ "tbl" ],

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.exec.store.iceberg.format.IcebergFormatPluginConfig;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -103,6 +104,9 @@ public class StoragePluginTestUtils {
 
     newFormats.put("psv", new TextFormatConfig(
         ImmutableList.of("tbl"), null, "|", null, null, null, null, null));
+
+    IcebergFormatPluginConfig.IcebergFormatPluginConfigBuilder icebergFormatPluginConfigBuilder = new IcebergFormatPluginConfig.IcebergFormatPluginConfigBuilder();
+    newFormats.put("iceberg", icebergFormatPluginConfigBuilder.build());
 
     SequenceFileFormatConfig seqConfig = new SequenceFileFormatConfig(ImmutableList.of("seq"));
     newFormats.put("sequencefile", seqConfig);


### PR DESCRIPTION
# [DRILL-8127](https://issues.apache.org/jira/browse/DRILL-8127): add iceberg format to bootstrap-storage-plugins.json

## Description

/exec/java-exec/src/main/resources/bootstrap-storage-plugins.json is missing the iceberg format.

To query iceberg users have to add it herself.

We could add

```
  "formats": {
    "iceberg": {
      "type": "iceberg"
    },
```


To all file storage plugins, so that users cann query iceberg tables directly.

## Documentation

no need for documenting this, user can use icebert tables out of the box.

## Testing

1. activate iceberg metastore
2. populate metastore via `analyze table dfs.xxx.xxx refresh metadata`
3. query the metastore directly via `select * from dfs./user/drill/metastore/tables/`
