### PR TITLE
DRILL-8140: Add JSON Post Body to HTTP Rest Storage Plugin

### DIFF
--- a/contrib/storage-http/README.md
+++ b/contrib/storage-http/README.md
@@ -137,6 +137,18 @@ postBody: "key1=value1
 key2=value2"
 ```
 
+`jsonPostBody`: Some APIs require that data be sent as part of a JSON post body. Simply add the JSON string 
+which is to be included as shown below.  
+
+**Note that APIs can have either a JSON post body OR key/value pairs in the post body
+but not both.**
+
+```json
+jsonPostBody: "{ \"foo\": \"bar\" }"
+
+```
+
+
 #### Headers
 
 `headers`: Often APIs will require custom headers as part of the authentication. This field allows

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
@@ -66,6 +66,9 @@ public class HttpApiConfig {
   private final String postBody;
 
   @JsonProperty
+  private final String jsonPostBody;
+
+  @JsonProperty
   private final Map<String, String> headers;
 
   /**
@@ -127,6 +130,8 @@ public class HttpApiConfig {
   public String postBody() {
     return this.postBody;
   }
+
+  public String jsonPostBody() { return jsonPostBody; }
 
   public Map<String, String> headers() {
     return this.headers;
@@ -196,6 +201,7 @@ public class HttpApiConfig {
       && Objects.equals(inputType, that.inputType)
       && Objects.equals(limitQueryParam, that.limitQueryParam)
       && Objects.equals(jsonOptions, that.jsonOptions)
+      && Objects.equals(jsonPostBody, that.jsonPostBody)
       && Objects.equals(credentialsProvider, that.credentialsProvider)
       && Objects.equals(paginator, that.paginator);
   }
@@ -203,7 +209,7 @@ public class HttpApiConfig {
   @Override
   public int hashCode() {
     return Objects.hash(url, requireTail, method, postBody, headers, params, dataPath,
-      authType, inputType, xmlDataLevel, limitQueryParam, errorOn400, jsonOptions, verifySSLCert,
+      authType, inputType, xmlDataLevel, limitQueryParam, errorOn400, jsonOptions, jsonPostBody, verifySSLCert,
       credentialsProvider, paginator, directCredentials);
   }
 
@@ -223,6 +229,7 @@ public class HttpApiConfig {
       .field("limitQueryParam", limitQueryParam)
       .field("errorOn400", errorOn400)
       .field("jsonOptions", jsonOptions)
+      .field("jsonOptions", jsonPostBody)
       .field("verifySSLCert", verifySSLCert)
       .field("credentialsProvider", credentialsProvider)
       .field("paginator", paginator)
@@ -271,6 +278,7 @@ public class HttpApiConfig {
     // Accept either basic or none.  The default is none.
     this.authType = StringUtils.defaultIfEmpty(builder.authType, "none");
     this.postBody = builder.postBody;
+    this.jsonPostBody = builder.jsonPostBody;
     this.params = CollectionUtils.isEmpty(builder.params) ? null :
       ImmutableList.copyOf(builder.params);
     this.dataPath = StringUtils.defaultIfEmpty(builder.dataPath, null);
@@ -348,6 +356,8 @@ public class HttpApiConfig {
     private String method;
 
     private String postBody;
+
+    private String jsonPostBody;
 
     private Map<String, String> headers;
 
@@ -432,6 +442,11 @@ public class HttpApiConfig {
 
     public HttpApiConfigBuilder postBody(String postBody) {
       this.postBody = postBody;
+      return this;
+    }
+
+    public HttpApiConfigBuilder jsonPostBody(String jsonPostBody) {
+      this.jsonPostBody = jsonPostBody;
       return this;
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -22,9 +22,11 @@ import okhttp3.Credentials;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 
 import org.apache.commons.lang3.StringUtils;
@@ -251,8 +253,14 @@ public class SimpleHttp {
     HttpApiConfig apiConfig = scanDefn.tableSpec().connectionConfig();
     if (apiConfig.getMethodType() == HttpMethod.POST) {
       // Handle POST requests
-      FormBody.Builder formBodyBuilder = buildPostBody(apiConfig.postBody());
-      requestBuilder.post(formBodyBuilder.build());
+      // Users can add either a JSON Post Body OR key/value pairs to a POST request, but not both.
+      if (StringUtils.isNotEmpty(apiConfig.jsonPostBody())) {
+        RequestBody body = RequestBody.create(apiConfig.jsonPostBody(), MediaType.parse("application/json"));
+        requestBuilder.post(body);
+      } else {
+        FormBody.Builder formBodyBuilder = buildPostBody(apiConfig.postBody());
+        requestBuilder.post(formBodyBuilder.build());
+      }
     }
 
     // Log the URL and method to aid in debugging user issues.

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -80,7 +80,7 @@ import java.util.regex.Pattern;
  */
 public class SimpleHttp {
   private static final Logger logger = LoggerFactory.getLogger(SimpleHttp.class);
-
+  public static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
   private static final Pattern URL_PARAM_REGEX = Pattern.compile("\\{(\\w+)(?:=(\\w*))?\\}");
 
   private final OkHttpClient client;
@@ -255,7 +255,7 @@ public class SimpleHttp {
       // Handle POST requests
       // Users can add either a JSON Post Body OR key/value pairs to a POST request, but not both.
       if (StringUtils.isNotEmpty(apiConfig.jsonPostBody())) {
-        RequestBody body = RequestBody.create(apiConfig.jsonPostBody(), MediaType.parse("application/json"));
+        RequestBody body = RequestBody.create(apiConfig.jsonPostBody(), JSON_MEDIA_TYPE);
         requestBuilder.post(body);
       } else {
         FormBody.Builder formBodyBuilder = buildPostBody(apiConfig.postBody());

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -38,8 +38,6 @@ import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.rowSet.RowSetUtilities;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -322,6 +322,7 @@ public class TestHttpPlugin extends ClusterTest {
         .addRow("live.sunrise", "http")
         .addRow("local", "http")
         .addRow("local.mockcsv", "http")
+        .addRow("local.mockjsonpost", "http")
         .addRow("local.mockpost", "http")
         .addRow("local.mockxml", "http")
         .addRow("local.nullpost", "http")


### PR DESCRIPTION
# [DRILL-8140](https://issues.apache.org/jira/browse/DRILL-8140): Add JSON Post Body to HTTP Rest Storage Plugin

## Description
This PR adds the ability to send a JSON body in a `post` request.

## Documentation
This PR adds the following possibility to the API config:

`jsonPostBody`: Some APIs require that data be sent as part of a JSON post body. Simply add the JSON string 
which is to be included as shown below.  

**Note that APIs can have either a JSON post body OR key/value pairs in the post body
but not both.**

```json
jsonPostBody: "{ 'foo': 'bar' }"

```

## Testing
Added unit test.