### PR TITLE
DRILL-8130: Upgrade Hadoop 2 to 2.10.1 because of CVE-2020-9492

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -886,7 +886,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>50300000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>50400000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -4035,7 +4035,7 @@
         </property>
       </activation>
       <properties>
-        <hadoop.version>2.9.2</hadoop.version>
+        <hadoop.version>2.10.1</hadoop.version>
       </properties>
       <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# [DRILL-8130](https://issues.apache.org/jira/browse/DRILL-8130): Upgrade Hadoop 2 to 2.10.1 because of CVE-2020-9492.

## Description

In Apache Hadoop 3.2.0 to 3.2.1, 3.0.0-alpha1 to 3.1.3, and 2.0.0-alpha to 2.10.0, WebHDFS client might send SPNEGO authorization header to remote URL without proper verification.

## Documentation
N/A

## Testing
Existing unit tests.
