### PR TITLE
DRILL-8131: Infinite planning when JDBC or Phoenix plugin is enabled

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -68,6 +68,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.drill.contrib.data</groupId>
+      <artifactId>tpch-sample-data</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>${mysql.connector.version}</version>

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/DrillJdbcConvention.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/DrillJdbcConvention.java
@@ -36,7 +36,6 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.drill.exec.planner.RuleInstance;
 import org.apache.drill.exec.planner.logical.DrillRel;
 import org.apache.drill.exec.planner.logical.DrillRelFactories;
-import org.apache.drill.exec.planner.physical.Prel;
 import org.apache.drill.exec.store.enumerable.plan.DrillJdbcRuleBase;
 import org.apache.drill.exec.store.enumerable.plan.VertexDrelConverterRule;
 import org.apache.drill.exec.store.jdbc.rules.JdbcLimitRule;
@@ -66,8 +65,7 @@ public class DrillJdbcConvention extends JdbcConvention {
 
     List<RelTrait> inputTraits = Arrays.asList(
       Convention.NONE,
-      DrillRel.DRILL_LOGICAL,
-      Prel.DRILL_PHYSICAL);
+      DrillRel.DRILL_LOGICAL);
 
     ImmutableSet.Builder<RelOptRule> builder = ImmutableSet.<RelOptRule>builder()
       .addAll(calciteJdbcRules)

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
@@ -395,4 +395,16 @@ public class TestJdbcPluginWithMySQLIT extends ClusterTest {
         .exclude("Limit\\(")
         .match();
   }
+
+  @Test // DRILL-8131
+  public void testParquetLimitWithSort() throws Exception {
+    queryBuilder()
+      .sql("SELECT n_name\n" +
+        "FROM cp.`/tpch/nation.parquet`\n" +
+        "ORDER BY n_name DESC\n" +
+        "LIMIT 1")
+      .planMatcher()
+      .include("Limit\\(")
+      .match();
+  }
 }

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixConvention.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/rules/PhoenixConvention.java
@@ -38,7 +38,6 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.drill.exec.planner.RuleInstance;
 import org.apache.drill.exec.planner.logical.DrillRel;
 import org.apache.drill.exec.planner.logical.DrillRelFactories;
-import org.apache.drill.exec.planner.physical.Prel;
 import org.apache.drill.exec.store.enumerable.plan.DrillJdbcRuleBase;
 import org.apache.drill.exec.store.enumerable.plan.VertexDrelConverterRule;
 import org.apache.drill.exec.store.phoenix.PhoenixStoragePlugin;
@@ -66,8 +65,7 @@ public class PhoenixConvention extends JdbcConvention {
 
     List<RelTrait> inputTraits = Arrays.asList(
       Convention.NONE,
-      DrillRel.DRILL_LOGICAL,
-      Prel.DRILL_PHYSICAL);
+      DrillRel.DRILL_LOGICAL);
 
     ImmutableSet.Builder<RelOptRule> builder = ImmutableSet.<RelOptRule>builder()
       .addAll(calciteJdbcRules)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillLimitRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillLimitRelBase.java
