### PR TITLE
DRILL-8161: Add Global Credentials to HTTP Storage Plugin

### DIFF
--- a/contrib/storage-http/README.md
+++ b/contrib/storage-http/README.md
@@ -282,6 +282,22 @@ If the `authType` is set to `basic`, `username` and `password` must be set in th
 
 `password`: The password for basic authentication.
 
+##### Global Credentials
+If you have an HTTP plugin with multiple endpoints that all use the same credentials, you can set the `authType` to `basic` and set global 
+credentials in the storage plugin configuration. 
+
+Simply add the following to the storage plugin configuration:
+```json
+ "credentialsProvider": {
+    "credentialsProviderType": "PlainCredentialsProvider",
+    "credentials": {
+      "username": "user1",
+      "password": "user1Pass"
+    }
+  }
+```
+Note that the `authType` still must be set to `basic` and that any endpoint credentials will override the global credentials.
+
 #### Limiting Results
 Some APIs support a query parameter which is used to limit the number of results returned by the API.  In this case you can set the `limitQueryParam` config variable to the query parameter name and Drill will automatically include this in your query.  For instance, if you have an API which supports a limit query parameter called `maxRecords` and you set the abovementioned config variable then execute the following query:
   

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -30,7 +30,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -30,6 +30,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
@@ -146,9 +147,10 @@ public class SimpleHttp {
       builder.authenticator(new AccessTokenAuthenticator(repository));
       builder.addInterceptor(new AccessTokenInterceptor(repository));
     } else if (apiConfig.authType().equalsIgnoreCase("basic")) {
-      // If the API uses basic authentication add the authentication code.
+      // If the API uses basic authentication add the authentication code.  Use the global credentials unless there are credentials
+      // for the specific endpoint.
       logger.debug("Adding Interceptor");
-      UsernamePasswordCredentials credentials = apiConfig.getUsernamePasswordCredentials();
+      UsernamePasswordCredentials credentials = getCredentials();
       builder.addInterceptor(new BasicAuthInterceptor(credentials.getUsername(), credentials.getPassword()));
     }
 
