### PR TITLE
DRILL-8140: Add JSON Post Body to HTTP Rest Storage Plugin

### DIFF
--- a/contrib/storage-http/README.md
+++ b/contrib/storage-http/README.md
@@ -137,6 +137,11 @@ postBody: "key1=value1
 key2=value2"
 ```
 
+`postBodyLocation`:  If the API uses the `POST` method, you can send parameters in several different ways:
+* `query_string`:  Parameters from the query are pushed down to the query string.  Static parameters are pushed to the post body.
+* `post_body`:  Both static and parameters from the query are pushed to the post body as key/value pairs
+* `json_body`:  Both static and parameters from the query are pushed to the post body as json.
+
 #### Headers
 
 `headers`: Often APIs will require custom headers as part of the authentication. This field allows
@@ -584,8 +589,8 @@ ORDER BY issue_count DESC
 
 ~~4. This plugin only reads JSON and CSV responses.~~
 
-5. `POST` bodies can only be in the format of key/value pairs. Some APIs accept
-    JSON based `POST` bodies but this is not currently supported.
+~~5. `POST` bodies can only be in the format of key/value pairs. Some APIs accept
+    JSON based `POST` bodies but this is not currently supported.~~
 
 6. When using `dataPath`, the returned message should a single JSON object. The field
    pointed to by the `dataPath` should contain a single JSON object or an array of objects.

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
@@ -47,6 +47,10 @@ public class HttpApiConfig {
   protected static final String CSV_INPUT_FORMAT = "csv";
   protected static final String XML_INPUT_FORMAT = "xml";
 
+  public static final String POST_BODY_POST_LOCATION = "post_body";
+  public static final String QUERY_STRING_POST_LOCATION = "query_string";
+  public static final String JSON_BODY_POST_LOCATION = "json_body";
+
   @JsonProperty
   private final String url;
   /**
@@ -92,6 +96,9 @@ public class HttpApiConfig {
   private final int xmlDataLevel;
   @JsonProperty
   private final String limitQueryParam;
+  @JsonProperty
+  private final String postParameterLocation;
+
   @JsonProperty
   private final boolean errorOn400;
 
@@ -172,6 +179,8 @@ public class HttpApiConfig {
     return this.paginator;
   }
 
+  public String getPostParameterLocation() { return postParameterLocation; }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -191,6 +200,7 @@ public class HttpApiConfig {
       && Objects.equals(postBody, that.postBody)
       && Objects.equals(headers, that.headers)
       && Objects.equals(params, that.params)
+      && Objects.equals(postParameterLocation, that.postParameterLocation)
       && Objects.equals(dataPath, that.dataPath)
       && Objects.equals(authType, that.authType)
       && Objects.equals(inputType, that.inputType)
@@ -204,7 +214,7 @@ public class HttpApiConfig {
   public int hashCode() {
     return Objects.hash(url, requireTail, method, postBody, headers, params, dataPath,
       authType, inputType, xmlDataLevel, limitQueryParam, errorOn400, jsonOptions, verifySSLCert,
-      credentialsProvider, paginator, directCredentials);
+      credentialsProvider, paginator, directCredentials, postParameterLocation);
   }
 
   @Override
@@ -214,6 +224,7 @@ public class HttpApiConfig {
       .field("requireTail", requireTail)
       .field("method", method)
       .field("postBody", postBody)
+      .field("postParameterLocation", postParameterLocation)
       .field("headers", headers)
       .field("params", params)
       .field("dataPath", dataPath)
@@ -271,6 +282,10 @@ public class HttpApiConfig {
     // Accept either basic or none.  The default is none.
     this.authType = StringUtils.defaultIfEmpty(builder.authType, "none");
     this.postBody = builder.postBody;
+
+    // Default to query string to avoid breaking changes
+    this.postParameterLocation = StringUtils.defaultIfEmpty(builder.postParameterLocation.trim().toLowerCase(), QUERY_STRING_POST_LOCATION);
+
     this.params = CollectionUtils.isEmpty(builder.params) ? null :
       ImmutableList.copyOf(builder.params);
     this.dataPath = StringUtils.defaultIfEmpty(builder.dataPath, null);
@@ -348,6 +363,8 @@ public class HttpApiConfig {
     private String method;
 
     private String postBody;
+
+    private String postParameterLocation = QUERY_STRING_POST_LOCATION;
 
     private Map<String, String> headers;
 
@@ -432,6 +449,11 @@ public class HttpApiConfig {
 
     public HttpApiConfigBuilder postBody(String postBody) {
       this.postBody = postBody;
+      return this;
+    }
+
+    public HttpApiConfigBuilder postParameterLocation(String postParameterLocation) {
+      this.postParameterLocation = postParameterLocation;
       return this;
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
@@ -179,7 +179,9 @@ public class HttpApiConfig {
     return this.paginator;
   }
 
-  public String getPostParameterLocation() { return postParameterLocation; }
+  public String getPostParameterLocation() {
+    return postParameterLocation;
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -241,6 +243,27 @@ public class HttpApiConfig {
       .toString();
   }
 
+  /**
+   * Config variable to determine how POST variables are sent to the downstream API
+   */
+  public enum PostLocation {
+    /**
+     * Parameters from the query other than static parameters are pushed to
+     * the query string, as in a GET request
+     */
+    QUERY_STRING,
+    /**
+     * All POST parameters, both static and from the query, are pushed to the POST body
+     * as key/value pairs
+     */
+    POST_BODY,
+    /**
+     * All POST parameters, both static and from the query, are pushed to the POST body
+     * as a JSON object.
+     */
+    JSON_BODY
+  }
+
   public enum HttpMethod {
     /**
      * Value for HTTP GET method
@@ -278,13 +301,16 @@ public class HttpApiConfig {
         .build(logger);
     }
 
+    // Default to query string to avoid breaking changes
+    this.postParameterLocation = StringUtils.isEmpty(builder.postParameterLocation) ?
+      PostLocation.QUERY_STRING.toString() : builder.postParameterLocation.trim().toUpperCase();
+
     // Get the authentication method. Future functionality will include OAUTH2 authentication but for now
     // Accept either basic or none.  The default is none.
     this.authType = StringUtils.defaultIfEmpty(builder.authType, "none");
     this.postBody = builder.postBody;
 
-    // Default to query string to avoid breaking changes
-    this.postParameterLocation = StringUtils.defaultIfEmpty(builder.postParameterLocation.trim().toLowerCase(), QUERY_STRING_POST_LOCATION);
+
 
     this.params = CollectionUtils.isEmpty(builder.params) ? null :
       ImmutableList.copyOf(builder.params);
@@ -331,6 +357,11 @@ public class HttpApiConfig {
   @JsonIgnore
   public HttpMethod getMethodType() {
     return HttpMethod.valueOf(this.method);
+  }
+
+  @JsonIgnore
+  public PostLocation getPostLocation() {
+    return PostLocation.valueOf(this.postParameterLocation);
   }
 
   @JsonIgnore

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -198,7 +198,8 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     baseUrl = SimpleHttp.mapURLParameters(parsedURL, subScan.filters());
 
     HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
-    if (apiConfig.params() != null && !apiConfig.params().isEmpty() &&
+    if (apiConfig.params() != null &&
+      !apiConfig.params().isEmpty() &&
         subScan.filters() != null) {
       addFilters(urlBuilder, apiConfig.params(), subScan.filters());
     }
@@ -218,6 +219,14 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
   protected void addFilters(Builder urlBuilder, List<String> params,
       Map<String, String> filters) {
 
+    // If the request is a POST query and the user selected to push the filters to either JSON body
+    // or the post body, do not add to the query string.
+    if (subScan.tableSpec().connectionConfig().getMethodType() == HttpApiConfig.HttpMethod.POST &&
+      (subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.POST_BODY_POST_LOCATION) ||
+        subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.JSON_BODY_POST_LOCATION) )
+    ) {
+      return;
+    }
     for (String param : params) {
       String value = filters.get(param);
       if (value != null) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -223,7 +223,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     // or the post body, do not add to the query string.
     if (subScan.tableSpec().connectionConfig().getMethodType() == HttpApiConfig.HttpMethod.POST &&
       (subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.POST_BODY_POST_LOCATION) ||
-        subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.JSON_BODY_POST_LOCATION) )
+        subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.JSON_BODY_POST_LOCATION))
     ) {
       return;
     }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
+import org.apache.drill.exec.store.http.HttpApiConfig.PostLocation;
 import org.apache.drill.exec.store.http.paginator.Paginator;
 import org.apache.drill.exec.store.http.util.HttpProxyConfig;
 import org.apache.drill.exec.store.http.util.HttpProxyConfig.ProxyBuilder;
@@ -222,8 +223,8 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     // If the request is a POST query and the user selected to push the filters to either JSON body
     // or the post body, do not add to the query string.
     if (subScan.tableSpec().connectionConfig().getMethodType() == HttpApiConfig.HttpMethod.POST &&
-      (subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.POST_BODY_POST_LOCATION) ||
-        subScan.tableSpec().connectionConfig().getPostParameterLocation().equalsIgnoreCase(HttpApiConfig.JSON_BODY_POST_LOCATION))
+      (subScan.tableSpec().connectionConfig().getPostLocation() == PostLocation.POST_BODY ||
+        subScan.tableSpec().connectionConfig().getPostLocation() == PostLocation.JSON_BODY)
     ) {
       return;
     }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -36,6 +36,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.oauth.PersistentTokenTable;
 import org.apache.drill.exec.store.http.HttpApiConfig;
 import org.apache.drill.exec.store.http.HttpApiConfig.HttpMethod;
+import org.apache.drill.exec.store.http.HttpApiConfig.PostLocation;
 import org.apache.drill.exec.store.http.HttpOAuthConfig;
 import org.apache.drill.exec.store.http.HttpStoragePluginConfig;
 import org.apache.drill.exec.store.http.HttpSubScan;
@@ -259,10 +260,10 @@ public class SimpleHttp {
       FormBody.Builder formBodyBuilder;
 
       // If the user wants filters pushed down to the POST body, do so here.
-      if (Objects.equals(apiConfig.getPostParameterLocation(), HttpApiConfig.POST_BODY_POST_LOCATION)) {
+      if (apiConfig.getPostLocation() == PostLocation.POST_BODY) {
         formBodyBuilder = buildPostBody(filters, apiConfig.postBody());
         requestBuilder.post(formBodyBuilder.build());
-      } else if (Objects.equals(apiConfig.getPostParameterLocation(), HttpApiConfig.JSON_BODY_POST_LOCATION)) {
+      } else if (apiConfig.getPostLocation() == PostLocation.JSON_BODY) {
         // Add static parameters from postBody
         JSONObject json = buildJsonPostBody(apiConfig.postBody());
         // Now add filters

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -93,7 +93,7 @@ public class SimpleHttp {
   private final Paginator paginator;
   private final HttpUrl url;
   private final PersistentTokenTable tokenTable;
-  private final Map<String,String> filters;
+  private final Map<String, String> filters;
   private final HttpApiConfig apiConfig;
   private String responseMessage;
   private int responseCode;


### PR DESCRIPTION
# [DRILL-8140](https://issues.apache.org/jira/browse/DRILL-8140): Add JSON Post Body to HTTP Rest Storage Plugin

## Description
This PR allows the user to control where parameters are pushed down during `POST` requests.  The choices are:
* `query_string`:  `POST` parameters (both filters and static) are pushed to the query string. 
* `post_body`: `POST` parameters (both filters and static) are pushed to the post body as key/value pairs
* `json_body`: `POST` parameters (both filters and static) are pushed to the post body as JSON.

The user can set this by adding the `postParameterLocation` parameter to an API configuration.  The default is `query_string`. 

## Documentation

### Set the POST destination
The user can set the destination and format of POST parameters by adding the `postParameterLocation` parameter to an API configuration.  The default is `query_string`. 

The choices are:
* `query_string`:  `POST` parameters (filters only) are pushed to the query string. 
* `post_body`: `POST` parameters (both filters and static) are pushed to the post body as key/value pairs
* `json_body`: `POST` parameters (both filters and static) are pushed to the post body as JSON.

## Testing
Added unit tests.