### PR TITLE
DRILL-8139: Data corruption and occasional segfaults querying Parquet/gzip under the async column reader and sync page reader

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/compression/AirliftBytesInputCompressor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/compression/AirliftBytesInputCompressor.java
@@ -163,9 +163,12 @@ public class AirliftBytesInputCompressor implements CompressionCodecFactory.Byte
     int bufCount  = allocatedBuffers.size();
 
     // LIFO release order to try to reduce memory fragmentation.
+    int i = 0;
     while (!allocatedBuffers.isEmpty()) {
       allocator.release(allocatedBuffers.pop());
+      i++;
     }
+    assert bufCount == i;
 
     logger.debug("released {} allocated buffers", bufCount);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/compression/AirliftBytesInputCompressor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/compression/AirliftBytesInputCompressor.java
@@ -19,7 +19,8 @@ package org.apache.drill.exec.store.parquet.compression;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Stack;
+import java.util.Deque;
+import java.util.LinkedList;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
@@ -59,7 +60,7 @@ public class AirliftBytesInputCompressor implements CompressionCodecFactory.Byte
   private ByteBufferAllocator allocator;
 
   // all the direct memory buffers we've allocated, and must release
-  private Stack<ByteBuffer> allocatedBuffers;
+  private Deque<ByteBuffer> allocatedBuffers;
 
   public AirliftBytesInputCompressor(CompressionCodecName codecName, ByteBufferAllocator allocator) {
     this.codecName = codecName;
@@ -86,7 +87,7 @@ public class AirliftBytesInputCompressor implements CompressionCodecFactory.Byte
     }
 
     this.allocator = allocator;
-    this.allocatedBuffers = new Stack<>();
+    this.allocatedBuffers = new LinkedList<>();
 
     logger.debug(
         "constructed a {} using a backing compressor of {}",
@@ -159,13 +160,13 @@ public class AirliftBytesInputCompressor implements CompressionCodecFactory.Byte
 
   @Override
   public void release() {
-    logger.debug(
-        "will release {} allocated buffers.",
-        this.allocatedBuffers.size()
-    );
+    int bufCount  = allocatedBuffers.size();
 
-    while (!this.allocatedBuffers.isEmpty()) {
-      this.allocator.release(allocatedBuffers.pop());
+    // LIFO release order to try to reduce memory fragmentation.
+    while (!allocatedBuffers.isEmpty()) {
+      allocator.release(allocatedBuffers.pop());
     }
+
+    logger.debug("released {} allocated buffers", bufCount);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <shaded.guava.version>28.2-jre</shaded.guava.version>
     <guava.version>30.1.1-jre</guava.version>
     <forkCount>2</forkCount>
-    <parquet.version>1.12.0</parquet.version>
+    <parquet.version>1.12.2</parquet.version>
     <parquet.format.version>2.8.0</parquet.format.version>
     <!--
       For development purposes to be able to use custom Calcite versions (e.g. not present in jitpack


### PR DESCRIPTION
# [DRILL-8139](https://issues.apache.org/jira/browse/DRILL-8139): Data corruption and occasional segfaults querying Parquet/gzip under the async column reader and sync page reader

## Description

This PR implementes a workaround for [PARQUET-2126](https://issues.apache.org/jira/browse/PARQUET-2126).  Once PARQUET-2126 is fixed, this change can be reversed.  Until then it is needed to read gzip and brotli compressed parquet under the async column reader without data corruption or query failures.

The gzip and rdblue/brotli-codec decompressor objects returned by the Parquet lib's codec factory are not thread safe.  Here we work around the problem by creating, and later releasing, single-use codec factories for codecs other than snappy which is immune due to its internal thread safety.  Many codec factories can be created during the reading of a Parquet file containing gzip compressed column data which is unnatural and unfortunate but [the added overhead does appear to be small](https://github.com/apache/parquet-mr/blob/apache-parquet-1.12.2/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java).

~~Note: currently this PR is rebased onto #2460 since that is required for a clean test run.  Only [the final commit](https://github.com/apache/drill/pull/2463/commits/042e968664afb5c409941ecfe9e8246451da5958) belongs to this PR.~~

Rebased on master now that #2460 is merged.

## Documentation
N/A

## Testing

TestParquetWriter#testTPCHReadWriteDictGzip
TestParquetWriter#testTPCHReadWriteDictBrotli
Manual testing, especially under the async column reader.
A unit test that uses the async column reader is currently not possible because of DRILL-8138.