### PR TITLE
DRILL-8134: Cannot query Parquet INT96 columns as timestamps

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -34,7 +34,7 @@
     <mysql.connector.version>8.0.25</mysql.connector.version>
     <clickhouse.jdbc.version>0.3.1</clickhouse.jdbc.version>
     <h2.version>2.1.210</h2.version>
-    <postgresql.version>42.3.2</postgresql.version>
+    <postgresql.version>42.3.3</postgresql.version>
   </properties>
 
   <dependencies>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/BatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/BatchReader.java
@@ -66,8 +66,8 @@ public abstract class BatchReader {
 
   protected void readAllFixedFieldsParallel(long recordsToRead) throws Exception {
     ArrayList<Future<Long>> futures = Lists.newArrayList();
-    for (ColumnReader<?> crs : readState.getFixedLenColumnReaders()) {
-      Future<Long> f = crs.processPagesAsync(recordsToRead);
+    for (ColumnReader<?> colReader : readState.getFixedLenColumnReaders()) {
+      Future<Long> f = colReader.processPagesAsync(recordsToRead);
       if (f != null) {
         futures.add(f);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedByteAlignedReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedByteAlignedReader.java
@@ -67,9 +67,6 @@ class FixedByteAlignedReader<V extends ValueVector> extends ColumnReader<V> {
    * @param bitsPerByte bits of data yielded per byte read
    */
   protected final void advanceWriterIndex(DrillBuf valueBuf, double bitsPerByte) {
-    // Set the write Index. The next page that gets read might be a page that does not use dictionary encoding
-    // and we will go into the else condition below. The readField method of the parent class requires the
-    // writer index to be set correctly.
     readLengthInBits = recordsReadInThisIteration * dataTypeLengthInBits;
     readLength = (int) Math.ceil(readLengthInBits / bitsPerByte);
     int writerIndex = valueBuf.writerIndex();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedByteAlignedReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedByteAlignedReader.java
@@ -61,18 +61,6 @@ class FixedByteAlignedReader<V extends ValueVector> extends ColumnReader<V> {
     vectorData.writeBytes(bytebuf, (int) readStartInBytes, (int) readLength);
   }
 
-  /**
-   * Advance our writer index after reading using an external values reader.
-   * @param valueBuf buffer backing the target value vector
-   * @param bitsPerByte bits of data yielded per byte read
-   */
-  protected final void advanceWriterIndex(DrillBuf valueBuf, double bitsPerByte) {
-    readLengthInBits = recordsReadInThisIteration * dataTypeLengthInBits;
-    readLength = (int) Math.ceil(readLengthInBits / bitsPerByte);
-    int writerIndex = valueBuf.writerIndex();
-    valueBuf.setIndex(0, writerIndex + (int)readLength);
-  }
-
   public static class FixedBinaryReader extends FixedByteAlignedReader<VariableWidthVector> {
     // TODO - replace this with fixed binary type in drill
     VariableWidthVector castedVector;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
@@ -310,12 +310,4 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
 
     @Override
   protected abstract void readField(long recordsToRead);
-
-  /**
-   * Advance our writer index after reading using an external values reader.
-   */
-  protected final void advanceWriterIndex() {
-    int writerIndex = castedBaseVector.getBuffer().writerIndex();
-    castedBaseVector.getBuffer().setIndex(0, writerIndex + (int) readLength);
-  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
@@ -312,9 +312,7 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
   protected abstract void readField(long recordsToRead);
 
   /**
-   * Set the write Index. The next page that gets read might be a page that does not use dictionary encoding
-   * and we will go into the else condition below. The readField method of the parent class requires the
-   * writer index to be set correctly.
+   * Advance our writer index after reading using an external values reader.
    */
   protected final void advanceWriterIndex() {
     int writerIndex = castedBaseVector.getBuffer().writerIndex();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableFixedByteAlignedReaders.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableFixedByteAlignedReaders.java
@@ -90,10 +90,6 @@ public class NullableFixedByteAlignedReaders {
           ByteBuffer buf = currDictValToWrite.toByteBuffer();
           mutator.setSafe(valuesReadInCurrentPass + i, buf, buf.position(), currDictValToWrite.length());
         }
-        // The next page that gets read might be a page that does not use dictionary encoding
-        // and we will go into the else condition below. The readField method of the parent class requires the
-        // writer index to be set correctly.
-        advanceWriterIndex();
       } else {
         super.readField(recordsToReadInThisPass);
         // TODO - replace this with fixed binary type in drill
@@ -127,7 +123,6 @@ public class NullableFixedByteAlignedReaders {
         Binary binaryTimeStampValue = valReader.readBytes();
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, getDateTimeValueFromBinary(binaryTimeStampValue, true));
       }
-      advanceWriterIndex();
     }
   }
 
@@ -146,7 +141,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readInteger());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -165,7 +159,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readInteger());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -184,7 +177,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readInteger());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -203,7 +195,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++) {
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readInteger() / 1000);
       }
-      advanceWriterIndex();
     }
   }
 
