### PR TITLE
DRILL-8137: Prevent reading union inputs after cancellation request

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.physical.impl.union;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -71,7 +72,7 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
   private final List<TransferPair> transfers = new ArrayList<>();
   private final List<ValueVector> allocationVectors = new ArrayList<>();
   private int recordCount;
-  private UnionInputIterator unionInputIterator;
+  private Iterator<Pair<IterOutcome, BatchStatusWrappper>> unionInputIterator;
 
   public UnionAllRecordBatch(UnionAll config, List<RecordBatch> children, FragmentContext context) throws OutOfMemoryException {
     super(config, context, true, children.get(0), children.get(1));
@@ -425,6 +426,13 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
     public void remove() {
       throw new UnsupportedOperationException();
     }
+  }
+
+  @Override
+  protected void cancelIncoming() {
+    super.cancelIncoming();
+    // prevent iterating union inputs after the cancellation request
+    unionInputIterator = Collections.emptyIterator();
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
@@ -1323,4 +1323,23 @@ public class TestUnionAll extends BaseTestQuery {
         .run();
   }
 
+  @Test // DRILL-8137
+  public void testUnionCancellation() throws Exception {
+    String query = "WITH foo AS\n" +
+      "  (SELECT 1 AS a FROM cp.`/tpch/nation.parquet`\n" +
+      "   UNION ALL\n" +
+      "   SELECT 1 AS a FROM cp.`/tpch/nation.parquet`\n" +
+      "   WHERE n_nationkey > (SELECT 1) )\n" +
+      "SELECT * FROM foo\n" +
+      "LIMIT 1";
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("a")
+      .baselineValues(1)
+      .build()
+      .run();
+  }
+
 }


### PR DESCRIPTION
# [DRILL-8137](https://issues.apache.org/jira/browse/DRILL-8137): Prevent reading union inputs after cancellation request

## Description
Please see the Jira ticket for detailed RCA.

## Documentation
NA

## Testing
Added UT
