### PR TITLE
DRILL-8153: Convert OAuth REST APIs to JSON

### DIFF
--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthTokenUpdate.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthTokenUpdate.java
@@ -19,7 +19,7 @@
 package org.apache.drill.exec.store.http;
 
 import okhttp3.Call;
-import okhttp3.FormBody;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -32,6 +32,7 @@ import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
 import org.apache.drill.exec.store.security.oauth.OAuthTokenCredentials;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
+import org.json.simple.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TestOAuthTokenUpdate extends ClusterTest {
 
+  public static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
   private static final String CONNECTION_NAME = "localOauth";
   private static final int MOCK_SERVER_PORT = 47770;
   private static final int TIMEOUT = 30;
@@ -95,13 +97,13 @@ public class TestOAuthTokenUpdate extends ClusterTest {
 
   @Test
   public void testUpdateAccessToken() throws Exception {
-    RequestBody formBody = new FormBody.Builder()
-      .add("access_token", "access_approved")
-      .build();
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("accessToken", "access_approved");
 
+    RequestBody requestBody = RequestBody.create(jsonObject.toString(), JSON_MEDIA_TYPE);
     Request request = new Request.Builder()
       .url(hostname + "/update_access_token")
-      .post(formBody)
+      .post(requestBody)
       .build();
 
     Call call = httpClient.newCall(request);
@@ -109,18 +111,19 @@ public class TestOAuthTokenUpdate extends ClusterTest {
     assertEquals(response.code(), 200);
 
     PersistentTokenTable tokenTable = getTokenTable();
-    assertEquals(tokenTable.getAccessToken(), "access_approved");
+    assertEquals("access_approved", tokenTable.getAccessToken());
   }
 
   @Test
   public void testUpdateRefreshToken() throws Exception {
-    RequestBody formBody = new FormBody.Builder()
-      .add("refresh_token", "refresh_me")
-      .build();
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("refreshToken", "refresh_me");
+
+    RequestBody requestBody = RequestBody.create(jsonObject.toString(), JSON_MEDIA_TYPE);
 
     Request request = new Request.Builder()
       .url(hostname + "/update_refresh_token")
-      .post(formBody)
+      .post(requestBody)
       .build();
 
     Call call = httpClient.newCall(request);
@@ -134,14 +137,15 @@ public class TestOAuthTokenUpdate extends ClusterTest {
 
   @Test
   public void testUpdateAllTokens() throws Exception {
-    RequestBody formBody = new FormBody.Builder()
-      .add("access_token", "access_approved")
-      .add("refresh_token", "refresh_me")
-      .build();
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("accessToken", "access_approved");
+    jsonObject.put("refreshToken", "refresh_me");
+
+    RequestBody requestBody = RequestBody.create(jsonObject.toString(), JSON_MEDIA_TYPE);
 
     Request request = new Request.Builder()
       .url(hostname + "/update_oauth_tokens")
-      .post(formBody)
+      .post(requestBody)
       .build();
 
     Call call = httpClient.newCall(request);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/OAuthTokenContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/OAuthTokenContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.server.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class OAuthTokenContainer {
+  private final String accessToken;
+  private final String refreshToken;
+
+  @JsonCreator
+  public OAuthTokenContainer(@JsonProperty("accessToken") String accessToken,
+                             @JsonProperty("refreshToken") String refreshToken) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getRefreshToken() {
+    return refreshToken;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -204,9 +204,9 @@ public class StorageResources {
 
   @POST
   @Path("/storage/{name}/update_refresh_token")
+  @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public Response updateRefreshToken(@PathParam("name") String name,
-                                    @FormParam("refresh_token") String refreshToken) {
+  public Response updateRefreshToken(@PathParam("name") String name, OAuthTokenContainer tokens) {
     try {
       if (storage.getPlugin(name).getConfig() instanceof AbstractSecuredStoragePluginConfig) {
         DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
@@ -214,7 +214,7 @@ public class StorageResources {
         PersistentTokenTable tokenTable = tokenProvider.getOauthTokenRegistry().getTokenTable(name);
 
         // Set the access token
-        tokenTable.setRefreshToken(refreshToken);
+        tokenTable.setRefreshToken(tokens.getRefreshToken());
 
         return Response.status(Status.OK)
           .entity("Refresh token have been updated.")
@@ -235,9 +235,9 @@ public class StorageResources {
 
   @POST
   @Path("/storage/{name}/update_access_token")
+  @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public Response updateAccessToken(@PathParam("name") String name,
-                                    @FormParam("access_token") String accessToken) {
+  public Response updateAccessToken(@PathParam("name") String name, OAuthTokenContainer tokens) {
     try {
       if (storage.getPlugin(name).getConfig() instanceof AbstractSecuredStoragePluginConfig) {
         DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
@@ -245,7 +245,7 @@ public class StorageResources {
         PersistentTokenTable tokenTable = tokenProvider.getOauthTokenRegistry().getTokenTable(name);
 
         // Set the access token
-        tokenTable.setAccessToken(accessToken);
+        tokenTable.setAccessToken(tokens.getAccessToken());
 
         return Response.status(Status.OK)
           .entity("Access tokens have been updated.")
@@ -266,10 +266,10 @@ public class StorageResources {
 
   @POST
   @Path("/storage/{name}/update_oauth_tokens")
+  @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public Response updateOAuthTokens(@PathParam("name") String name,
-                                    @FormParam("access_token") String accessToken,
-                                    @FormParam("refresh_token") String refreshToken) {
+                                    OAuthTokenContainer tokenContainer) {
     try {
       if (storage.getPlugin(name).getConfig() instanceof AbstractSecuredStoragePluginConfig) {
         DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
@@ -277,8 +277,8 @@ public class StorageResources {
         PersistentTokenTable tokenTable = tokenProvider.getOauthTokenRegistry().getTokenTable(name);
 
         // Set the access and refresh token
-        tokenTable.setAccessToken(accessToken);
-        tokenTable.setRefreshToken(refreshToken);
+        tokenTable.setAccessToken(tokenContainer.getAccessToken());
+        tokenTable.setRefreshToken(tokenContainer.getRefreshToken());
 
         return Response.status(Status.OK)
           .entity("Access tokens have been updated.")


### PR DESCRIPTION
# [DRILL-8153](https://issues.apache.org/jira/browse/DRILL-8153): Convert OAuth REST APIs to JSON

## Description
This PR converts the OAuth REST APIs to accept JSON.  

## Documentation
The following API calls are now available for updating an HTTP Storage Plugin's OAuth tokens if OAuth is used. These three new endpoints are POST requests and accept the tokens as part of the form body.

* `/storage/{plugin name}/update_access_token`
* `/storage/{plugin name}/update_refresh_token`
* `/storage/{plugin name}/update_oauth_tokens`

These endpoints take as arguments: `accessToken`, `refreshToken` or both.

## Testing
Updated unit tests. 