### PR TITLE
DRILL-8132: Improvement of RPC

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlClient.java
@@ -50,7 +50,7 @@ public class ControlClient extends BasicClient<RpcType, ControlConnection, BitCo
     super(ControlRpcConfig.getMapping(config.getBootstrapContext().getConfig(),
         config.getBootstrapContext().getExecutor()),
         config.getAllocator().getAsByteBufAllocator(),
-        config.getBootstrapContext().getBitLoopGroup(),
+        config.getBootstrapContext().getControlLoopGroup(),
         RpcType.HANDSHAKE,
         BitControlHandshake.class,
         BitControlHandshake.PARSER);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlServer.java
@@ -41,7 +41,7 @@ public class ControlServer extends BasicServer<RpcType, ControlConnection>{
     super(ControlRpcConfig.getMapping(config.getBootstrapContext().getConfig(),
         config.getBootstrapContext().getExecutor()),
         config.getAllocator().getAsByteBufAllocator(),
-        config.getBootstrapContext().getBitLoopGroup());
+        config.getBootstrapContext().getControlLoopGroup());
     this.config = config;
     this.connectionRegistry = connectionRegistry;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataClient.java
@@ -51,7 +51,7 @@ public class DataClient extends BasicClient<RpcType, DataClientConnection, BitCl
         DataRpcConfig.getMapping(config.getBootstrapContext().getConfig(),
             config.getBootstrapContext().getExecutor()),
         config.getAllocator().getAsByteBufAllocator(),
-        config.getBootstrapContext().getBitClientLoopGroup(),
+        config.getBootstrapContext().getDataClientLoopGroup(),
         RpcType.HANDSHAKE,
         BitServerHandshake.class,
         BitServerHandshake.PARSER);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataServer.java
@@ -41,7 +41,7 @@ public class DataServer extends BasicServer<RpcType, DataServerConnection> {
         DataRpcConfig.getMapping(config.getBootstrapContext().getConfig(),
             config.getBootstrapContext().getExecutor()),
         config.getAllocator().getAsByteBufAllocator(),
-        config.getBootstrapContext().getBitLoopGroup());
+        config.getBootstrapContext().getDataServerLoopGroup());
     this.config = config;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -227,7 +227,7 @@ public class DrillbitContext implements AutoCloseable {
   public OAuthTokenProvider getoAuthTokenProvider() { return oAuthTokenProvider; }
 
   public EventLoopGroup getBitLoopGroup() {
-    return context.getBitLoopGroup();
+    return context.getControlLoopGroup();
   }
 
   public DataConnectionCreator getDataConnectionsPool() {

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -91,7 +91,7 @@ drill.exec: {
           count: 7200,
           delay: 500
         },
-        threads: 10
+        threads: 8
         memory: {
           control: {
             reservation: 0,


### PR DESCRIPTION
# [DRILL-8132](https://issues.apache.org/jira/browse/DRILL-8132): Improvement of RPC

## Description
As all the connection pairs between drillbits will share the same thread pool of netty, so I propose to at least sepatate data server from control client/server. Also changed the default threads number to power of two to benefit from PowerOfTwoEventExecutorChooser of Netty.

## Documentation
NA

## Testing
Start two or more drillbits, see the query which uses two or more drillbits to scan can perform correctly.
