### PR TITLE
DRILL-8121: Add UserSession to StoragePlugins

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -28,6 +28,7 @@ import org.apache.drill.common.exceptions.UserExceptionUtils;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePlugin;
@@ -58,8 +59,8 @@ public class DynamicRootSchema extends DynamicSchema {
   private final AliasRegistryProvider aliasRegistryProvider;
 
   /** Creates a root schema. */
-  DynamicRootSchema(StoragePluginRegistry storages, SchemaConfig schemaConfig, AliasRegistryProvider aliasRegistryProvider) {
-    super(null, new RootSchema(storages), ROOT_SCHEMA_NAME);
+  DynamicRootSchema(StoragePluginRegistry storages, SchemaConfig schemaConfig, AliasRegistryProvider aliasRegistryProvider, UserSession session) {
+    super(null, new RootSchema(storages), ROOT_SCHEMA_NAME, session);
     this.schemaConfig = schemaConfig;
     this.storages = storages;
     this.aliasRegistryProvider = aliasRegistryProvider;

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -107,6 +107,7 @@ public class DynamicRootSchema extends DynamicSchema {
       SchemaPlus schemaPlus = this.plus();
       StoragePlugin plugin = storages.getPlugin(schemaName);
       if (plugin != null) {
+        plugin.establishConnection(getSession());
         plugin.registerSchemas(schemaConfig, schemaPlus);
         return;
       }
@@ -123,6 +124,7 @@ public class DynamicRootSchema extends DynamicSchema {
         SchemaPlus firstLevelSchema = schemaPlus.getSubSchema(paths.get(0));
         if (firstLevelSchema == null) {
           // register schema for this storage plugin to 'this'.
+          plugin.establishConnection(getSession());
           plugin.registerSchemas(schemaConfig, schemaPlus);
           firstLevelSchema = schemaPlus.getSubSchema(paths.get(0));
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -186,7 +186,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    */
   @Override
   public SchemaPlus getRootSchema(final String userName) {
-    return schemaTreeProvider.createRootSchema(userName, this);
+    return schemaTreeProvider.createRootSchema(userName, this, session);
   }
 
   /**
@@ -196,7 +196,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    * @return A {@link org.apache.calcite.schema.SchemaPlus} with given <i>schemaConfig</i>.
    */
   public SchemaPlus getRootSchema(SchemaConfig schemaConfig) {
-    return schemaTreeProvider.createRootSchema(schemaConfig);
+    return schemaTreeProvider.createRootSchema(schemaConfig, session);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/BaseQueryRunner.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/BaseQueryRunner.java
@@ -31,6 +31,7 @@ import org.apache.drill.exec.proto.UserProtos.QueryResultsMode;
 import org.apache.drill.exec.proto.UserProtos.RunQuery;
 import org.apache.drill.exec.rpc.UserClientConnection;
 import org.apache.drill.exec.rpc.user.InboundImpersonationManager;
+import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.SchemaTreeProvider;
@@ -46,12 +47,14 @@ public abstract class BaseQueryRunner {
   protected final WorkManager workManager;
   protected final WebUserConnection webUserConnection;
   private final OptionSet options;
+  private final UserSession session;
   protected int maxRows;
   protected QueryId queryId;
 
   public BaseQueryRunner(final WorkManager workManager, final WebUserConnection webUserConnection) {
     this.workManager = workManager;
     this.webUserConnection = webUserConnection;
+    this.session = webUserConnection.getSession();
     this.options = webUserConnection.getSession().getOptions();
     this.maxRows = options.getInt(ExecConstants.QUERY_MAX_ROWS);
   }
@@ -96,7 +99,7 @@ public abstract class BaseQueryRunner {
       SessionOptionManager options = webUserConnection.getSession().getOptions();
       @SuppressWarnings("resource")
       SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(workManager.getContext());
-      SchemaPlus rootSchema = schemaTreeProvider.createRootSchema(options);
+      SchemaPlus rootSchema = schemaTreeProvider.createRootSchema(options, session);
       webUserConnection.getSession().setDefaultSchemaPath(defaultSchema, rootSchema);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
 import org.apache.drill.exec.planner.PlannerPhase;
 
+import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SessionOptionManager;
@@ -43,10 +44,16 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
 
   protected final DrillbitContext context;
   private final String name;
+  private UserSession session;
 
   protected AbstractStoragePlugin(DrillbitContext inContext, String inName) {
     this.context = inContext;
     this.name = inName == null ? null : inName.toLowerCase();
+  }
+
+  @Override
+  public void establishConnection(UserSession session) {
+    this.session = session;
   }
 
   @Override
@@ -157,4 +164,15 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
     return context;
   }
 
+  public UserSession getSession() {
+    return session;
+  }
+
+  public String getActiveUser() {
+    if (session == null) {
+      return "anonymous";
+    } else {
+      return session.getCredentials().getUserName();
+    }
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
@@ -29,6 +29,7 @@ import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.dfs.FormatPlugin;
 
@@ -44,6 +45,15 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
    * Initialize the storage plugin. The storage plugin will not be used until this method is called.
    */
   void start() throws IOException;
+
+  /**
+   * This function is a lifecycle function which is called after the storage plugin has been created
+   * but before registerSchemas() in the planning phase.  It makes the active user available during
+   * planning which is necessary if the plugin does not use user-impersonation and allows individual
+   * credentials.
+   * @param session The active user session
+   */
+  void establishConnection(UserSession session);
 
   /**
    * Indicates if Drill can read the table from this format.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
@@ -569,7 +569,7 @@ public class MetadataProvider {
   private static <S> PojoRecordReader<S> getPojoRecordReader(final InfoSchemaTableType tableType, final InfoSchemaFilter filter, final DrillConfig config,
       final SchemaTreeProvider provider, final UserSession userSession, final MetastoreRegistry metastoreRegistry) {
     final SchemaPlus rootSchema =
-        provider.createRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(config, userSession, provider));
+        provider.createRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(config, userSession, provider), userSession);
     return tableType.getRecordReader(rootSchema, filter, userSession.getOptions(), metastoreRegistry);
   }
 
@@ -590,7 +590,7 @@ public class MetadataProvider {
 
       @Override
       public SchemaPlus getRootSchema(String userName) {
-        return schemaTreeProvider.createRootSchema(userName, this);
+        return schemaTreeProvider.createRootSchema(userName, this, session);
       }
 
       @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -107,7 +107,7 @@ public class PlanningBase extends ExecTest {
     final FunctionImplementationRegistry functionRegistry = new FunctionImplementationRegistry(config);
     final DrillOperatorTable table = new DrillOperatorTable(functionRegistry, systemOptions);
     SchemaConfig schemaConfig = SchemaConfig.newBuilder("foo", context).build();
-    SchemaPlus root = DynamicSchema.createRootSchema(registry, schemaConfig, new AliasRegistryProvider(dbContext));
+    SchemaPlus root = DynamicSchema.createRootSchema(registry, schemaConfig, new AliasRegistryProvider(dbContext), userSession);
 
     when(context.getNewDefaultSchema()).thenReturn(root);
     when(context.getLpPersistence()).thenReturn(new LogicalPlanPersistence(config, ClassPathScanner.fromPrescan(config)));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestUserSessionInStorage.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestUserSessionInStorage.java
@@ -120,6 +120,7 @@ public class TestUserSessionInStorage extends ClusterTest {
       .build();
 
     client.queryBuilder().sql(sql).run();
+    assertNotNull(plugin.getSession());
     assertEquals(TEST_USER_2, plugin.getActiveUser());
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestUserSessionInStorage.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestUserSessionInStorage.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2_PASSWORD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * Tests the UserSession getting down to the storage plugins.  Makes sure
+ * the correct UserSession is going to the correct plugin.
+ */
+public class TestUserSessionInStorage extends ClusterTest {
+
+  @ClassRule
+  public static final BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();
+
+  @After
+  public void cleanup() throws Exception {
+    FileUtils.cleanDirectory(dirTestWatcher.getStoreDir());
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
+  }
+
+  @Test
+  public void testAnonymousUserSession() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    ClusterFixture cluster = builder.build();
+
+    StoragePluginRegistry registry = cluster.storageRegistry();
+
+    // Run a query
+    String sql = "SHOW FILES IN dfs";
+    client.queryBuilder().sql(sql).run();
+
+    AbstractStoragePlugin plugin = (AbstractStoragePlugin) registry.getPlugin("dfs");
+
+    // Get the active user.  If there is no authentication, the UserSession may be null.  The
+    // getActiveUser() method is always safe to use because it will return anonymous if the
+    // UserSession is null.
+    assertEquals("anonymous", plugin.getActiveUser());
+  }
+
+  @Test
+  public void testWithUser() throws Exception {
+    ClientFixture client = cluster.clientBuilder()
+      .property(DrillProperties.USER, TEST_USER_1)
+      .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+      .build();
+
+    StoragePluginRegistry registry = cluster.storageRegistry();
+    // Run a query
+    String sql = "SHOW FILES IN dfs";
+    client.queryBuilder().sql(sql).run();
+
+    AbstractStoragePlugin plugin = (AbstractStoragePlugin) registry.getPlugin("dfs");
+
+    // Get the user session.  This should not be null.
+    assertNotNull(plugin.getSession());
+    assertEquals(TEST_USER_1, plugin.getActiveUser());
+  }
+
+  @Test
+  public void testUserUpdate() throws Exception {
+    ClientFixture client = cluster.clientBuilder()
+      .property(DrillProperties.USER, TEST_USER_1)
+      .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+      .build();
+
+    StoragePluginRegistry registry = cluster.storageRegistry();
+    // Run a query
+    String sql = "SHOW FILES IN dfs";
+    client.queryBuilder().sql(sql).run();
+
+    AbstractStoragePlugin plugin = (AbstractStoragePlugin) registry.getPlugin("dfs");
+
+    // Get the user session.  This should not be null.
+    assertNotNull(plugin.getSession());
+    assertEquals(TEST_USER_1, plugin.getActiveUser());
+
+    // Run another query with a different user.
+    client = cluster.clientBuilder()
+      .property(DrillProperties.USER, TEST_USER_2)
+      .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+      .build();
+
+    client.queryBuilder().sql(sql).run();
+    assertEquals(TEST_USER_2, plugin.getActiveUser());
+  }
+}


### PR DESCRIPTION
# [DRILL-8121](https://issues.apache.org/jira/browse/DRILL-8121): Add UserSession to StoragePlugins

## Description

One of the major limitations of Drill is that per-user credentials are not supported in non-Hadoop, or file system storage plugins. In conducting experiments, one of the major challenges preventing this was that there was no reliable way for a storage plugin to obtain the username of the user who submitted the query.

This PR represents the first step in making this possible by passing the UserSession object down to the storage plugin instance. Thus for each query, the storage plugin can obtain the active user id. This does not affect any current Drill behavior, but will make it possible to implement per-user credentials for plugins such as JDBC, Splunk, ElasticSearch and others that do not have the concept of user impersonation.

## Documentation
No user facing changes

## Testing
Added unit tests.