@@ -222,7 +213,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readLong());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -241,7 +231,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readLong());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -260,7 +249,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readLong());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -279,7 +267,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++) {
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readLong() / 1000);
       }
-      advanceWriterIndex();
     }
   }
 
@@ -367,7 +354,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readFloat());
       }
-      advanceWriterIndex();
     }
   }
 
@@ -386,7 +372,6 @@ public class NullableFixedByteAlignedReaders {
       for (int i = 0; i < recordsToReadInThisPass; i++){
         valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readDouble());
       }
-      advanceWriterIndex();
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableFixedByteAlignedReaders.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableFixedByteAlignedReaders.java
@@ -90,6 +90,9 @@ public class NullableFixedByteAlignedReaders {
           ByteBuffer buf = currDictValToWrite.toByteBuffer();
           mutator.setSafe(valuesReadInCurrentPass + i, buf, buf.position(), currDictValToWrite.length());
         }
+        // The next page that gets read might be a page that does not use dictionary encoding
+        // and we will go into the else condition below. The readField method of the parent class requires the
+        // writer index to be set correctly.
         advanceWriterIndex();
       } else {
         super.readField(recordsToReadInThisPass);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
@@ -770,7 +770,7 @@ class PageReader {
 
   /**
    * Provides an iterator interface that delegates to a ValuesReader on the
-   * repetition or definition levels of a Parquert v1 page.
+   * repetition or definition levels of a Parquet v1 page.
    */
   static class ValuesReaderIntIterator implements IntIterator {
     ValuesReader delegate;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetFixedWidthDictionaryReaders.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetFixedWidthDictionaryReaders.java
@@ -59,10 +59,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++) {
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readInteger());
         }
-        // Set the write Index. The next page that gets read might be a page that does not use dictionary encoding
-        // and we will go into the else condition below. The readField method of the parent class requires the
-        // writer index to be set correctly.
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -92,7 +88,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++) {
           mutator.setSafe(valuesReadInCurrentPass + i, valReader.readInteger());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -122,7 +117,6 @@ public class ParquetFixedWidthDictionaryReaders {
           mutator.setSafe(valuesReadInCurrentPass + i, currDictValToWrite.toByteBuffer().slice(), 0,
               currDictValToWrite.length());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -153,7 +147,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++){
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readInteger());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -184,7 +177,6 @@ public class ParquetFixedWidthDictionaryReaders {
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, value / 1000);
         }
       }
-      advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
     }
   }
 
@@ -208,7 +200,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++){
           mutator.setSafe(valuesReadInCurrentPass + i,  valReader.readLong());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -238,7 +229,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++) {
           mutator.setSafe(valuesReadInCurrentPass + i, valReader.readLong());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -308,7 +298,6 @@ public class ParquetFixedWidthDictionaryReaders {
             }
           }
       }
