### PR TITLE
[MINOR-UPDATE]: Set Brotli codec jar and test to occur only on Linux amd64.

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -650,14 +650,6 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.rdblue</groupId>
-      <artifactId>brotli-codec</artifactId>
-      <version>0.1.1</version>
-      <!-- brotli-codec bundles natives for linux and darwin, amd64 only so
-      we don't ship it so as not to break startup on windows or arm -->
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <profiles>
@@ -767,8 +759,26 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <!-- Only include a Brotli codec in test scope on Linux / amd64, see PARQUET-1975 -->
+      <id>linux-amd64</id>
+      <activation>
+        <os>
+          <arch>amd64</arch>
+          <name>Linux</name>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.rdblue</groupId>
+          <artifactId>brotli-codec</artifactId>
+          <version>0.1.1</version>
+          <!-- this codec is not shipped because it breaks startup on unsupported platforms -->
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
-
   <build>
     <plugins>
       <plugin>

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -53,7 +53,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -999,12 +998,11 @@ public class TestParquetWriter extends ClusterTest {
     }
   }
 
-  // We currently bundle the JNI-based com.rdblue.brotli-codec and it only provides
-  // natives for Mac and Linux on AMD64.  See PARQUET-1975.
+  // Only attempt this test on Linux / amd64 because com.rdblue.brotli-codec
+  // only bundles natives for Mac and Linux on AMD64.  See PARQUET-1975.
   @Test
-  @DisabledIfSystemProperty(named = "os.name", matches = "Windows")
-  @EnabledIfSystemProperty(named = "os.arch", matches = "amd64") // reported for Linux on AMD64
-  @EnabledIfSystemProperty(named = "os.arch", matches = "x86_64") // reported for OS X on AMD64
+  @EnabledIfSystemProperty(named = "os.name", matches = "Linux")
+  @EnabledIfSystemProperty(named = "os.arch", matches = "amd64")
   public void testTPCHReadWriteBrotli() throws Exception {
     try {
       client.alterSession(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, "brotli");

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <javax.validation.api>2.0.1.Final</javax.validation.api>
     <asm.version>9.2</asm.version>
     <excludedGroups />
-    <memoryMb>2500</memoryMb>
+    <memoryMb>2000</memoryMb>
     <directMemoryMb>2500</directMemoryMb>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>


### PR DESCRIPTION
# [MINOR-UPDATE]: Set Brotli codec jar and test to occur only on Linux amd64.

## Description

Because it is not fully cross platform, com.rdblue.brotli-codec is moved to test scope on Linux amd64 only.  TestParquetWriter#testTPCHReadWriteBrotli is set to execute on Linux amd64 only.

## Documentation
None.

## Testing
Verify that the distribution archive still does not include brotli-codec, which breaks startup on unsupported platforms.
Obtain clean CI runs on amd64 and aarch64 with TestParquetWriter#testTPCHReadWriteBrotli included only on amd64.

