### PR TITLE
DRILL-8129: Storage-phoenix cannot resolve OSGi bundle apache-ds.jdbm1

### DIFF
--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -266,6 +266,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -325,6 +329,12 @@
           </excludes>
           <argLine>-Xms2048m -Xmx2048m</argLine>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.4</version>
+        <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -330,12 +330,21 @@
           <argLine>-Xms2048m -Xmx2048m</argLine>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.4</version>
-        <extensions>true</extensions>
-      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>hadoop-2</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>5.1.4</version>
+            <extensions>true</extensions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -33,7 +33,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>49300000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>49400000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>
@@ -886,7 +886,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>47700000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>50300000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
# [DRILL-8129](https://issues.apache.org/jira/browse/DRILL-8129): Storage-phoenix cannot resolve OSGi bundle apache-ds.jdbm1

## Description

Because this dependency is of type "bundle", the module requires the maven-bundle-plugin in order to resolve it, and for the module to build.  This dependency only arises under the Hadoop 2 profile, or when building with `-Phadoop-2`.

## Documentation
N/A

## Testing
Build Drill under the default profile and under -Phadoop-2