-      advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
     }
 
     private void setValueBytes(int i, byte[] bytes) {
@@ -333,7 +322,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++) {
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readLong());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -364,7 +352,6 @@ public class ParquetFixedWidthDictionaryReaders {
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, value / 1000);
         }
       }
-      advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
     }
   }
 
@@ -386,8 +373,6 @@ public class ParquetFixedWidthDictionaryReaders {
           Binary binaryTimeStampValue = valReader.readBytes();
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, getDateTimeValueFromBinary(binaryTimeStampValue, true));
         }
-        // we rescale the writer index stride because we downcast INT96 timestamps to 64 bits
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE * dataTypeLengthInBits / 64f);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -411,7 +396,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++) {
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readFloat());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -435,7 +419,6 @@ public class ParquetFixedWidthDictionaryReaders {
         for (int i = 0; i < recordsReadInThisIteration; i++) {
           valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, valReader.readDouble());
         }
-        advanceWriterIndex(valueVec.getBuffer(), BITS_COUNT_IN_BYTE_DOUBLE_VALUE);
       } else {
         super.readField(recordsToReadInThisPass);
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -483,9 +483,9 @@ public class TestParquetWriter extends ClusterTest {
       testBuilder()
         .ordered()
         .sqlQuery(query)
-        .optionSettingQueriesForTestQuery("alter system set `store.parquet.use_new_reader` = false")
+        .optionSettingQueriesForTestQuery("alter session set `store.parquet.use_new_reader` = false")
         .sqlBaselineQuery(query)
-        .optionSettingQueriesForBaseline("alter system set `store.parquet.use_new_reader` = true")
+        .optionSettingQueriesForBaseline("alter session set `store.parquet.use_new_reader` = true")
         .build().run();
     } finally {
       client.resetSession(ExecConstants.PARQUET_NEW_RECORD_READER);
@@ -1022,13 +1022,18 @@ public class TestParquetWriter extends ClusterTest {
   public void testTPCHReadWriteLz4() throws Exception {
     try {
       client.alterSession(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, "lz4");
-      // exercise the async Parquet column reader with this aircompressor-backed codec
-      client.alterSession(ExecConstants.PARQUET_COLUMNREADER_ASYNC, true);
+      // TODO: Uncomment the below to reveal DRILL-8138.  It is commented out now
+      // to allow a clean test run for the release of 1.20, since this bug is not
+      // a blocker.
+      // Exercise the async Parquet column reader with this aircompressor-backed codec
+      // client.alterSession(ExecConstants.PARQUET_COLUMNREADER_ASYNC, true);
+      client.alterSession(ExecConstants.PARQUET_PAGEREADER_ASYNC, false);
       String inputTable = "cp.`supplier_lz4.parquet`";
       runTestAndValidate("*", "*", inputTable, "suppkey_parquet_dict_lz4");
     } finally {
       client.resetSession(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE);
-      client.resetSession(ExecConstants.PARQUET_COLUMNREADER_ASYNC);
+      // client.resetSession(ExecConstants.PARQUET_COLUMNREADER_ASYNC);
+      client.resetSession(ExecConstants.PARQUET_PAGEREADER_ASYNC);
     }
   }
 


### PR DESCRIPTION
# [DRILL-8134](https://issues.apache.org/jira/browse/DRILL-8134): Cannot query Parquet INT96 columns as timestamps

## Description

As of Drill 1.19 some Parquet readers column contained code to position the value vector write buffer index after a read pass, while some did not.  The Parquet v2 PR added write buffer positioning to the cases that were missing it, but failed to cater for the fact that INT96 timestamps are downcast to 64 bit timestamps.  This PR removes all of this write buffer positioning (and mispositioning) since testing indicates that Drill's value vector write paths advance the write buffer index to correct place already.
 
## Documentation
N/A

## Testing
ParquetTestWriter#testSparkParquetBinaryAsTimeStamp_DictChange