@@ -31,17 +31,19 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 
+import java.util.List;
+
 /**
  * Base class for logical and physical Limits implemented in Drill
  */
 public abstract class DrillLimitRelBase extends SingleRel implements DrillRelNode {
   protected RexNode offset;
   protected RexNode fetch;
-  private boolean pushDown;  // whether limit has been pushed past its child.
-                             // Limit is special in that when it's pushed down, the original LIMIT still remains.
-                             // Once the limit is pushed down, this flag will be TRUE for the original LIMIT
-                             // and be FALSE for the pushed down LIMIT.
-                             // This flag will prevent optimization rules to fire in a loop.
+  private final boolean pushDown;  // whether limit has been pushed past its child.
+                                   // Limit is special in that when it's pushed down, the original LIMIT still remains.
+                                   // Once the limit is pushed down, this flag will be TRUE for the original LIMIT
+                                   // and be FALSE for the pushed down LIMIT.
+                                   // This flag will prevent optimization rules to fire in a loop.
 
   public DrillLimitRelBase(RelOptCluster cluster, RelTraitSet traitSet, RelNode child, RexNode offset, RexNode fetch) {
     this(cluster, traitSet, child, offset, fetch, false);
@@ -53,6 +55,8 @@ public abstract class DrillLimitRelBase extends SingleRel implements DrillRelNod
     this.fetch = fetch;
     this.pushDown = pushDown;
   }
+
+  public abstract RelNode copy(RelTraitSet traitSet, List<RelNode> inputs, boolean pushDown);
 
   public RexNode getOffset() {
     return this.offset;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillLimitRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillLimitRel.java
@@ -48,6 +48,11 @@ public class DrillLimitRel extends DrillLimitRelBase implements DrillRel {
   }
 
   @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs, boolean pushDown) {
+    return new DrillLimitRel(getCluster(), traitSet, sole(inputs), offset, fetch, pushDown);
+  }
+
+  @Override
   public LogicalOperator implement(DrillImplementor implementor) {
     LogicalOperator inputOp = implementor.visitChild(this, 0, getInput());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/LimitPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/LimitPrel.java
@@ -57,6 +57,11 @@ public class LimitPrel extends DrillLimitRelBase implements Prel {
   }
 
   @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs, boolean pushDown) {
+    return new LimitPrel(getCluster(), traitSet, sole(inputs), offset, fetch, pushDown, isPartitioned);
+  }
+
+  @Override
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
     Prel child = (Prel) this.getInput();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
@@ -146,6 +146,12 @@ public abstract class DrillJdbcRuleBase extends ConverterRule {
     }
 
     @Override
+    public boolean matches(RelOptRuleCall call) {
+      DrillLimitRelBase limit = call.rel(0);
+      return !limit.isPushDown() && super.matches(call);
+    }
+
+    @Override
     public RelNode convert(RelNode rel) {
       DrillLimitRelBase limit = (DrillLimitRelBase) rel;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rel/PluginLimitRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rel/PluginLimitRel.java
@@ -36,8 +36,8 @@ import java.util.List;
 public class PluginLimitRel extends DrillLimitRelBase implements PluginRel {
 
   public PluginLimitRel(RelOptCluster cluster, RelTraitSet traitSet,
-      RelNode child, RexNode offset, RexNode fetch) {
-    super(cluster, traitSet, child, offset, fetch);
+      RelNode child, RexNode offset, RexNode fetch, boolean pushDown) {
+    super(cluster, traitSet, child, offset, fetch, pushDown);
     assert getConvention() == child.getConvention();
   }
 
@@ -48,7 +48,12 @@ public class PluginLimitRel extends DrillLimitRelBase implements PluginRel {
 
   @Override
   public PluginLimitRel copy(RelTraitSet traitSet, List<RelNode> inputs) {
-    return new PluginLimitRel(getCluster(), traitSet, inputs.get(0), offset, fetch);
+    return new PluginLimitRel(getCluster(), traitSet, inputs.get(0), offset, fetch, isPushDown());
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs, boolean pushDown) {
+    return new PluginLimitRel(getCluster(), traitSet, inputs.get(0), offset, fetch, pushDown);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginLimitRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginLimitRule.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.plan.rule;
 
 import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.rel.RelNode;
 import org.apache.drill.exec.planner.common.DrillLimitRelBase;
@@ -30,6 +31,12 @@ public class PluginLimitRule extends PluginConverterRule {
 
   public PluginLimitRule(RelTrait in, Convention out, PluginImplementor pluginImplementor) {
     super(DrillLimitRelBase.class, in, out, "PluginLimitRule", pluginImplementor);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    DrillLimitRelBase limit = call.rel(0);
+    return !limit.isPushDown() && super.matches(call);
   }
 
   @Override
@@ -52,6 +59,7 @@ public class PluginLimitRule extends PluginConverterRule {
         limit.getTraitSet().replace(getOutConvention()),
         input,
         limit.getOffset(),
-        limit.getFetch());
+        limit.getFetch(),
+        true);
   }
 }


### PR DESCRIPTION
# [DRILL-8131](https://issues.apache.org/jira/browse/DRILL-8131): Infinite planning when JDBC or Phoenix plugin is enabled

## Description
Prevented applying JDBC and Phoenix rules for DRILL_PHYSICAL rel nodes.
Updated JDBC limit rule to be applied only for limits that weren't pushed down, and split limit into several ones for the case of MSSql database instead of relying on splitting it later during physical optimizations.

## Documentation
NA

## Testing
Added unit test, checked more complex cases manually.
