### PR TITLE
DRILL-8158: Remove non-reproducible build outputs

### DIFF
--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -246,10 +246,6 @@
       <outputDirectory />
     </file>
     <file>
-      <source>../git.properties</source>
-      <outputDirectory />
-    </file>
-    <file>
       <source>src/main/resources/runbit</source>
       <fileMode>0755</fileMode>
       <outputDirectory>bin</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <sourceReleaseAssemblyDescriptor>source-release-zip-tar</sourceReleaseAssemblyDescriptor>
-    <project.build.outputTimestamp>1</project.build.outputTimestamp>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
     <target.gen.source.path>${project.basedir}/target/generated-sources</target.gen.source.path>
     <proto.cas.path>${project.basedir}/src/main/protobuf/</proto.cas.path>
     <junit.version>5.7.2</junit.version>
@@ -532,7 +532,6 @@
             </manifest>
             <manifestEntries>
               <Extension-Name>org.apache.drill</Extension-Name>
-              <Built-By>${user.name}</Built-By>
               <url>https://drill.apache.org/</url>
             </manifestEntries>
           </archive>
@@ -544,67 +543,6 @@
             </goals>
             <configuration>
               <skipIfEmpty>true</skipIfEmpty>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.0.0</version>
-        <executions>
-          <execution>
-            <id>for-source-tarball</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <inherited>false</inherited>
-            <configuration>
-              <generateGitPropertiesFilename>./git.properties</generateGitPropertiesFilename>
-            </configuration>
-          </execution>
-        </executions>
-
-        <configuration>
-          <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-          <verbose>false</verbose>
-          <skipPoms>false</skipPoms>
-          <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          <gitDescribe>
-            <skip>false</skip>
-            <always>false</always>
-            <abbrev>7</abbrev>
-            <dirty>-dirty</dirty>
-            <forceLongFormat>true</forceLongFormat>
-          </gitDescribe>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
-        <executions>
-          <execution>
-            <!-- copy root git.properties file to target/classes folder for every module
-                to ensure that it will be placed into jar -->
-            <phase>initialize</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <resources>
-                <resource>
-                  <!--suppress UnresolvedMavenProperty -->
-                  <directory>${maven.multiModuleProjectDirectory}</directory>
-                  <includes>
-                    <include>git.properties</include>
-                  </includes>
-                </resource>
-              </resources>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
# [DRILL-8158](https://issues.apache.org/jira/browse/DRILL-8158): Remove non-reproducible build outputs

Drill 1.20.0 has many non-reproducible outputs: https://github.com/jvm-repo-rebuild/reproducible-central#org.apache.drill:drill-root
see details https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/drill/drill-root-1.20.0.diffoscope

this PR fixes 2 causes that represents the vast majority of reproducibility issues: a timestamp in MANIFEST.MF and detailed Git properties

once these issues are fixed, only 1 issue will remain: `META-INF/drill-module-scan/registry.json` is not reproducible, because of unreproducible entries order

testing local reproducibility can be done with `mvn clean && mvn install -Papache-release -DskipTests -Dgpg.skip && mvn clean && mvn package -Papache-release -DskipTests -Dgpg.skip artifact:compare`