@@ -358,6 +360,34 @@ public class SimpleHttp {
     } else {
       return ((responseCode >= 200 && responseCode <= 299) ||
         (responseCode >= 400 && responseCode <= 499));
+    }
+  }
+
+  /**
+   * Logic to determine whether the API connection has global credentials or credentials specific for the
+   * API endpoint.
+   * @param endpointConfig The API endpoint configuration
+   * @return True if the endpoint has credentials, false if not.
+   */
+  private boolean hasEndpointCredentials(HttpApiConfig endpointConfig) {
+    UsernamePasswordCredentials credentials = endpointConfig.getUsernamePasswordCredentials();
+    if (StringUtils.isNotEmpty(credentials.getUsername()) &&
+    StringUtils.isNotEmpty(credentials.getPassword())) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * If the user has defined username/password for the specific API endpoint, pass the API endpoint credentials.
+   * Otherwise, use the global connection credentials.
+   * @return A UsernamePasswordCredentials collection with the correct username/password
+   */
+  private UsernamePasswordCredentials getCredentials() {
+    if (hasEndpointCredentials(apiConfig)) {
+      return apiConfig.getUsernamePasswordCredentials();
+    } else {
+      return scanDefn.tableSpec().config().getUsernamePasswordCredentials();
     }
   }
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
@@ -109,7 +109,7 @@ public class TestOAuthProcess extends ClusterTest {
 
     // Add storage plugin for test OAuth
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, TIMEOUT, "", 80, "", "", "",
+      new HttpStoragePluginConfig(false, configs, TIMEOUT, null, null, "", 80, "", "", "",
         oAuthConfig, credentialsProvider);
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("localOauth", mockStorageConfigWithWorkspace);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthTokenUpdate.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthTokenUpdate.java
@@ -89,7 +89,7 @@ public class TestOAuthTokenUpdate extends ClusterTest {
 
     // Add storage plugin for test OAuth
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, TIMEOUT, "", 80, "", "", "",
+      new HttpStoragePluginConfig(false, configs, TIMEOUT,null, null, "", 80, "", "", "",
         oAuthConfig, credentialsProvider);
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("localOauth", mockStorageConfigWithWorkspace);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.http;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.util.DrillFileUtils;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TestPagination extends ClusterTest {
   private static final int MOCK_SERVER_PORT = 8092;
@@ -113,7 +115,7 @@ public class TestPagination extends ClusterTest {
     configs.put("github", githubConfig);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 10, "", 80, "", "", "", null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
+      new HttpStoragePluginConfig(false, configs, 10, null, null, "", 80, "", "", "", null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("live", mockStorageConfigWithWorkspace);
   }
@@ -193,7 +195,7 @@ public class TestPagination extends ClusterTest {
     configs.put("xml_paginator_url_params", mockXmlConfigWithPaginatorAndUrlParams);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 2, "", 80, "", "", "", null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
+      new HttpStoragePluginConfig(false, configs, 2, null, null, "", 80, "", "", "", null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER);
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("local", mockStorageConfigWithWorkspace);
   }
@@ -349,6 +351,10 @@ public class TestPagination extends ClusterTest {
         b.release();
       }
       assertEquals(6, count);
+
+      // Verify that there are no random headers being inserted if authorization is not defined.
+      RecordedRequest recordedRequest = server.takeRequest();
+      assertNull(recordedRequest.getHeader("Authorization"));
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
@@ -56,7 +56,7 @@ public class CredentialProviderUtils {
    * @param tokenURI The URI from which you swap the auth code for access and refresh tokens.
    * @param username  Optional username for other services
    * @param password  Optional password for proxy or other services
-   * @param proxyUserName Optional username for a proxy server.
+   * @param proxyUsername Optional username for a proxy server.
    * @param proxyPassword Optional password for a proxy server.
    * @param credentialsProvider  The credential store which retains the credentials.
    * @return A credential provider with the access tokens
@@ -67,7 +67,7 @@ public class CredentialProviderUtils {
     String tokenURI,
     String username,
     String password,
-    String proxyUserName,
+    String proxyUsername,
     String proxyPassword,
     CredentialsProvider credentialsProvider) {
 
@@ -90,8 +90,8 @@ public class CredentialProviderUtils {
     if (tokenURI != null) {
       mapBuilder.put(OAuthTokenCredentials.TOKEN_URI, tokenURI);
     }
-    if (proxyUserName != null) {
-      mapBuilder.put(OAuthTokenCredentials.PROXY_USERNAME, proxyUserName);
+    if (proxyUsername != null) {
+      mapBuilder.put(OAuthTokenCredentials.PROXY_USERNAME, proxyUsername);
     }
     if (proxyPassword != null) {
       mapBuilder.put(OAuthTokenCredentials.PROXY_PASSWORD, proxyPassword);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
@@ -54,8 +54,10 @@ public class CredentialProviderUtils {
    * @param clientID The OAuth Client ID.  This is provided by the application during signup.
    * @param clientSecret The OAUth Client Secret.  This is provided by the application during signup.
    * @param tokenURI The URI from which you swap the auth code for access and refresh tokens.
-   * @param username  Optional username for proxy or other services
+   * @param username  Optional username for other services
    * @param password  Optional password for proxy or other services
+   * @param proxyUserName Optional username for a proxy server.
+   * @param proxyPassword Optional password for a proxy server.
    * @param credentialsProvider  The credential store which retains the credentials.
    * @return A credential provider with the access tokens
    */
@@ -65,6 +67,8 @@ public class CredentialProviderUtils {
     String tokenURI,
     String username,
     String password,
+    String proxyUserName,
+    String proxyPassword,
     CredentialsProvider credentialsProvider) {
 
     if (credentialsProvider != null) {
@@ -85,6 +89,12 @@ public class CredentialProviderUtils {
     }
     if (tokenURI != null) {
       mapBuilder.put(OAuthTokenCredentials.TOKEN_URI, tokenURI);
+    }
+    if (proxyUserName != null) {
+      mapBuilder.put(OAuthTokenCredentials.PROXY_USERNAME, proxyUserName);
+    }
+    if (proxyPassword != null) {
+      mapBuilder.put(OAuthTokenCredentials.PROXY_PASSWORD, proxyPassword);
     }
 
     return new PlainCredentialsProvider(mapBuilder.build());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordWithProxyCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordWithProxyCredentials.java
@@ -30,7 +30,7 @@ public class UsernamePasswordWithProxyCredentials extends UsernamePasswordCreden
 
   public UsernamePasswordWithProxyCredentials(CredentialsProvider credentialsProvider) {
     super(credentialsProvider);
-    if (credentialsProvider == null) {
+    if (credentialsProvider == null || credentialsProvider.getCredentials() == null) {
       this.proxyUsername = null;
       this.proxyPassword = null;
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordWithProxyCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordWithProxyCredentials.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.security;
+
+import org.apache.drill.common.logical.security.CredentialsProvider;
+import org.apache.drill.exec.store.security.oauth.OAuthTokenCredentials;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UsernamePasswordWithProxyCredentials extends UsernamePasswordCredentials {
+  private final String proxyUsername;
+  private final String proxyPassword;
+
+  public UsernamePasswordWithProxyCredentials(CredentialsProvider credentialsProvider) {
+    super(credentialsProvider);
+    if (credentialsProvider == null) {
+      this.proxyUsername = null;
+      this.proxyPassword = null;
+    } else {
+      Map<String, String> credentials = credentialsProvider.getCredentials() == null ? new HashMap<>() : credentialsProvider.getCredentials();
+      this.proxyUsername = credentials.get(OAuthTokenCredentials.PROXY_USERNAME);
+      this.proxyPassword = credentials.get(OAuthTokenCredentials.PROXY_PASSWORD);
+    }
+  }
+
+  public String getProxyUsername() {
+    return proxyUsername;
+  }
+
+  public String getProxyPassword() {
+    return proxyPassword;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/oauth/OAuthTokenCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/oauth/OAuthTokenCredentials.java
@@ -32,6 +32,8 @@ public class OAuthTokenCredentials extends UsernamePasswordCredentials {
   public static final String ACCESS_TOKEN = "accessToken";
   public static final String REFRESH_TOKEN = "refreshToken";
   public static final String TOKEN_URI = "tokenURI";
+  public static final String PROXY_USERNAME = "proxyUsername";
+  public static final String PROXY_PASSWORD = "proxyPassword";
 
   private final String clientID;
   private final String clientSecret;


### PR DESCRIPTION
# [DRILL-8161](https://issues.apache.org/jira/browse/DRILL-8161): Add Global Credentials to HTTP Storage Plugin

## Description
Currently, Drill forces to you set username and passwords individually for every API endpoint in a http storage plugin.  This PR allows you to set global credentials which will be used for all endpoints in a given HTTP storage plugin instance.

## Documentation
Users can now add a credential provider to an HTTP Storage Plugin configuration and these credentials will be applied to every endpoint in that instance.  However, if credentials are supplied in an endpoint, those credentials override the global credentials. 

## Testing
Added assertions to existing unit tests to make sure that the correct credentials are going to the connection. 