### PR TITLE
DRILL-8146: SAS reader fails to read the majority of sas files

### DIFF
--- a/contrib/format-sas/src/test/java/org/apache/drill/exec/store/sas/TestSasReader.java
+++ b/contrib/format-sas/src/test/java/org/apache/drill/exec/store/sas/TestSasReader.java
@@ -56,7 +56,7 @@ public class TestSasReader extends ClusterTest {
     RowSet results  = client.queryBuilder().sql(sql).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .addNullable("x1", MinorType.BIGINT)
+      .addNullable("x1", MinorType.FLOAT8)
       .addNullable("x2", MinorType.FLOAT8)
       .addNullable("x3", MinorType.VARCHAR)
       .addNullable("x4", MinorType.FLOAT8)
@@ -70,13 +70,13 @@ public class TestSasReader extends ClusterTest {
       .addNullable("x12", MinorType.FLOAT8)
       .addNullable("x13", MinorType.FLOAT8)
       .addNullable("x14", MinorType.FLOAT8)
-      .addNullable("x15", MinorType.BIGINT)
-      .addNullable("x16", MinorType.BIGINT)
-      .addNullable("x17", MinorType.BIGINT)
-      .addNullable("x18", MinorType.BIGINT)
-      .addNullable("x19", MinorType.BIGINT)
-      .addNullable("x20", MinorType.BIGINT)
-      .addNullable("x21", MinorType.BIGINT)
+      .addNullable("x15", MinorType.FLOAT8)
+      .addNullable("x16", MinorType.FLOAT8)
+      .addNullable("x17", MinorType.FLOAT8)
+      .addNullable("x18", MinorType.FLOAT8)
+      .addNullable("x19", MinorType.FLOAT8)
+      .addNullable("x20", MinorType.FLOAT8)
+      .addNullable("x21", MinorType.FLOAT8)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
@@ -122,7 +122,7 @@ public class TestSasReader extends ClusterTest {
     RowSet results  = client.queryBuilder().sql(sql).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .addNullable("x1", MinorType.BIGINT)
+      .addNullable("x1", MinorType.FLOAT8)
       .addNullable("x2", MinorType.FLOAT8)
       .addNullable("x3", MinorType.VARCHAR)
       .buildSchema();


### PR DESCRIPTION
# [DRILL-8146](https://issues.apache.org/jira/browse/DRILL-8146): SAS reader fails to read the majority of sas files

## Description

The idea to infer schema by analyzing the type of first row is not the best idea in this case because either the value of field in the first row can be null or the entire row can be missing (0 rows). Moreover, I think that there is no point of using MinorType.BIGINT (Long) at all since SAS stores all numbers as Double anyway. Actually, as it turned out, SAS stores any data either in VARCHAR or DOUBLE format.

My proposal is to analyze SAS column type (VARCHAR/DOUBLE) together with column format to define MinorType. In this case we don't need to use the first row at all. 
As you can see below, we can take advantage of dictionaries with all possible Date/Time formats that are already defined in parso lib to distinguish between TIME, DATE and TIMESTAMP. 
```
        if (DateTimeConstants.TIME_FORMAT_STRINGS.contains(columnFormat.getName())) {
          type = MinorType.TIME;
        } else if (DateTimeConstants.DATE_FORMAT_STRINGS.containsKey(columnFormat.getName())) {
          type = MinorType.DATE;
        } else if (DateTimeConstants.DATETIME_FORMAT_STRINGS.containsKey(columnFormat.getName())) {
          type = MinorType.TIMESTAMP;
```
All other fields that are not Date/Time can be recognized either as String or Double.

## Documentation

## Testing
I tested it on 160 real world sas files and 90 synthetic sas files. In all cases the result was ok.
