### PR TITLE
DRILL-8162: Add OpenAPI Specification documentation for Drill's REST API

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -18,8 +18,7 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>exec-parent</artifactId>
@@ -423,12 +422,12 @@
           <artifactId>log4j</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-all</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -811,9 +810,7 @@
           <execution> <!-- copy all templates/data in the same location to compile them at once -->
             <id>copy-fmpp-resources</id>
             <phase>initialize</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
+            <goals><goal>copy-resources</goal></goals>
             <configuration>
               <outputDirectory>${project.build.directory}/codegen</outputDirectory>
               <resources>
@@ -830,8 +827,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
-          <!-- Extract parser grammar template from calcite-core.jar and put
-            it under ${project.build.directory}/codegen/templates where all freemarker templates are. -->
+        <!-- Extract parser grammar template from calcite-core.jar and put
+          it under ${project.build.directory}/codegen/templates where all freemarker templates are. -->
           <execution>
             <id>unpack-parser-template</id>
             <phase>initialize</phase>
@@ -852,8 +849,8 @@
             </configuration>
           </execution>
 
-          <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put
-            it under ${project.build.directory}/codegen/data where all freemarker data files are. -->
+        <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put
+          it under ${project.build.directory}/codegen/data where all freemarker data files are. -->
           <execution>
             <id>unpack-vector-types</id>
             <phase>initialize</phase>
@@ -885,8 +882,7 @@
             <id>generate-fmpp</id>
             <phase>generate-sources</phase>
             <goals>
-              <goal>generate</goal>
-            </goals>
+              <goal>generate</goal></goals>
             <configuration>
               <config>${project.build.directory}/codegen/config.fmpp</config>
               <output>${project.build.directory}/generated-sources</output>
@@ -903,9 +899,7 @@
           <execution>
             <id>javacc</id>
             <phase>generate-sources</phase>
-            <goals>
-              <goal>javacc</goal>
-            </goals>
+            <goals><goal>javacc</goal></goals>
             <configuration>
               <sourceDirectory>${project.build.directory}/generated-sources/</sourceDirectory>
               <includes>
@@ -914,11 +908,11 @@
               <lookAhead>2</lookAhead>
               <isStatic>false</isStatic>
               <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
-              <!--
-                            <debugParser>true</debugParser>
-                            <debugLookAhead>true</debugLookAhead>
-                            <debugTokenManager>true</debugTokenManager>
-               -->
+<!--
+              <debugParser>true</debugParser>
+              <debugLookAhead>true</debugLookAhead>
+              <debugTokenManager>true</debugTokenManager>
+ -->
             </configuration>
           </execution>
         </executions>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -18,7 +18,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>exec-parent</artifactId>
@@ -422,12 +423,12 @@
           <artifactId>log4j</artifactId>
         </exclusion>
         <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
         <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -810,7 +811,9 @@
           <execution> <!-- copy all templates/data in the same location to compile them at once -->
             <id>copy-fmpp-resources</id>
             <phase>initialize</phase>
-            <goals><goal>copy-resources</goal></goals>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
             <configuration>
               <outputDirectory>${project.build.directory}/codegen</outputDirectory>
               <resources>
@@ -827,8 +830,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
-        <!-- Extract parser grammar template from calcite-core.jar and put
-          it under ${project.build.directory}/codegen/templates where all freemarker templates are. -->
+          <!-- Extract parser grammar template from calcite-core.jar and put
+            it under ${project.build.directory}/codegen/templates where all freemarker templates are. -->
           <execution>
             <id>unpack-parser-template</id>
             <phase>initialize</phase>
@@ -849,8 +852,8 @@
             </configuration>
           </execution>
 
-        <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put
-          it under ${project.build.directory}/codegen/data where all freemarker data files are. -->
+          <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put
+            it under ${project.build.directory}/codegen/data where all freemarker data files are. -->
           <execution>
             <id>unpack-vector-types</id>
             <phase>initialize</phase>
@@ -881,7 +884,9 @@
           <execution>
             <id>generate-fmpp</id>
             <phase>generate-sources</phase>
-            <goals><goal>generate</goal></goals>
+            <goals>
+              <goal>generate</goal>
+            </goals>
             <configuration>
               <config>${project.build.directory}/codegen/config.fmpp</config>
               <output>${project.build.directory}/generated-sources</output>
@@ -898,7 +903,9 @@
           <execution>
             <id>javacc</id>
             <phase>generate-sources</phase>
-            <goals><goal>javacc</goal></goals>
+            <goals>
+              <goal>javacc</goal>
+            </goals>
             <configuration>
               <sourceDirectory>${project.build.directory}/generated-sources/</sourceDirectory>
               <includes>
@@ -907,11 +914,11 @@
               <lookAhead>2</lookAhead>
               <isStatic>false</isStatic>
               <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
-<!--
-              <debugParser>true</debugParser>
-              <debugLookAhead>true</debugLookAhead>
-              <debugTokenManager>true</debugTokenManager>
- -->
+              <!--
+                            <debugParser>true</debugParser>
+                            <debugLookAhead>true</debugLookAhead>
+                            <debugTokenManager>true</debugTokenManager>
+               -->
             </configuration>
           </execution>
         </executions>
@@ -996,7 +1003,6 @@
       </plugins>
     </pluginManagement>
   </build>
-
 
 
 </project>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -650,6 +650,24 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.rdblue</groupId>
+      <artifactId>brotli-codec</artifactId>
+      <version>0.1.1</version>
+      <!-- brotli-codec bundles natives for linux and darwin, amd64 only so
+      we don't ship it so as not to break startup on windows or arm -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-jaxrs2</artifactId>
+      <version>${swagger.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+      <version>${swagger.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -21,12 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonMappingExceptionMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
-import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.cache.FileTemplateLoader;
@@ -81,12 +79,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 @OpenAPIDefinition(info = @Info(
-  title = "My OpenApi Title", description = "My API Description", license = @License(name = "Apache 2.0", url = "http://some.url"),
-  contact = @Contact(url = "http://some-url.com", name = "MyName", email = "myemail@gmail.com")
-),
+  title = "Apache Drill REST API", description = "OpenAPI Specification", license = @License(name = "Apache Software Foundation (ASF)", url = "http://www.apache" +
+  ".org/licenses/LICENSE-2.0"),
+  contact = @Contact(name = "Apache Drill", url = "https://drill.apache.org/")
+))/*,
 tags = {
   @Tag(name = "My Tag 1", description = "Tag 1's Description", externalDocs = @ExternalDocumentation(description = "docs description1")),
-  @Tag(name = "My Tag 2", description = "Tag 2's Description", externalDocs = @ExternalDocumentation(description = "docs description2"))})
+  @Tag(name = "My Tag 2", description = "Tag 2's Description", externalDocs = @ExternalDocumentation(description = "docs description2"))})*/
 
 public class DrillRestServer extends ResourceConfig {
   static final Logger logger = LoggerFactory.getLogger(DrillRestServer.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -78,14 +78,9 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
-@OpenAPIDefinition(info = @Info(
-  title = "Apache Drill REST API", description = "OpenAPI Specification", license = @License(name = "Apache Software Foundation (ASF)", url = "http://www.apache" +
-  ".org/licenses/LICENSE-2.0"),
-  contact = @Contact(name = "Apache Drill", url = "https://drill.apache.org/")
-))/*,
-tags = {
-  @Tag(name = "My Tag 1", description = "Tag 1's Description", externalDocs = @ExternalDocumentation(description = "docs description1")),
-  @Tag(name = "My Tag 2", description = "Tag 2's Description", externalDocs = @ExternalDocumentation(description = "docs description2"))})*/
+@OpenAPIDefinition(info = @Info(title = "Apache Drill REST API", description = "OpenAPI Specification",
+  license = @License(name = "Apache Software Foundation (ASF)", url = "http://www.apache" + ".org/licenses/LICENSE-2.0"),
+  contact = @Contact(name = "Apache Drill", url = "https://drill.apache.org/")))
 
 public class DrillRestServer extends ResourceConfig {
   static final Logger logger = LoggerFactory.getLogger(DrillRestServer.class);
@@ -106,8 +101,7 @@ public class DrillRestServer extends ResourceConfig {
     register(MultiPartFeature.class);
     property(ServerProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
 
-    final boolean isAuthEnabled =
-        workManager.getContext().getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED);
+    final boolean isAuthEnabled = workManager.getContext().getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED);
 
     if (isAuthEnabled) {
       register(LogInLogOutResources.class);
@@ -116,8 +110,7 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     //disable moxy so it doesn't conflict with jackson.
-    final String disableMoxy = PropertiesHelper.getPropertyNameForRuntime(CommonProperties.MOXY_JSON_FEATURE_DISABLE,
-        getConfiguration().getRuntimeType());
+    final String disableMoxy = PropertiesHelper.getPropertyNameForRuntime(CommonProperties.MOXY_JSON_FEATURE_DISABLE, getConfiguration().getRuntimeType());
     property(disableMoxy, true);
 
     register(JsonParseExceptionMapper.class);
@@ -204,20 +197,15 @@ public class DrillRestServer extends ResourceConfig {
       }
 
       // User is logged in, get/set the WebSessionResources attribute
-      WebSessionResources webSessionResources =
-              (WebSessionResources) session.getAttribute(WebSessionResources.class.getSimpleName());
+      WebSessionResources webSessionResources = (WebSessionResources) session.getAttribute(WebSessionResources.class.getSimpleName());
 
       if (webSessionResources == null) {
         // User is login in for the first time
         final DrillbitContext drillbitContext = workManager.getContext();
         final DrillConfig config = drillbitContext.getConfig();
-        final UserSession drillUserSession = UserSession.Builder.newBuilder()
-                .withCredentials(UserBitShared.UserCredentials.newBuilder()
-                        .setUserName(sessionUserPrincipal.getName())
-                        .build())
-                .withOptionManager(drillbitContext.getOptionManager())
-                .setSupportComplexTypes(config.getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES))
-                .build();
+        final UserSession drillUserSession = UserSession.Builder.newBuilder().withCredentials(UserBitShared.UserCredentials.newBuilder()
+          .setUserName(sessionUserPrincipal.getName()).build()).withOptionManager(drillbitContext.getOptionManager())
+          .setSupportComplexTypes(config.getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES)).build();
 
         // Only try getting remote address in first login since it's a costly operation.
         SocketAddress remoteAddress = null;
@@ -232,10 +220,9 @@ public class DrillRestServer extends ResourceConfig {
 
         // Create per session BufferAllocator and set it in session
         final String sessionAllocatorName = String.format("WebServer:AuthUserSession:%s", session.getId());
-        final BufferAllocator sessionAllocator = workManager.getContext().getAllocator().newChildAllocator(
-                sessionAllocatorName,
-                config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
-                config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
+        final BufferAllocator sessionAllocator = workManager.getContext().getAllocator()
+          .newChildAllocator(sessionAllocatorName, config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
+            config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
 
         // Create a future which is needed by Foreman only. Foreman uses this future to add a close
         // listener to known about channel close event from underlying layer. We use this future to notify Foreman
@@ -253,7 +240,8 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(WebUserConnection instance) { }
+    public void dispose(WebUserConnection instance) {
+    }
   }
 
   public static class AnonWebUserConnectionProvider implements Factory<WebUserConnection> {
@@ -273,21 +261,15 @@ public class DrillRestServer extends ResourceConfig {
       final DrillConfig config = drillbitContext.getConfig();
 
       // Create an allocator here for each request
-      final BufferAllocator sessionAllocator = drillbitContext.getAllocator()
-              .newChildAllocator("WebServer:AnonUserSession",
-                      config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
-                      config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
+      final BufferAllocator sessionAllocator = drillbitContext.getAllocator().newChildAllocator("WebServer:AnonUserSession",
+        config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION), config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
 
       final Principal sessionUserPrincipal = createSessionUserPrincipal(config, request);
 
       // Create new UserSession for each request from non-authenticated user
-      final UserSession drillUserSession = UserSession.Builder.newBuilder()
-              .withCredentials(UserBitShared.UserCredentials.newBuilder()
-                      .setUserName(sessionUserPrincipal.getName())
-                      .build())
-              .withOptionManager(drillbitContext.getOptionManager())
-              .setSupportComplexTypes(drillbitContext.getConfig().getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES))
-              .build();
+      final UserSession drillUserSession = UserSession.Builder.newBuilder().withCredentials(UserBitShared.UserCredentials.newBuilder()
+        .setUserName(sessionUserPrincipal.getName()).build()).withOptionManager(drillbitContext.getOptionManager())
+        .setSupportComplexTypes(drillbitContext.getConfig().getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES)).build();
 
       // Try to get the remote Address but set it to null in case of failure.
       SocketAddress remoteAddress = null;
@@ -306,15 +288,15 @@ public class DrillRestServer extends ResourceConfig {
       // But we need this close future as it's expected by Foreman.
       final Promise<Void> closeFuture = new DefaultPromise(executor);
 
-      final WebSessionResources webSessionResources = new WebSessionResources(sessionAllocator, remoteAddress,
-          drillUserSession, closeFuture);
+      final WebSessionResources webSessionResources = new WebSessionResources(sessionAllocator, remoteAddress, drillUserSession, closeFuture);
 
       // Create a AnonWenUserConnection for this request
       return new AnonWebUserConnection(webSessionResources);
     }
 
     @Override
-    public void dispose(WebUserConnection instance) { }
+    public void dispose(WebUserConnection instance) {
+    }
 
     /**
      * Creates session user principal. If impersonation is enabled without
@@ -323,7 +305,7 @@ public class DrillRestServer extends ResourceConfig {
      * name will be used. In both cases session user principal will have admin
      * rights.
      *
-     * @param config drill config
+     * @param config  drill config
      * @param request client request
      * @return session user principal
      */
@@ -344,7 +326,8 @@ public class DrillRestServer extends ResourceConfig {
    */
   public static class DrillUserPrincipalProvider implements Factory<DrillUserPrincipal> {
 
-    @Inject HttpServletRequest request;
+    @Inject
+    HttpServletRequest request;
 
     @Override
     public DrillUserPrincipal provide() {
@@ -352,7 +335,8 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(DrillUserPrincipal principal) { }
+    public void dispose(DrillUserPrincipal principal) {
+    }
   }
 
   // Provider which creates and cleanups DrillUserPrincipal for anonymous (auth disabled) mode

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -101,7 +101,8 @@ public class DrillRestServer extends ResourceConfig {
     register(MultiPartFeature.class);
     property(ServerProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
 
-    final boolean isAuthEnabled = workManager.getContext().getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED);
+    final boolean isAuthEnabled =
+      workManager.getContext().getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED);
 
     if (isAuthEnabled) {
       register(LogInLogOutResources.class);
@@ -110,7 +111,8 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     //disable moxy so it doesn't conflict with jackson.
-    final String disableMoxy = PropertiesHelper.getPropertyNameForRuntime(CommonProperties.MOXY_JSON_FEATURE_DISABLE, getConfiguration().getRuntimeType());
+    final String disableMoxy = PropertiesHelper.getPropertyNameForRuntime(CommonProperties.MOXY_JSON_FEATURE_DISABLE,
+      getConfiguration().getRuntimeType());
     property(disableMoxy, true);
 
     register(JsonParseExceptionMapper.class);
@@ -197,15 +199,20 @@ public class DrillRestServer extends ResourceConfig {
       }
 
       // User is logged in, get/set the WebSessionResources attribute
-      WebSessionResources webSessionResources = (WebSessionResources) session.getAttribute(WebSessionResources.class.getSimpleName());
+      WebSessionResources webSessionResources =
+        (WebSessionResources) session.getAttribute(WebSessionResources.class.getSimpleName());
 
       if (webSessionResources == null) {
         // User is login in for the first time
         final DrillbitContext drillbitContext = workManager.getContext();
         final DrillConfig config = drillbitContext.getConfig();
-        final UserSession drillUserSession = UserSession.Builder.newBuilder().withCredentials(UserBitShared.UserCredentials.newBuilder()
-          .setUserName(sessionUserPrincipal.getName()).build()).withOptionManager(drillbitContext.getOptionManager())
-          .setSupportComplexTypes(config.getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES)).build();
+        final UserSession drillUserSession = UserSession.Builder.newBuilder()
+          .withCredentials(UserBitShared.UserCredentials.newBuilder()
+            .setUserName(sessionUserPrincipal.getName())
+            .build())
+          .withOptionManager(drillbitContext.getOptionManager())
+          .setSupportComplexTypes(config.getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES))
+          .build();
 
         // Only try getting remote address in first login since it's a costly operation.
         SocketAddress remoteAddress = null;
@@ -220,8 +227,9 @@ public class DrillRestServer extends ResourceConfig {
 
         // Create per session BufferAllocator and set it in session
         final String sessionAllocatorName = String.format("WebServer:AuthUserSession:%s", session.getId());
-        final BufferAllocator sessionAllocator = workManager.getContext().getAllocator()
-          .newChildAllocator(sessionAllocatorName, config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
+        final BufferAllocator sessionAllocator = workManager.getContext().getAllocator().newChildAllocator(
+            sessionAllocatorName,
+            config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
             config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
 
         // Create a future which is needed by Foreman only. Foreman uses this future to add a close
@@ -240,8 +248,7 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(WebUserConnection instance) {
-    }
+    public void dispose(WebUserConnection instance) { }
   }
 
   public static class AnonWebUserConnectionProvider implements Factory<WebUserConnection> {
@@ -261,15 +268,21 @@ public class DrillRestServer extends ResourceConfig {
       final DrillConfig config = drillbitContext.getConfig();
 
       // Create an allocator here for each request
-      final BufferAllocator sessionAllocator = drillbitContext.getAllocator().newChildAllocator("WebServer:AnonUserSession",
-        config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION), config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
+      final BufferAllocator sessionAllocator = drillbitContext.getAllocator()
+        .newChildAllocator("WebServer:AnonUserSession",
+          config.getLong(ExecConstants.HTTP_SESSION_MEMORY_RESERVATION),
+          config.getLong(ExecConstants.HTTP_SESSION_MEMORY_MAXIMUM));
 
       final Principal sessionUserPrincipal = createSessionUserPrincipal(config, request);
 
       // Create new UserSession for each request from non-authenticated user
-      final UserSession drillUserSession = UserSession.Builder.newBuilder().withCredentials(UserBitShared.UserCredentials.newBuilder()
-        .setUserName(sessionUserPrincipal.getName()).build()).withOptionManager(drillbitContext.getOptionManager())
-        .setSupportComplexTypes(drillbitContext.getConfig().getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES)).build();
+      final UserSession drillUserSession = UserSession.Builder.newBuilder()
+          .withCredentials(UserBitShared.UserCredentials.newBuilder()
+              .setUserName(sessionUserPrincipal.getName())
+              .build())
+          .withOptionManager(drillbitContext.getOptionManager())
+          .setSupportComplexTypes(drillbitContext.getConfig().getBoolean(ExecConstants.CLIENT_SUPPORT_COMPLEX_TYPES))
+          .build();
 
       // Try to get the remote Address but set it to null in case of failure.
       SocketAddress remoteAddress = null;
@@ -288,15 +301,15 @@ public class DrillRestServer extends ResourceConfig {
       // But we need this close future as it's expected by Foreman.
       final Promise<Void> closeFuture = new DefaultPromise(executor);
 
-      final WebSessionResources webSessionResources = new WebSessionResources(sessionAllocator, remoteAddress, drillUserSession, closeFuture);
+      final WebSessionResources webSessionResources = new WebSessionResources(sessionAllocator, remoteAddress,
+        drillUserSession, closeFuture);
 
       // Create a AnonWenUserConnection for this request
       return new AnonWebUserConnection(webSessionResources);
     }
 
     @Override
-    public void dispose(WebUserConnection instance) {
-    }
+    public void dispose(WebUserConnection instance) { }
 
     /**
      * Creates session user principal. If impersonation is enabled without
@@ -305,7 +318,7 @@ public class DrillRestServer extends ResourceConfig {
      * name will be used. In both cases session user principal will have admin
      * rights.
      *
-     * @param config  drill config
+     * @param config drill config
      * @param request client request
      * @return session user principal
      */
@@ -326,8 +339,7 @@ public class DrillRestServer extends ResourceConfig {
    */
   public static class DrillUserPrincipalProvider implements Factory<DrillUserPrincipal> {
 
-    @Inject
-    HttpServletRequest request;
+    @Inject HttpServletRequest request;
 
     @Override
     public DrillUserPrincipal provide() {
@@ -335,8 +347,7 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(DrillUserPrincipal principal) {
-    }
+    public void dispose(DrillUserPrincipal principal) { }
   }
 
   // Provider which creates and cleanups DrillUserPrincipal for anonymous (auth disabled) mode

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -31,6 +31,7 @@ import freemarker.core.HTMLOutputFormat;
 import freemarker.template.Configuration;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Promise;
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.netty.util.concurrent.EventExecutor;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
@@ -140,6 +141,8 @@ public class DrillRestServer extends ResourceConfig {
         }
       }
     });
+
+    register(OpenApiResource.class);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -21,6 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonMappingExceptionMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.cache.FileTemplateLoader;
@@ -73,6 +79,14 @@ import java.net.SocketAddress;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
+
+@OpenAPIDefinition(info = @Info(
+  title = "My OpenApi Title", description = "My API Description", license = @License(name = "Apache 2.0", url = "http://some.url"),
+  contact = @Contact(url = "http://some-url.com", name = "MyName", email = "myemail@gmail.com")
+),
+tags = {
+  @Tag(name = "My Tag 1", description = "Tag 1's Description", externalDocs = @ExternalDocumentation(description = "docs description1")),
+  @Tag(name = "My Tag 2", description = "Tag 2's Description", externalDocs = @ExternalDocumentation(description = "docs description2"))})
 
 public class DrillRestServer extends ResourceConfig {
   static final Logger logger = LoggerFactory.getLogger(DrillRestServer.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -36,8 +36,8 @@ import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
@@ -105,6 +105,8 @@ public class DrillRoot {
   @GET
   @Path("/gracePeriod")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "  https://drill.apache.org/docs/stopping-drill/#:~:text=draining%2C%20and%20offline.%0A%20%20%20%20%20--,grace,-%3A%20A%20period%20in"))
+
   public Map<String, Integer> getGracePeriod() {
     final DrillConfig config = work.getContext().getConfig();
     final int gracePeriod = config.getInt(ExecConstants.GRACE_PERIOD);
@@ -128,6 +130,8 @@ public class DrillRoot {
   @GET
   @Path("/queriesCount")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/apidocs/org/apache/drill/exec/work/WorkManager.html#:~:text=waitToExit(boolean%C2%A0forcefulShutdown)-,getremainingqueries,-public%C2%A0Map%3CString"))
+
   public Response getRemainingQueries() {
     Map<String, Integer> queriesInfo = work.getRemainingQueries();
     return setResponse(queriesInfo);
@@ -137,6 +141,8 @@ public class DrillRoot {
   @Path("/gracefulShutdown")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public Response shutdownDrillbit() throws Exception {
     String resp = "Graceful Shutdown request is triggered";
     return shutdown(resp);
@@ -146,6 +152,8 @@ public class DrillRoot {
   @Path("/gracefulShutdown/{hostname}")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public String shutdownDrillbitByName(@PathParam("hostname") String hostname) throws Exception {
     URL shutdownURL = WebUtils.getDrillbitURL(work, request, hostname, "/gracefulShutdown");
     return WebUtils.doHTTPRequest(new HttpPost(shutdownURL.toURI()), work.getContext().getConfig());
@@ -155,6 +163,8 @@ public class DrillRoot {
   @Path("/shutdown")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public Response shutdownForcefully() throws Exception {
     drillbit.setForcefulShutdown(true);
     String resp = "Forceful shutdown request is triggered";
@@ -165,9 +175,8 @@ public class DrillRoot {
   @Path("/quiescent")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
-  @Operation(summary="My summary", tags={"my tags"}, responses = {
-    @ApiResponse(description = "my description for response")
-  })
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public Response drillbitToQuiescentMode() throws Exception {
     drillbit.setQuiescentMode(true);
     String resp = "Request to put drillbit in Quiescent mode is triggered";
@@ -177,6 +186,8 @@ public class DrillRoot {
   @GET
   @Path("/cluster.json")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=Gets%20metric%20information.-,get%20%2Fcluster.json,-Get%20Drillbit%20information"))
+
   public ClusterInfo getClusterInfoJSON() {
     final Collection<DrillbitInfo> drillbits = Sets.newTreeSet();
     final Collection<String> mismatchedVersions = Sets.newTreeSet();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -36,6 +36,8 @@ import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
@@ -163,6 +165,9 @@ public class DrillRoot {
   @Path("/quiescent")
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
+  @Operation(summary="My summary", tags={"my tags"}, responses = {
+    @ApiResponse(description = "my description for response")
+  })
   public Response drillbitToQuiescentMode() throws Exception {
     drillbit.setQuiescentMode(true);
     String resp = "Request to put drillbit in Quiescent mode is triggered";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -74,12 +74,16 @@ public class DrillRoot {
 
   @Inject
   UserAuthEnabled authEnabled;
+
   @Inject
   WorkManager work;
+
   @Inject
   SecurityContext sc;
+
   @Inject
   Drillbit drillbit;
+
   @Inject
   HttpServletRequest request;
 
@@ -105,8 +109,7 @@ public class DrillRoot {
   @GET
   @Path("/gracePeriod")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "  https://drill.apache.org/docs/stopping-drill/#:~:text=draining%2C%20and%20offline.%0A%20%20%20%20%20--,grace,-%3A%20A%20period%20in"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "  https://drill.apache.org/docs/stopping-drill/"))
   public Map<String, Integer> getGracePeriod() {
     final DrillConfig config = work.getContext().getConfig();
     final int gracePeriod = config.getInt(ExecConstants.GRACE_PERIOD);
@@ -130,8 +133,8 @@ public class DrillRoot {
   @GET
   @Path("/queriesCount")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/apidocs/org/apache/drill/exec/work/WorkManager.html#:~:text=waitToExit(boolean%C2%A0forcefulShutdown)-,getremainingqueries,-public%C2%A0Map%3CString"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/apidocs/org/apache/drill/exec/work" +
+    "/WorkManager.html"))
   public Response getRemainingQueries() {
     Map<String, Integer> queriesInfo = work.getRemainingQueries();
     return setResponse(queriesInfo);
@@ -142,7 +145,6 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
-
   public Response shutdownDrillbit() throws Exception {
     String resp = "Graceful Shutdown request is triggered";
     return shutdown(resp);
@@ -153,7 +155,6 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
-
   public String shutdownDrillbitByName(@PathParam("hostname") String hostname) throws Exception {
     URL shutdownURL = WebUtils.getDrillbitURL(work, request, hostname, "/gracefulShutdown");
     return WebUtils.doHTTPRequest(new HttpPost(shutdownURL.toURI()), work.getContext().getConfig());
@@ -164,7 +165,6 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
-
   public Response shutdownForcefully() throws Exception {
     drillbit.setForcefulShutdown(true);
     String resp = "Forceful shutdown request is triggered";
@@ -176,7 +176,6 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
-
   public Response drillbitToQuiescentMode() throws Exception {
     drillbit.setQuiescentMode(true);
     String resp = "Request to put drillbit in Quiescent mode is triggered";
@@ -186,8 +185,7 @@ public class DrillRoot {
   @GET
   @Path("/cluster.json")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=Gets%20metric%20information.-,get%20%2Fcluster.json,-Get%20Drillbit%20information"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public ClusterInfo getClusterInfoJSON() {
     final Collection<DrillbitInfo> drillbits = Sets.newTreeSet();
     final Collection<String> mismatchedVersions = Sets.newTreeSet();
@@ -197,19 +195,15 @@ public class DrillRoot {
     final String currentVersion = currentDrillbit.getVersion();
 
     final DrillConfig config = dbContext.getConfig();
-    final boolean userEncryptionEnabled =
-            config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) ||
-                    config .getBoolean(ExecConstants.USER_SSL_ENABLED);
+    final boolean userEncryptionEnabled = config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) || config.getBoolean(ExecConstants.USER_SSL_ENABLED);
     final boolean bitEncryptionEnabled = config.getBoolean(ExecConstants.BIT_ENCRYPTION_SASL_ENABLED);
 
     OptionManager optionManager = work.getContext().getOptionManager();
     final boolean isUserLoggedIn = AuthDynamicFeature.isUserLoggedIn(sc);
-    final boolean shouldShowAdminInfo = isUserLoggedIn && ((DrillUserPrincipal)sc.getUserPrincipal()).isAdminUser();
+    final boolean shouldShowAdminInfo = isUserLoggedIn && ((DrillUserPrincipal) sc.getUserPrincipal()).isAdminUser();
 
     for (DrillbitEndpoint endpoint : work.getContext().getAvailableBits()) {
-      final DrillbitInfo drillbit = new DrillbitInfo(endpoint,
-              isDrillbitsTheSame(currentDrillbit, endpoint),
-              currentVersion.equals(endpoint.getVersion()));
+      final DrillbitInfo drillbit = new DrillbitInfo(endpoint, isDrillbitsTheSame(currentDrillbit, endpoint), currentVersion.equals(endpoint.getVersion()));
       if (!drillbit.isVersionMatch()) {
         mismatchedVersions.add(drillbit.getVersion());
       }
@@ -224,18 +218,13 @@ public class DrillRoot {
       String adminUsers = ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(optionManager);
       String adminUserGroups = ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(optionManager);
 
-      logger.debug("Admin info: user: "  + adminUsers +  " user group: " + adminUserGroups +
-          " userLoggedIn "  + isUserLoggedIn + " shouldShowAdminInfo: " + shouldShowAdminInfo);
+      logger.debug("Admin info: user: {} user group: {} userLoggedIn {} shouldShowAdminInfo: {}",
+      adminUsers, adminUserGroups, isUserLoggedIn, shouldShowAdminInfo);
 
-      return new ClusterInfo(drillbits, currentVersion, mismatchedVersions,
-          userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo,
-          QueueInfo.build(dbContext.getResourceManager()),
-          processUser, processUserGroups, adminUsers, adminUserGroups, authEnabled.get());
+      return new ClusterInfo(drillbits, currentVersion, mismatchedVersions, userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo, QueueInfo.build(dbContext.getResourceManager()), processUser, processUserGroups, adminUsers, adminUserGroups, authEnabled.get());
     }
 
-    return new ClusterInfo(drillbits, currentVersion, mismatchedVersions,
-        userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo,
-        QueueInfo.build(dbContext.getResourceManager()), authEnabled.get());
+    return new ClusterInfo(drillbits, currentVersion, mismatchedVersions, userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo, QueueInfo.build(dbContext.getResourceManager()), authEnabled.get());
   }
 
   /**
@@ -246,278 +235,300 @@ public class DrillRoot {
    * @return true if drillbit are the same
    */
   private boolean isDrillbitsTheSame(DrillbitEndpoint endpoint1, DrillbitEndpoint endpoint2) {
-    return endpoint1.getAddress().equals(endpoint2.getAddress()) &&
-        endpoint1.getControlPort() == endpoint2.getControlPort() &&
-        endpoint1.getDataPort() == endpoint2.getDataPort() &&
-        endpoint1.getUserPort() == endpoint2.getUserPort();
+    return endpoint1.getAddress().equals(endpoint2.getAddress()) && endpoint1.getControlPort() == endpoint2.getControlPort() && endpoint1.getDataPort() == endpoint2.getDataPort() && endpoint1.getUserPort() == endpoint2.getUserPort();
   }
 
   private Response setResponse(Map<String, ?> entity) {
-    return Response.ok()
-            .entity(entity)
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT")
-            .header("Access-Control-Allow-Credentials","true")
-            .allow("OPTIONS").build();
+    return Response.ok().entity(entity).header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT").header("Access-Control-Allow-Credentials", "true").allow("OPTIONS").build();
   }
 
   private Response shutdown(String resp) throws Exception {
     Map<String, String> shutdownInfo = new HashMap<String, String>();
     new Thread(new Runnable() {
-        @Override
-        public void run() {
-          try {
-            drillbit.close();
-          } catch (Exception e) {
-            logger.error("Request to shutdown drillbit failed", e);
-          }
+      @Override
+      public void run() {
+        try {
+          drillbit.close();
+        } catch (Exception e) {
+          logger.error("Request to shutdown drillbit failed", e);
         }
-      }).start();
-    shutdownInfo.put("response",resp);
+      }
+    }).start();
+    shutdownInfo.put("response", resp);
     return setResponse(shutdownInfo);
   }
 
-/**
- * Pretty-printing wrapper class around the ZK-based queue summary.
- */
-
-@XmlRootElement
-public static class QueueInfo {
-  private final ZKQueueInfo zkQueueInfo;
-
-  public static QueueInfo build(ResourceManager rm) {
-
-    // Consider queues enabled only if the ZK-based queues are in use.
-
-    ThrottledResourceManager throttledRM = null;
-    if (rm != null && rm instanceof DynamicResourceManager) {
-      DynamicResourceManager dynamicRM = (DynamicResourceManager) rm;
-      rm = dynamicRM.activeRM();
-    }
-    if (rm != null && rm instanceof ThrottledResourceManager) {
-      throttledRM = (ThrottledResourceManager) rm;
-    }
-    if (throttledRM == null) {
-      return new QueueInfo(null);
-    }
-    QueryQueue queue = throttledRM.queue();
-    if (queue == null || !(queue instanceof DistributedQueryQueue)) {
-      return new QueueInfo(null);
-    }
-
-    return new QueueInfo(((DistributedQueryQueue) queue).getInfo());
-  }
-
-  @JsonCreator
-  public QueueInfo(ZKQueueInfo queueInfo) {
-    zkQueueInfo = queueInfo;
-  }
-
-  public boolean isEnabled() { return zkQueueInfo != null; }
-
-  public int smallQueueSize() {
-    return isEnabled() ? zkQueueInfo.smallQueueSize : 0;
-  }
-
-  public int largeQueueSize() {
-    return isEnabled() ? zkQueueInfo.largeQueueSize : 0;
-  }
-
-  public String threshold() {
-    return isEnabled()
-            ? Double.toString(zkQueueInfo.queueThreshold)
-            : "N/A";
-  }
-
-  public String smallQueueMemory() {
-    return isEnabled()
-            ? toBytes(zkQueueInfo.memoryPerSmallQuery)
-            : "N/A";
-  }
-
-  public String largeQueueMemory() {
-    return isEnabled()
-            ? toBytes(zkQueueInfo.memoryPerLargeQuery)
-            : "N/A";
-  }
-
-  public String totalMemory() {
-    return isEnabled()
-            ? toBytes(zkQueueInfo.memoryPerNode)
-            : "N/A";
-  }
-
-  private final long ONE_MB = 1024 * 1024;
-
-  private String toBytes(long memory) {
-    if (memory < 10 * ONE_MB) {
-      return String.format("%,d bytes", memory);
-    } else {
-      return String.format("%,.0f MB", memory * 1.0D / ONE_MB);
-    }
-  }
-}
-
-@XmlRootElement
-@JsonInclude(JsonInclude.Include.NON_ABSENT)
-public static class ClusterInfo {
-  private final Collection<DrillbitInfo> drillbits;
-  private final String currentVersion;
-  private final Collection<String> mismatchedVersions;
-  private final boolean userEncryptionEnabled;
-  private final boolean bitEncryptionEnabled;
-  private final boolean shouldShowAdminInfo;
-  private final boolean authEnabled;
-  private final QueueInfo queueInfo;
-
-  private String adminUsers;
-  private String adminUserGroups;
-  private String processUser;
-  private String processUserGroups;
-
-  @JsonCreator
-  public ClusterInfo(Collection<DrillbitInfo> drillbits,
-                     String currentVersion,
-                     Collection<String> mismatchedVersions,
-                     boolean userEncryption,
-                     boolean bitEncryption,
-                     boolean shouldShowAdminInfo,
-                     QueueInfo queueInfo,
-                     boolean authEnabled) {
-    this.drillbits = Sets.newTreeSet(drillbits);
-    this.currentVersion = currentVersion;
-    this.mismatchedVersions = Sets.newTreeSet(mismatchedVersions);
-    this.userEncryptionEnabled = userEncryption;
-    this.bitEncryptionEnabled = bitEncryption;
-    this.shouldShowAdminInfo = shouldShowAdminInfo;
-    this.queueInfo = queueInfo;
-    this.authEnabled = authEnabled;
-  }
-
-  @JsonCreator
-  public ClusterInfo(Collection<DrillbitInfo> drillbits,
-                     String currentVersion,
-                     Collection<String> mismatchedVersions,
-                     boolean userEncryption,
-                     boolean bitEncryption,
-                     boolean shouldShowAdminInfo,
-                     QueueInfo queueInfo,
-                     String processUser,
-                     String processUserGroups,
-                     String adminUsers,
-                     String adminUserGroups,
-                     boolean authEnabled) {
-    this(drillbits, currentVersion, mismatchedVersions, userEncryption, bitEncryption, shouldShowAdminInfo, queueInfo, authEnabled);
-    this.processUser = processUser;
-    this.processUserGroups = processUserGroups;
-    this.adminUsers = adminUsers;
-    this.adminUserGroups = adminUserGroups;
-  }
-
-  public Collection<DrillbitInfo> getDrillbits() {
-    return Sets.newTreeSet(drillbits);
-  }
-
-  public String getCurrentVersion() {
-    return currentVersion;
-  }
-
-  public Collection<String> getMismatchedVersions() {
-    return Sets.newTreeSet(mismatchedVersions);
-  }
-
-  public boolean isUserEncryptionEnabled() { return userEncryptionEnabled; }
-
-  public boolean isBitEncryptionEnabled() { return bitEncryptionEnabled; }
-
-  public String getProcessUser() { return processUser; }
-
-  public String getProcessUserGroups() { return processUserGroups; }
-
-  public String getAdminUsers() { return adminUsers; }
-
-  public String getAdminUserGroups() { return adminUserGroups; }
-
-  public boolean shouldShowAdminInfo() { return shouldShowAdminInfo; }
-
-  public QueueInfo queueInfo() { return queueInfo; }
-
-  public boolean isAuthEnabled() { return  authEnabled; }
-}
-
-public static class DrillbitInfo implements Comparable<DrillbitInfo> {
-  private final String address;
-  private final String httpPort;
-  private final String userPort;
-  private final String controlPort;
-  private final String dataPort;
-  private final String version;
-  private final boolean current;
-  private final boolean versionMatch;
-  private final String state;
-
-  @JsonCreator
-  public DrillbitInfo(DrillbitEndpoint drillbit, boolean current, boolean versionMatch) {
-    this.address = drillbit.getAddress();
-    this.httpPort = String.valueOf(drillbit.getHttpPort());
-    this.userPort = String.valueOf(drillbit.getUserPort());
-    this.controlPort = String.valueOf(drillbit.getControlPort());
-    this.dataPort = String.valueOf(drillbit.getDataPort());
-    this.version = Strings.isNullOrEmpty(drillbit.getVersion()) ? "Undefined" : drillbit.getVersion();
-    this.current = current;
-    this.versionMatch = versionMatch;
-    this.state = String.valueOf(drillbit.getState());
-  }
-
-  public String getAddress() { return address; }
-
-  public String getHttpPort() { return httpPort; }
-
-  public String getUserPort() { return userPort; }
-
-  public String getControlPort() { return controlPort; }
-
-  public String getDataPort() { return dataPort; }
-
-  public String getVersion() { return version; }
-
-  public boolean isCurrent() { return current; }
-
-  public boolean isVersionMatch() { return versionMatch; }
-
-  public String getState() { return state; }
-
   /**
-   * Method used to sort Drillbits. Current Drillbit goes first.
-   * Then Drillbits with matching versions, after them Drillbits with mismatching versions.
-   * Matching Drillbits are sorted according address natural order,
-   * mismatching Drillbits are sorted according version, address natural order.
-   *
-   * @param drillbitToCompare Drillbit to compare against
-   * @return -1 if Drillbit should be before, 1 if after in list
+   * Pretty-printing wrapper class around the ZK-based queue summary.
    */
-  @Override
-  public int compareTo(DrillbitInfo drillbitToCompare) {
-    if (this.isCurrent()) {
-      return -1;
-    }
 
-    if (drillbitToCompare.isCurrent()) {
-      return 1;
-    }
+  @XmlRootElement
+  public static class QueueInfo {
+    private final ZKQueueInfo zkQueueInfo;
 
-    if (this.isVersionMatch() == drillbitToCompare.isVersionMatch()) {
-      if (this.version.equals(drillbitToCompare.getVersion())) {
-        {
-          if (this.address.equals(drillbitToCompare.getAddress())) {
-            return (this.controlPort.compareTo(drillbitToCompare.getControlPort()));
-          }
-          return (this.address.compareTo(drillbitToCompare.getAddress()));
-        }
+    public static QueueInfo build(ResourceManager rm) {
+
+      // Consider queues enabled only if the ZK-based queues are in use.
+
+      ThrottledResourceManager throttledRM = null;
+      if (rm != null && rm instanceof DynamicResourceManager) {
+        DynamicResourceManager dynamicRM = (DynamicResourceManager) rm;
+        rm = dynamicRM.activeRM();
       }
-      return this.version.compareTo(drillbitToCompare.getVersion());
+      if (rm != null && rm instanceof ThrottledResourceManager) {
+        throttledRM = (ThrottledResourceManager) rm;
+      }
+      if (throttledRM == null) {
+        return new QueueInfo(null);
+      }
+      QueryQueue queue = throttledRM.queue();
+      if (queue == null || !(queue instanceof DistributedQueryQueue)) {
+        return new QueueInfo(null);
+      }
+
+      return new QueueInfo(((DistributedQueryQueue) queue).getInfo());
     }
-    return this.versionMatch ? -1 : 1;
+
+    @JsonCreator
+    public QueueInfo(ZKQueueInfo queueInfo) {
+      zkQueueInfo = queueInfo;
+    }
+
+    public boolean isEnabled() {
+      return zkQueueInfo != null;
+    }
+
+    public int smallQueueSize() {
+      return isEnabled() ? zkQueueInfo.smallQueueSize : 0;
+    }
+
+    public int largeQueueSize() {
+      return isEnabled() ? zkQueueInfo.largeQueueSize : 0;
+    }
+
+    public String threshold() {
+      return isEnabled() ? Double.toString(zkQueueInfo.queueThreshold) : "N/A";
+    }
+
+    public String smallQueueMemory() {
+      return isEnabled() ? toBytes(zkQueueInfo.memoryPerSmallQuery) : "N/A";
+    }
+
+    public String largeQueueMemory() {
+      return isEnabled() ? toBytes(zkQueueInfo.memoryPerLargeQuery) : "N/A";
+    }
+
+    public String totalMemory() {
+      return isEnabled() ? toBytes(zkQueueInfo.memoryPerNode) : "N/A";
+    }
+
+    private final long ONE_MB = 1024 * 1024;
+
+    private String toBytes(long memory) {
+      if (memory < 10 * ONE_MB) {
+        return String.format("%,d bytes", memory);
+      } else {
+        return String.format("%,.0f MB", memory * 1.0D / ONE_MB);
+      }
+    }
   }
-}
+
+  @XmlRootElement
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
+  public static class ClusterInfo {
+    private final Collection<DrillbitInfo> drillbits;
+
+    private final String currentVersion;
+
+    private final Collection<String> mismatchedVersions;
+
+    private final boolean userEncryptionEnabled;
+
+    private final boolean bitEncryptionEnabled;
+
+    private final boolean shouldShowAdminInfo;
+
+    private final boolean authEnabled;
+
+    private final QueueInfo queueInfo;
+
+    private String adminUsers;
+
+    private String adminUserGroups;
+
+    private String processUser;
+
+    private String processUserGroups;
+
+    @JsonCreator
+    public ClusterInfo(Collection<DrillbitInfo> drillbits, String currentVersion, Collection<String> mismatchedVersions, boolean userEncryption, boolean bitEncryption, boolean shouldShowAdminInfo, QueueInfo queueInfo, boolean authEnabled) {
+      this.drillbits = Sets.newTreeSet(drillbits);
+      this.currentVersion = currentVersion;
+      this.mismatchedVersions = Sets.newTreeSet(mismatchedVersions);
+      this.userEncryptionEnabled = userEncryption;
+      this.bitEncryptionEnabled = bitEncryption;
+      this.shouldShowAdminInfo = shouldShowAdminInfo;
+      this.queueInfo = queueInfo;
+      this.authEnabled = authEnabled;
+    }
+
+    @JsonCreator
+    public ClusterInfo(Collection<DrillbitInfo> drillbits, String currentVersion, Collection<String> mismatchedVersions, boolean userEncryption, boolean bitEncryption, boolean shouldShowAdminInfo, QueueInfo queueInfo, String processUser, String processUserGroups, String adminUsers, String adminUserGroups, boolean authEnabled) {
+      this(drillbits, currentVersion, mismatchedVersions, userEncryption, bitEncryption, shouldShowAdminInfo, queueInfo, authEnabled);
+      this.processUser = processUser;
+      this.processUserGroups = processUserGroups;
+      this.adminUsers = adminUsers;
+      this.adminUserGroups = adminUserGroups;
+    }
+
+    public Collection<DrillbitInfo> getDrillbits() {
+      return Sets.newTreeSet(drillbits);
+    }
+
+    public String getCurrentVersion() {
+      return currentVersion;
+    }
+
+    public Collection<String> getMismatchedVersions() {
+      return Sets.newTreeSet(mismatchedVersions);
+    }
+
+    public boolean isUserEncryptionEnabled() {
+      return userEncryptionEnabled;
+    }
+
+    public boolean isBitEncryptionEnabled() {
+      return bitEncryptionEnabled;
+    }
+
+    public String getProcessUser() {
+      return processUser;
+    }
+
+    public String getProcessUserGroups() {
+      return processUserGroups;
+    }
+
+    public String getAdminUsers() {
+      return adminUsers;
+    }
+
+    public String getAdminUserGroups() {
+      return adminUserGroups;
+    }
+
+    public boolean shouldShowAdminInfo() {
+      return shouldShowAdminInfo;
+    }
+
+    public QueueInfo queueInfo() {
+      return queueInfo;
+    }
+
+    public boolean isAuthEnabled() {
+      return authEnabled;
+    }
+  }
+
+  public static class DrillbitInfo implements Comparable<DrillbitInfo> {
+    private final String address;
+
+    private final String httpPort;
+
+    private final String userPort;
+
+    private final String controlPort;
+
+    private final String dataPort;
+
+    private final String version;
+
+    private final boolean current;
+
+    private final boolean versionMatch;
+
+    private final String state;
+
+    @JsonCreator
+    public DrillbitInfo(DrillbitEndpoint drillbit, boolean current, boolean versionMatch) {
+      this.address = drillbit.getAddress();
+      this.httpPort = String.valueOf(drillbit.getHttpPort());
+      this.userPort = String.valueOf(drillbit.getUserPort());
+      this.controlPort = String.valueOf(drillbit.getControlPort());
+      this.dataPort = String.valueOf(drillbit.getDataPort());
+      this.version = Strings.isNullOrEmpty(drillbit.getVersion()) ? "Undefined" : drillbit.getVersion();
+      this.current = current;
+      this.versionMatch = versionMatch;
+      this.state = String.valueOf(drillbit.getState());
+    }
+
+    public String getAddress() {
+      return address;
+    }
+
+    public String getHttpPort() {
+      return httpPort;
+    }
+
+    public String getUserPort() {
+      return userPort;
+    }
+
+    public String getControlPort() {
+      return controlPort;
+    }
+
+    public String getDataPort() {
+      return dataPort;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public boolean isCurrent() {
+      return current;
+    }
+
+    public boolean isVersionMatch() {
+      return versionMatch;
+    }
+
+    public String getState() {
+      return state;
+    }
+
+    /**
+     * Method used to sort Drillbits. Current Drillbit goes first.
+     * Then Drillbits with matching versions, after them Drillbits with mismatching versions.
+     * Matching Drillbits are sorted according address natural order,
+     * mismatching Drillbits are sorted according version, address natural order.
+     *
+     * @param drillbitToCompare Drillbit to compare against
+     * @return -1 if Drillbit should be before, 1 if after in list
+     */
+    @Override
+    public int compareTo(DrillbitInfo drillbitToCompare) {
+      if (this.isCurrent()) {
+        return -1;
+      }
+
+      if (drillbitToCompare.isCurrent()) {
+        return 1;
+      }
+
+      if (this.isVersionMatch() == drillbitToCompare.isVersionMatch()) {
+        if (this.version.equals(drillbitToCompare.getVersion())) {
+          {
+            if (this.address.equals(drillbitToCompare.getAddress())) {
+              return (this.controlPort.compareTo(drillbitToCompare.getControlPort()));
+            }
+            return (this.address.compareTo(drillbitToCompare.getAddress()));
+          }
+        }
+        return this.version.compareTo(drillbitToCompare.getVersion());
+      }
+      return this.versionMatch ? -1 : 1;
+    }
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -74,16 +74,12 @@ public class DrillRoot {
 
   @Inject
   UserAuthEnabled authEnabled;
-
   @Inject
   WorkManager work;
-
   @Inject
   SecurityContext sc;
-
   @Inject
   Drillbit drillbit;
-
   @Inject
   HttpServletRequest request;
 
@@ -145,6 +141,7 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public Response shutdownDrillbit() throws Exception {
     String resp = "Graceful Shutdown request is triggered";
     return shutdown(resp);
@@ -155,6 +152,7 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public String shutdownDrillbitByName(@PathParam("hostname") String hostname) throws Exception {
     URL shutdownURL = WebUtils.getDrillbitURL(work, request, hostname, "/gracefulShutdown");
     return WebUtils.doHTTPRequest(new HttpPost(shutdownURL.toURI()), work.getContext().getConfig());
@@ -165,6 +163,7 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public Response shutdownForcefully() throws Exception {
     drillbit.setForcefulShutdown(true);
     String resp = "Forceful shutdown request is triggered";
@@ -176,6 +175,7 @@ public class DrillRoot {
   @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN_ROLE)
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/stopping-drill/"))
+
   public Response drillbitToQuiescentMode() throws Exception {
     drillbit.setQuiescentMode(true);
     String resp = "Request to put drillbit in Quiescent mode is triggered";
@@ -195,7 +195,9 @@ public class DrillRoot {
     final String currentVersion = currentDrillbit.getVersion();
 
     final DrillConfig config = dbContext.getConfig();
-    final boolean userEncryptionEnabled = config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) || config.getBoolean(ExecConstants.USER_SSL_ENABLED);
+    final boolean userEncryptionEnabled =
+      config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) ||
+        config.getBoolean(ExecConstants.USER_SSL_ENABLED);
     final boolean bitEncryptionEnabled = config.getBoolean(ExecConstants.BIT_ENCRYPTION_SASL_ENABLED);
 
     OptionManager optionManager = work.getContext().getOptionManager();
@@ -203,7 +205,9 @@ public class DrillRoot {
     final boolean shouldShowAdminInfo = isUserLoggedIn && ((DrillUserPrincipal) sc.getUserPrincipal()).isAdminUser();
 
     for (DrillbitEndpoint endpoint : work.getContext().getAvailableBits()) {
-      final DrillbitInfo drillbit = new DrillbitInfo(endpoint, isDrillbitsTheSame(currentDrillbit, endpoint), currentVersion.equals(endpoint.getVersion()));
+      final DrillbitInfo drillbit = new DrillbitInfo(endpoint,
+        isDrillbitsTheSame(currentDrillbit, endpoint),
+        currentVersion.equals(endpoint.getVersion()));
       if (!drillbit.isVersionMatch()) {
         mismatchedVersions.add(drillbit.getVersion());
       }
@@ -221,10 +225,15 @@ public class DrillRoot {
       logger.debug("Admin info: user: {} user group: {} userLoggedIn {} shouldShowAdminInfo: {}",
       adminUsers, adminUserGroups, isUserLoggedIn, shouldShowAdminInfo);
 
-      return new ClusterInfo(drillbits, currentVersion, mismatchedVersions, userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo, QueueInfo.build(dbContext.getResourceManager()), processUser, processUserGroups, adminUsers, adminUserGroups, authEnabled.get());
+      return new ClusterInfo(drillbits, currentVersion, mismatchedVersions,
+        userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo,
+        QueueInfo.build(dbContext.getResourceManager()),
+        processUser, processUserGroups, adminUsers, adminUserGroups, authEnabled.get());
     }
 
-    return new ClusterInfo(drillbits, currentVersion, mismatchedVersions, userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo, QueueInfo.build(dbContext.getResourceManager()), authEnabled.get());
+    return new ClusterInfo(drillbits, currentVersion, mismatchedVersions,
+      userEncryptionEnabled, bitEncryptionEnabled, shouldShowAdminInfo,
+      QueueInfo.build(dbContext.getResourceManager()), authEnabled.get());
   }
 
   /**
@@ -235,11 +244,19 @@ public class DrillRoot {
    * @return true if drillbit are the same
    */
   private boolean isDrillbitsTheSame(DrillbitEndpoint endpoint1, DrillbitEndpoint endpoint2) {
-    return endpoint1.getAddress().equals(endpoint2.getAddress()) && endpoint1.getControlPort() == endpoint2.getControlPort() && endpoint1.getDataPort() == endpoint2.getDataPort() && endpoint1.getUserPort() == endpoint2.getUserPort();
+    return endpoint1.getAddress().equals(endpoint2.getAddress()) &&
+      endpoint1.getControlPort() == endpoint2.getControlPort() &&
+      endpoint1.getDataPort() == endpoint2.getDataPort() &&
+      endpoint1.getUserPort() == endpoint2.getUserPort();
   }
 
   private Response setResponse(Map<String, ?> entity) {
-    return Response.ok().entity(entity).header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT").header("Access-Control-Allow-Credentials", "true").allow("OPTIONS").build();
+    return Response.ok()
+      .entity(entity)
+      .header("Access-Control-Allow-Origin", "*")
+      .header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT")
+      .header("Access-Control-Allow-Credentials", "true")
+      .allow("OPTIONS").build();
   }
 
   private Response shutdown(String resp) throws Exception {
@@ -307,19 +324,27 @@ public class DrillRoot {
     }
 
     public String threshold() {
-      return isEnabled() ? Double.toString(zkQueueInfo.queueThreshold) : "N/A";
+      return isEnabled()
+        ? Double.toString(zkQueueInfo.queueThreshold)
+        : "N/A";
     }
 
     public String smallQueueMemory() {
-      return isEnabled() ? toBytes(zkQueueInfo.memoryPerSmallQuery) : "N/A";
+      return isEnabled()
+        ? toBytes(zkQueueInfo.memoryPerSmallQuery)
+        : "N/A";
     }
 
     public String largeQueueMemory() {
-      return isEnabled() ? toBytes(zkQueueInfo.memoryPerLargeQuery) : "N/A";
+      return isEnabled()
+        ? toBytes(zkQueueInfo.memoryPerLargeQuery)
+        : "N/A";
     }
 
     public String totalMemory() {
-      return isEnabled() ? toBytes(zkQueueInfo.memoryPerNode) : "N/A";
+      return isEnabled()
+        ? toBytes(zkQueueInfo.memoryPerNode)
+        : "N/A";
     }
 
     private final long ONE_MB = 1024 * 1024;
@@ -337,31 +362,28 @@ public class DrillRoot {
   @JsonInclude(JsonInclude.Include.NON_ABSENT)
   public static class ClusterInfo {
     private final Collection<DrillbitInfo> drillbits;
-
     private final String currentVersion;
-
     private final Collection<String> mismatchedVersions;
-
     private final boolean userEncryptionEnabled;
-
     private final boolean bitEncryptionEnabled;
-
     private final boolean shouldShowAdminInfo;
-
     private final boolean authEnabled;
-
     private final QueueInfo queueInfo;
 
     private String adminUsers;
-
     private String adminUserGroups;
-
     private String processUser;
-
     private String processUserGroups;
 
     @JsonCreator
-    public ClusterInfo(Collection<DrillbitInfo> drillbits, String currentVersion, Collection<String> mismatchedVersions, boolean userEncryption, boolean bitEncryption, boolean shouldShowAdminInfo, QueueInfo queueInfo, boolean authEnabled) {
+    public ClusterInfo(Collection<DrillbitInfo> drillbits,
+                       String currentVersion,
+                       Collection<String> mismatchedVersions,
+                       boolean userEncryption,
+                       boolean bitEncryption,
+                       boolean shouldShowAdminInfo,
+                       QueueInfo queueInfo,
+                       boolean authEnabled) {
       this.drillbits = Sets.newTreeSet(drillbits);
       this.currentVersion = currentVersion;
       this.mismatchedVersions = Sets.newTreeSet(mismatchedVersions);
@@ -373,7 +395,18 @@ public class DrillRoot {
     }
 
     @JsonCreator
-    public ClusterInfo(Collection<DrillbitInfo> drillbits, String currentVersion, Collection<String> mismatchedVersions, boolean userEncryption, boolean bitEncryption, boolean shouldShowAdminInfo, QueueInfo queueInfo, String processUser, String processUserGroups, String adminUsers, String adminUserGroups, boolean authEnabled) {
+    public ClusterInfo(Collection<DrillbitInfo> drillbits,
+                       String currentVersion,
+                       Collection<String> mismatchedVersions,
+                       boolean userEncryption,
+                       boolean bitEncryption,
+                       boolean shouldShowAdminInfo,
+                       QueueInfo queueInfo,
+                       String processUser,
+                       String processUserGroups,
+                       String adminUsers,
+                       String adminUserGroups,
+                       boolean authEnabled) {
       this(drillbits, currentVersion, mismatchedVersions, userEncryption, bitEncryption, shouldShowAdminInfo, queueInfo, authEnabled);
       this.processUser = processUser;
       this.processUserGroups = processUserGroups;
@@ -432,21 +465,13 @@ public class DrillRoot {
 
   public static class DrillbitInfo implements Comparable<DrillbitInfo> {
     private final String address;
-
     private final String httpPort;
-
     private final String userPort;
-
     private final String controlPort;
-
     private final String dataPort;
-
     private final String version;
-
     private final boolean current;
-
     private final boolean versionMatch;
-
     private final String state;
 
     @JsonCreator

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 @Path("/")
 @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
 public class QueryResources {
-   private static final Logger logger = LoggerFactory.getLogger(QueryResources.class);
+  private static final Logger logger = LoggerFactory.getLogger(QueryResources.class);
 
   @Inject
   UserAuthEnabled authEnabled;
@@ -85,22 +85,16 @@ public class QueryResources {
   @Path("/query")
   @Produces(MediaType.TEXT_HTML)
   public Viewable getQuery() {
-    List<StorageResources.StoragePluginModel> enabledPlugins = sr.getConfigsFor("enabled")
-      .stream()
-      .map(plugin -> new StorageResources.StoragePluginModel(plugin, request))
-      .collect(Collectors.toList());
-    return ViewableWithPermissions.create(
-        authEnabled.get(), "/rest/query/query.ftl",
-        sc, new QueryPage(work, enabledPlugins, request));
+    List<StorageResources.StoragePluginModel> enabledPlugins =
+      sr.getConfigsFor("enabled").stream().map(plugin -> new StorageResources.StoragePluginModel(plugin, request)).collect(Collectors.toList());
+    return ViewableWithPermissions.create(authEnabled.get(), "/rest/query/query.ftl", sc, new QueryPage(work, enabledPlugins, request));
   }
 
   @POST
   @Path("/query.json")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache" +
-    ".org/docs/rest-api-introduction/#:~:text=programmatically%20run%20queries.-,post%20%2Fquery.json,-Submit%20a%20query"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public StreamingOutput submitQueryJSON(QueryWrapper query) throws Exception {
 
     /*
@@ -123,8 +117,7 @@ public class QueryResources {
     }
     return new StreamingOutput() {
       @Override
-      public void write(OutputStream output)
-          throws IOException, WebApplicationException {
+      public void write(OutputStream output) throws IOException, WebApplicationException {
         try {
           runner.sendResults(output);
         } catch (IOException e) {
@@ -140,29 +133,14 @@ public class QueryResources {
   @Path("/query")
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Produces(MediaType.TEXT_HTML)
-  public Viewable submitQuery(@FormParam("query") String query,
-                              @FormParam("queryType") String queryType,
-                              @FormParam("autoLimit") String autoLimit,
-                              @FormParam("userName") String userName,
-                              @FormParam("defaultSchema") String defaultSchema,
-                              Form form) throws Exception {
+  public Viewable submitQuery(@FormParam("query") String query, @FormParam("queryType") String queryType, @FormParam("autoLimit") String autoLimit, @FormParam("userName") String userName, @FormParam("defaultSchema") String defaultSchema, Form form) throws Exception {
     try {
       // Run the query and wrap the result sets in a model to be
       // transformed to HTML. This can be memory-intensive for larger
       // queries.
-      QueryWrapper wrapper = new RestQueryBuilder()
-          .query(query)
-          .queryType(queryType)
-          .rowLimit(autoLimit)
-          .userName(userName)
-          .defaultSchema(defaultSchema)
-          .sessionOptions(readOptionsFromForm(form))
-          .build();
-      final QueryResult result = new RestQueryRunner(wrapper,
-              work, webUserConnection)
-        .run();
-      List<Integer> rowsPerPageValues = work.getContext().getConfig().getIntList(
-          ExecConstants.HTTP_WEB_CLIENT_RESULTSET_ROWS_PER_PAGE_VALUES);
+      QueryWrapper wrapper = new RestQueryBuilder().query(query).queryType(queryType).rowLimit(autoLimit).userName(userName).defaultSchema(defaultSchema).sessionOptions(readOptionsFromForm(form)).build();
+      final QueryResult result = new RestQueryRunner(wrapper, work, webUserConnection).run();
+      List<Integer> rowsPerPageValues = work.getContext().getConfig().getIntList(ExecConstants.HTTP_WEB_CLIENT_RESULTSET_ROWS_PER_PAGE_VALUES);
       Collections.sort(rowsPerPageValues);
       final String rowsPerPageValuesAsStr = Joiner.on(",").join(rowsPerPageValues);
       return ViewableWithPermissions.create(authEnabled.get(), "/rest/query/result.ftl", sc, new TabularResult(result, rowsPerPageValuesAsStr));
@@ -183,12 +161,11 @@ public class QueryResources {
     Map<String, String> options = new HashMap<>();
     for (Map.Entry<String, List<String>> pair : form.asMap().entrySet()) {
       List<String> values = pair.getValue();
-       if (values.isEmpty()) {
+      if (values.isEmpty()) {
         continue;
       }
       if (values.size() > 1) {
-        throw new BadRequestException(String.format(
-            "Multiple values given for option '%s'", pair.getKey()));
+        throw new BadRequestException(String.format("Multiple values given for option '%s'", pair.getKey()));
       }
 
       options.put(pair.getKey(), values.get(0));
@@ -201,9 +178,13 @@ public class QueryResources {
    */
   public static class QueryPage {
     private final boolean onlyImpersonationEnabled;
+
     private final boolean autoLimitEnabled;
+
     private final int defaultRowsAutoLimited;
+
     private final List<StorageResources.StoragePluginModel> enabledPlugins;
+
     private final String csrfToken;
 
     public QueryPage(WorkManager work, List<StorageResources.StoragePluginModel> enabledPlugins, HttpServletRequest request) {
@@ -242,19 +223,24 @@ public class QueryResources {
    */
   public static class TabularResult {
     private final List<String> columns;
+
     private final List<List<String>> rows;
+
     private final String queryId;
+
     private final String rowsPerPageValues;
+
     private final String queryState;
+
     private final int autoLimitedRowCount;
 
     public TabularResult(QueryResult result, String rowsPerPageValuesAsStr) {
       rowsPerPageValues = rowsPerPageValuesAsStr;
       queryId = result.getQueryId();
       final List<List<String>> rows = Lists.newArrayList();
-      for (Map<String, String> rowMap:result.rows) {
+      for (Map<String, String> rowMap : result.rows) {
         final List<String> row = Lists.newArrayList();
-        for (String col:result.columns) {
+        for (String col : result.columns) {
           row.add(rowMap.get(col));
         }
         rows.add(row);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.server.rest;
 
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -96,6 +98,9 @@ public class QueryResources {
   @Path("/query.json")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache" +
+    ".org/docs/rest-api-introduction/#:~:text=programmatically%20run%20queries.-,post%20%2Fquery.json,-Submit%20a%20query"))
+
   public StreamingOutput submitQueryJSON(QueryWrapper query) throws Exception {
 
     /*

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -42,6 +42,8 @@ import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.ExecConstants;
@@ -90,6 +92,8 @@ public class StatusResources {
   @GET
   @Path(StatusResources.PATH_STATUS_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=Memory%22%2C%0A%20%20%20%20%20%20%22value%22%20%3A%208589934592%0A%20%20%20%20%7D%20%5D-,get%20%2Fstatus,-Get%20the%20status"))
+
   public Pair<String, String> getStatusJSON() {
     return new ImmutablePair<>("status", "Running!");
   }
@@ -104,6 +108,8 @@ public class StatusResources {
   @GET
   @Path(StatusResources.PATH_METRICS + "/{hostname}")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=Running!%3C%2Fstrong%3E%0A%20%20%20%20%20%20.%20.%20.%0A%0A%20%20%20%20%20%20%3C%2Fhtml%3E-,get%20%2Fstatus%2Fmetrics,-Get%20the%20current"))
+
   public String getMetrics(@PathParam("hostname") String hostname) throws Exception {
     URL metricsURL = WebUtils.getDrillbitURL(work, request, hostname, StatusResources.PATH_METRICS);
     return WebUtils.doHTTPRequest(new HttpGet(metricsURL.toURI()), work.getContext().getConfig());
@@ -132,6 +138,8 @@ public class StatusResources {
   @Path(StatusResources.PATH_OPTIONS_JSON)
   @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=gets%20system%20options.-,get%20%2Foptions.json,-List%20the%20name"))
+
   public List<OptionWrapper> getSystemPublicOptionsJSON() {
     return getSystemOptionsJSONHelper(false);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -67,13 +67,21 @@ public class StatusResources {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StatusResources.class);
 
   public static final String REST_API_SUFFIX = ".json";
+
   public static final String PATH_STATUS_JSON = "/status" + REST_API_SUFFIX;
+
   public static final String PATH_STATUS = "/status";
+
   public static final String PATH_METRICS = PATH_STATUS + "/metrics";
+
   public static final String PATH_OPTIONS_JSON = "/options" + REST_API_SUFFIX;
+
   public static final String PATH_INTERNAL_OPTIONS_JSON = "/internal_options" + REST_API_SUFFIX;
+
   public static final String PATH_OPTIONS = "/options";
+
   public static final String PATH_INTERNAL_OPTIONS = "/internal_options";
+
   //Used to access current filter state in WebUI
   private static final String CURRENT_FILTER_PARAM = "filter";
 
@@ -92,8 +100,7 @@ public class StatusResources {
   @GET
   @Path(StatusResources.PATH_STATUS_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=Memory%22%2C%0A%20%20%20%20%20%20%22value%22%20%3A%208589934592%0A%20%20%20%20%7D%20%5D-,get%20%2Fstatus,-Get%20the%20status"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Pair<String, String> getStatusJSON() {
     return new ImmutablePair<>("status", "Running!");
   }
@@ -108,18 +115,16 @@ public class StatusResources {
   @GET
   @Path(StatusResources.PATH_METRICS + "/{hostname}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=Running!%3C%2Fstrong%3E%0A%20%20%20%20%20%20.%20.%20.%0A%0A%20%20%20%20%20%20%3C%2Fhtml%3E-,get%20%2Fstatus%2Fmetrics,-Get%20the%20current"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public String getMetrics(@PathParam("hostname") String hostname) throws Exception {
     URL metricsURL = WebUtils.getDrillbitURL(work, request, hostname, StatusResources.PATH_METRICS);
     return WebUtils.doHTTPRequest(new HttpGet(metricsURL.toURI()), work.getContext().getConfig());
   }
 
-  private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal)
-  {
+  private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal) {
     List<OptionWrapper> options = new LinkedList<>();
     OptionManager optionManager = work.getContext().getOptionManager();
-    OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
+    OptionList optionList = internal ? optionManager.getInternalOptionList() : optionManager.getPublicOptionList();
 
     for (OptionValue option : optionList) {
       options.add(new OptionWrapper(option.name, option.getValue(), optionManager.getDefault(option.name).getValue().toString(), option.accessibleScopes, option.kind, option.scope));
@@ -128,7 +133,7 @@ public class StatusResources {
     Collections.sort(options, new Comparator<OptionWrapper>() {
       @Override
       public int compare(OptionWrapper o1, OptionWrapper o2) {
-         return o1.name.compareTo(o2.name);
+        return o1.name.compareTo(o2.name);
       }
     });
     return options;
@@ -138,8 +143,7 @@ public class StatusResources {
   @Path(StatusResources.PATH_OPTIONS_JSON)
   @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=gets%20system%20options.-,get%20%2Foptions.json,-List%20the%20name"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public List<OptionWrapper> getSystemPublicOptionsJSON() {
     return getSystemOptionsJSONHelper(false);
   }
@@ -161,10 +165,7 @@ public class StatusResources {
       currFilter = "";
     }
 
-    return ViewableWithPermissions.create(authEnabled.get(),
-      "/rest/options.ftl",
-      sc,
-      new OptionsListing(options, fltrList, currFilter, request));
+    return ViewableWithPermissions.create(authEnabled.get(), "/rest/options.ftl", sc, new OptionsListing(options, fltrList, currFilter, request));
   }
 
   @GET
@@ -188,11 +189,8 @@ public class StatusResources {
   @RolesAllowed(DrillUserPrincipal.ADMIN_ROLE)
   @Consumes("application/x-www-form-urlencoded")
   @Produces(MediaType.TEXT_HTML)
-  public Viewable updateSystemOption(@FormParam("name") String name,
-                                   @FormParam("value") String value,
-                                   @FormParam("kind") String kind) {
-    SystemOptionManager optionManager = work.getContext()
-      .getOptionManager();
+  public Viewable updateSystemOption(@FormParam("name") String name, @FormParam("value") String value, @FormParam("kind") String kind) {
+    SystemOptionManager optionManager = work.getContext().getOptionManager();
 
     try {
       optionManager.setLocalOption(OptionValue.Kind.valueOf(kind), name, value);
@@ -212,8 +210,11 @@ public class StatusResources {
    */
   public static class OptionsListing {
     private final List<OptionWrapper> options;
+
     private final List<String> filters;
+
     private final String dynamicFilter;
+
     private final String csrfToken;
 
     public OptionsListing(List<OptionWrapper> optList, List<String> fltrList, String currFilter, HttpServletRequest request) {
@@ -244,19 +245,21 @@ public class StatusResources {
   public static class OptionWrapper {
 
     private String name;
+
     private Object value;
+
     private String defaultValue;
+
     private OptionValue.AccessibleScopes accessibleScopes;
+
     private String kind;
+
     private String optionScope;
 
     @JsonCreator
-    public OptionWrapper(@JsonProperty("name") String name,
-                         @JsonProperty("value") Object value,
-                         @JsonProperty("defaultValue") String defaultValue,
-                         @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
-                         @JsonProperty("kind") Kind kind,
-                         @JsonProperty("optionScope") OptionValue.OptionScope scope) {
+    public OptionWrapper(@JsonProperty("name") String name, @JsonProperty("value") Object value,
+                         @JsonProperty("defaultValue") String defaultValue, @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
+                         @JsonProperty("kind") Kind kind, @JsonProperty("optionScope") OptionValue.OptionScope scope) {
       this.name = name;
       this.value = value;
       this.defaultValue = defaultValue;
@@ -296,7 +299,7 @@ public class StatusResources {
 
     @Override
     public String toString() {
-      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", default=" + defaultValue + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' +'}';
+      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", default=" + defaultValue + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' + '}';
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -67,21 +67,13 @@ public class StatusResources {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StatusResources.class);
 
   public static final String REST_API_SUFFIX = ".json";
-
   public static final String PATH_STATUS_JSON = "/status" + REST_API_SUFFIX;
-
   public static final String PATH_STATUS = "/status";
-
   public static final String PATH_METRICS = PATH_STATUS + "/metrics";
-
   public static final String PATH_OPTIONS_JSON = "/options" + REST_API_SUFFIX;
-
   public static final String PATH_INTERNAL_OPTIONS_JSON = "/internal_options" + REST_API_SUFFIX;
-
   public static final String PATH_OPTIONS = "/options";
-
   public static final String PATH_INTERNAL_OPTIONS = "/internal_options";
-
   //Used to access current filter state in WebUI
   private static final String CURRENT_FILTER_PARAM = "filter";
 
@@ -121,10 +113,11 @@ public class StatusResources {
     return WebUtils.doHTTPRequest(new HttpGet(metricsURL.toURI()), work.getContext().getConfig());
   }
 
-  private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal) {
+  private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal)
+  {
     List<OptionWrapper> options = new LinkedList<>();
     OptionManager optionManager = work.getContext().getOptionManager();
-    OptionList optionList = internal ? optionManager.getInternalOptionList() : optionManager.getPublicOptionList();
+    OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
 
     for (OptionValue option : optionList) {
       options.add(new OptionWrapper(option.name, option.getValue(), optionManager.getDefault(option.name).getValue().toString(), option.accessibleScopes, option.kind, option.scope));
@@ -165,7 +158,10 @@ public class StatusResources {
       currFilter = "";
     }
 
-    return ViewableWithPermissions.create(authEnabled.get(), "/rest/options.ftl", sc, new OptionsListing(options, fltrList, currFilter, request));
+    return ViewableWithPermissions.create(authEnabled.get(),
+      "/rest/options.ftl",
+      sc,
+      new OptionsListing(options, fltrList, currFilter, request));
   }
 
   @GET
@@ -189,8 +185,11 @@ public class StatusResources {
   @RolesAllowed(DrillUserPrincipal.ADMIN_ROLE)
   @Consumes("application/x-www-form-urlencoded")
   @Produces(MediaType.TEXT_HTML)
-  public Viewable updateSystemOption(@FormParam("name") String name, @FormParam("value") String value, @FormParam("kind") String kind) {
-    SystemOptionManager optionManager = work.getContext().getOptionManager();
+  public Viewable updateSystemOption(@FormParam("name") String name,
+                                     @FormParam("value") String value,
+                                     @FormParam("kind") String kind) {
+    SystemOptionManager optionManager = work.getContext()
+      .getOptionManager();
 
     try {
       optionManager.setLocalOption(OptionValue.Kind.valueOf(kind), name, value);
@@ -210,11 +209,8 @@ public class StatusResources {
    */
   public static class OptionsListing {
     private final List<OptionWrapper> options;
-
     private final List<String> filters;
-
     private final String dynamicFilter;
-
     private final String csrfToken;
 
     public OptionsListing(List<OptionWrapper> optList, List<String> fltrList, String currFilter, HttpServletRequest request) {
@@ -245,21 +241,19 @@ public class StatusResources {
   public static class OptionWrapper {
 
     private String name;
-
     private Object value;
-
     private String defaultValue;
-
     private OptionValue.AccessibleScopes accessibleScopes;
-
     private String kind;
-
     private String optionScope;
 
     @JsonCreator
-    public OptionWrapper(@JsonProperty("name") String name, @JsonProperty("value") Object value,
-                         @JsonProperty("defaultValue") String defaultValue, @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
-                         @JsonProperty("kind") Kind kind, @JsonProperty("optionScope") OptionValue.OptionScope scope) {
+    public OptionWrapper(@JsonProperty("name") String name,
+                         @JsonProperty("value") Object value,
+                         @JsonProperty("defaultValue") String defaultValue,
+                         @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
+                         @JsonProperty("kind") Kind kind,
+                         @JsonProperty("optionScope") OptionValue.OptionScope scope) {
       this.name = name;
       this.value = value;
       this.defaultValue = defaultValue;
@@ -299,7 +293,7 @@ public class StatusResources {
 
     @Override
     public String toString() {
-      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", default=" + defaultValue + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' + '}';
+      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", default=" + defaultValue + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' +'}';
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -50,6 +50,8 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
 import okhttp3.Request;
@@ -136,6 +138,8 @@ public class StorageResources {
   @GET
   @Path("/storage.json")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=storage%20plugin%20configurations.-,get%20%2Fstorage.json,-Get%20the%20list"))
+
   public List<PluginConfigWrapper> getPluginsJSON() {
     return getConfigsFor(ALL_PLUGINS);
   }
@@ -156,6 +160,8 @@ public class StorageResources {
 
   @GET
   @Path("/storage/{name}.json")
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=get%20%2Fstorage%2F%7Bname%7D.json"))
+
   @Produces(MediaType.APPLICATION_JSON)
   public Response getPluginConfig(@PathParam("name") String name) {
     try {
@@ -186,6 +192,8 @@ public class StorageResources {
   @Path("/storage/{name}/enable/{val}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=get%20%2Fstorage%2F%7Bname%7D%2Fenable%2F%7Bval%7D"))
+
   public Response enablePlugin(@PathParam("name") String name, @PathParam("val") Boolean enable) {
     try {
       storage.setEnabled(name, enable);
@@ -361,6 +369,8 @@ public class StorageResources {
   @GET
   @Path("/storage/{name}/enable/{val}")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=get%20%2Fstorage%2F%7Bname%7D%2Fenable%2F%7Bval%7D"))
+
   @Deprecated
   public Response enablePluginViaGet(@PathParam("name") String name, @PathParam("val") Boolean enable) {
     return enablePlugin(name, enable);
@@ -391,6 +401,8 @@ public class StorageResources {
   @DELETE
   @Path("/storage/{name}.json")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=DELETE%20%2Fstorage%2F%7Bname,storage%20plugin%20configuration."))
+
   public Response deletePlugin(@PathParam("name") String name) {
     try {
       TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name))
@@ -414,6 +426,8 @@ public class StorageResources {
   @Path("/storage/{name}.json")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=post%20%2Fstorage%2F%7Bname%7D.json"))
+
   public Response createOrUpdatePluginJSON(PluginConfigWrapper plugin) {
     try {
       plugin.createOrUpdateInStorage(storage);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -99,18 +99,14 @@ public class StorageResources {
   HttpServletRequest request;
 
   private static final String JSON_FORMAT = "json";
-
   private static final String HOCON_FORMAT = "conf";
-
   private static final String ALL_PLUGINS = "all";
-
   private static final String ENABLED_PLUGINS = "enabled";
-
   private static final String DISABLED_PLUGINS = "disabled";
-
   private static final String OAUTH_SUCCESS_PAGE = "/rest/storage/success.html";
 
-  private static final Comparator<PluginConfigWrapper> PLUGIN_COMPARATOR = Comparator.comparing(PluginConfigWrapper::getName);
+  private static final Comparator<PluginConfigWrapper> PLUGIN_COMPARATOR =
+    Comparator.comparing(PluginConfigWrapper::getName);
 
   /**
    * Regex allows the following paths:<pre><code>
@@ -128,9 +124,15 @@ public class StorageResources {
   @Produces(MediaType.APPLICATION_JSON)
   public Response getConfigsFor(@PathParam("group") String pluginGroup, @PathParam("format") String format) {
     format = StringUtils.isNotEmpty(format) ? format.replace("/", "") : JSON_FORMAT;
-    return isSupported(format) ? Response.ok().entity(getConfigsFor(pluginGroup).toArray()).header(HttpHeaders.CONTENT_DISPOSITION,
-      String.format("attachment;filename=\"%s_storage_plugins.%s\"", pluginGroup, format)).build() : Response.status(Response.Status.NOT_ACCEPTABLE)
-      .entity(message("Unknown \"%s\" file format for Storage Plugin config", format)).build();
+    return isSupported(format)
+      ? Response.ok()
+        .entity(getConfigsFor(pluginGroup).toArray())
+        .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s_storage_plugins.%s\"",
+          pluginGroup, format))
+        .build()
+      : Response.status(Response.Status.NOT_ACCEPTABLE)
+        .entity(message("Unknown \"%s\" file format for Storage Plugin config", format))
+        .build();
   }
 
   @GET
@@ -145,7 +147,9 @@ public class StorageResources {
   @Path("/storage")
   @Produces(MediaType.TEXT_HTML)
   public Viewable getPlugins() {
-    List<StoragePluginModel> model = getPluginsJSON().stream().map(plugin -> new StoragePluginModel(plugin, request)).collect(Collectors.toList());
+    List<StoragePluginModel> model = getPluginsJSON().stream()
+      .map(plugin -> new StoragePluginModel(plugin, request))
+      .collect(Collectors.toList());
     // Creating an empty model with CSRF token, if there are no storage plugins
     if (model.isEmpty()) {
       model.add(new StoragePluginModel(null, request));
@@ -159,11 +163,14 @@ public class StorageResources {
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response getPluginConfig(@PathParam("name") String name) {
     try {
-      return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name))).build();
+      return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
+        .build();
     } catch (Exception e) {
       logger.error("Failure while trying to access storage config: {}", name, e);
 
-      return Response.status(Response.Status.NOT_FOUND).entity(message("Failure while trying to access storage config: %s", e.getMessage())).build();
+      return Response.status(Response.Status.NOT_FOUND)
+        .entity(message("Failure while trying to access storage config: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -171,8 +178,12 @@ public class StorageResources {
   @Path("/storage/{name}")
   @Produces(MediaType.TEXT_HTML)
   public Viewable getPlugin(@PathParam("name") String name) {
-    StoragePluginModel model = new StoragePluginModel((PluginConfigWrapper) getPluginConfig(name).getEntity(), request);
-    return ViewableWithPermissions.create(authEnabled.get(), "/rest/storage/update.ftl", sc, model);
+    StoragePluginModel model = new StoragePluginModel(
+      (PluginConfigWrapper) getPluginConfig(name).getEntity(),
+      request
+    );
+    return ViewableWithPermissions.create(authEnabled.get(), "/rest/storage/update.ftl", sc,
+      model);
   }
 
   @POST
@@ -185,10 +196,14 @@ public class StorageResources {
       storage.setEnabled(name, enable);
       return Response.ok().entity(message("Success")).build();
     } catch (PluginNotFoundException e) {
-      return Response.status(Response.Status.NOT_FOUND).entity(message("No plugin exists with the given name: " + name)).build();
+      return Response.status(Response.Status.NOT_FOUND)
+        .entity(message("No plugin exists with the given name: " + name))
+        .build();
     } catch (PluginException e) {
       logger.info("Error when enabling storage name: {} flag: {}", name, enable);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Unable to enable/disable plugin: %s", e.getMessage())).build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Unable to enable/disable plugin: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -206,14 +221,20 @@ public class StorageResources {
         // Set the access token
         tokenTable.setRefreshToken(tokens.getRefreshToken());
 
-        return Response.status(Status.OK).entity("Refresh token have been updated.").build();
+        return Response.status(Status.OK)
+          .entity("Refresh token have been updated.")
+          .build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add access tokens to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", name)).build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR)
+          .entity(message("Unable to add tokens: %s", name))
+          .build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding tokens to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", e.getMessage())).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Unable to add tokens: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -231,14 +252,20 @@ public class StorageResources {
         // Set the access token
         tokenTable.setAccessToken(tokens.getAccessToken());
 
-        return Response.status(Status.OK).entity("Access tokens have been updated.").build();
+        return Response.status(Status.OK)
+          .entity("Access tokens have been updated.")
+          .build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add access tokens to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", name)).build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR)
+          .entity(message("Unable to add tokens: %s", name))
+          .build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding tokens to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", e.getMessage())).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Unable to add tokens: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -246,7 +273,8 @@ public class StorageResources {
   @Path("/storage/{name}/update_oauth_tokens")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public Response updateOAuthTokens(@PathParam("name") String name, OAuthTokenContainer tokenContainer) {
+  public Response updateOAuthTokens(@PathParam("name") String name,
+                                    OAuthTokenContainer tokenContainer) {
     try {
       if (storage.getPlugin(name).getConfig() instanceof AbstractSecuredStoragePluginConfig) {
         DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
@@ -257,14 +285,20 @@ public class StorageResources {
         tokenTable.setAccessToken(tokenContainer.getAccessToken());
         tokenTable.setRefreshToken(tokenContainer.getRefreshToken());
 
-        return Response.status(Status.OK).entity("Access tokens have been updated.").build();
+        return Response.status(Status.OK)
+          .entity("Access tokens have been updated.")
+          .build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add access tokens to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", name)).build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR)
+          .entity(message("Unable to add tokens: %s", name))
+          .build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding tokens to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", e.getMessage())).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Unable to add tokens: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -285,7 +319,10 @@ public class StorageResources {
         Map<String, String> updatedTokens = OAuthUtils.getOAuthTokens(client, accessTokenRequest);
 
         // Add to token registry
-        TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext().getoAuthTokenProvider().getOauthTokenRegistry();
+        TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name))
+          .getContext()
+          .getoAuthTokenProvider()
+          .getOauthTokenRegistry();
 
         // Add a token registry table if none exists
         tokenRegistry.createTokenTable(name);
@@ -300,7 +337,8 @@ public class StorageResources {
         try (InputStream inputStream = Resource.newClassPathResource(OAUTH_SUCCESS_PAGE).getInputStream()) {
           InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
           BufferedReader bufferedReader = new BufferedReader(reader);
-          successPage = bufferedReader.lines().collect(Collectors.joining("\n"));
+          successPage = bufferedReader.lines()
+            .collect(Collectors.joining("\n"));
           bufferedReader.close();
           reader.close();
         } catch (IOException e) {
@@ -310,11 +348,15 @@ public class StorageResources {
         return Response.status(Status.OK).entity(successPage).build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add auth code to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add authorization code: %s", name)).build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR)
+          .entity(message("Unable to add authorization code: %s", name))
+          .build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding auth token to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add authorization code: %s", e.getMessage())).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Unable to add authorization code: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -342,10 +384,14 @@ public class StorageResources {
   public Response exportPlugin(@PathParam("name") String name, @PathParam("format") String format) {
     format = StringUtils.isNotEmpty(format) ? format.replace("/", "") : JSON_FORMAT;
     if (!isSupported(format)) {
-      return Response.status(Response.Status.NOT_ACCEPTABLE).entity(message("Unknown \"%s\" file format for Storage Plugin config", format)).build();
+      return Response.status(Response.Status.NOT_ACCEPTABLE)
+        .entity(message("Unknown \"%s\" file format for Storage Plugin config", format))
+        .build();
     }
 
-    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name))).header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format)).build();
+    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
+      .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format))
+      .build();
   }
 
   @DELETE
@@ -354,7 +400,10 @@ public class StorageResources {
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response deletePlugin(@PathParam("name") String name) {
     try {
-      TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext().getoAuthTokenProvider().getOauthTokenRegistry();
+      TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name))
+        .getContext()
+        .getoAuthTokenProvider()
+        .getOauthTokenRegistry();
 
       // Delete a token registry table if it exists
       tokenRegistry.deleteTokenTable(name);
@@ -362,7 +411,9 @@ public class StorageResources {
       storage.remove(name);
       return Response.ok().entity(message("Success")).build();
     } catch (PluginException e) {
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Error while deleting plugin: %s", e.getMessage())).build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Error while deleting plugin: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -377,7 +428,9 @@ public class StorageResources {
       return Response.ok().entity(message("Success")).build();
     } catch (PluginException e) {
       logger.error("Unable to create/ update plugin: " + plugin.getName(), e);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Error while saving plugin: %s ", e.getMessage())).build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Error while saving plugin: %s ", e.getMessage()))
+        .build();
     }
   }
 
@@ -393,7 +446,9 @@ public class StorageResources {
   public Response createOrUpdatePlugin(@FormParam("name") String name, @FormParam("config") String storagePluginConfig) {
     name = name.trim();
     if (name.isEmpty()) {
-      return Response.status(Response.Status.BAD_REQUEST).entity(message("A storage config name may not be empty")).build();
+      return Response.status(Response.Status.BAD_REQUEST)
+        .entity(message("A storage config name may not be empty"))
+        .build();
     }
 
     try {
@@ -401,10 +456,14 @@ public class StorageResources {
       return Response.ok().entity(message("Success")).build();
     } catch (PluginEncodingException e) {
       logger.warn("Error in JSON mapping: {}", storagePluginConfig, e);
-      return Response.status(Response.Status.BAD_REQUEST).entity(message("Invalid JSON: %s", e.getMessage())).build();
+      return Response.status(Response.Status.BAD_REQUEST)
+        .entity(message("Invalid JSON: %s", e.getMessage()))
+        .build();
     } catch (PluginException e) {
       logger.error("Error while saving plugin", e);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Error while saving plugin: %s", e.getMessage())).build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity(message("Error while saving plugin: %s", e.getMessage()))
+        .build();
     }
   }
 
@@ -437,20 +496,24 @@ public class StorageResources {
   public List<PluginConfigWrapper> getConfigsFor(@PathParam("group") String pluginGroup) {
     PluginFilter filter;
     switch (pluginGroup.trim()) {
-      case ALL_PLUGINS:
-        filter = PluginFilter.ALL;
-        break;
-      case ENABLED_PLUGINS:
-        filter = PluginFilter.ENABLED;
-        break;
-      case DISABLED_PLUGINS:
-        filter = PluginFilter.DISABLED;
-        break;
-      default:
-        return Collections.emptyList();
+    case ALL_PLUGINS:
+      filter = PluginFilter.ALL;
+      break;
+    case ENABLED_PLUGINS:
+      filter = PluginFilter.ENABLED;
+      break;
+    case DISABLED_PLUGINS:
+      filter = PluginFilter.DISABLED;
+      break;
+    default:
+      return Collections.emptyList();
     }
     pluginGroup = StringUtils.isNotEmpty(pluginGroup) ? pluginGroup.replace("/", "") : ALL_PLUGINS;
-    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(storage.storedConfigs(filter).entrySet().iterator(), Spliterator.ORDERED), false).map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue())).sorted(PLUGIN_COMPARATOR).collect(Collectors.toList());
+    return StreamSupport.stream(
+      Spliterators.spliteratorUnknownSize(storage.storedConfigs(filter).entrySet().iterator(), Spliterator.ORDERED), false)
+        .map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue()))
+        .sorted(PLUGIN_COMPARATOR)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -496,9 +559,7 @@ public class StorageResources {
    */
   public static class StoragePluginModel {
     private final PluginConfigWrapper plugin;
-
     private final String type;
-
     private final String csrfToken;
 
     public StoragePluginModel(PluginConfigWrapper plugin, HttpServletRequest request) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -99,14 +99,18 @@ public class StorageResources {
   HttpServletRequest request;
 
   private static final String JSON_FORMAT = "json";
+
   private static final String HOCON_FORMAT = "conf";
+
   private static final String ALL_PLUGINS = "all";
+
   private static final String ENABLED_PLUGINS = "enabled";
+
   private static final String DISABLED_PLUGINS = "disabled";
+
   private static final String OAUTH_SUCCESS_PAGE = "/rest/storage/success.html";
 
-  private static final Comparator<PluginConfigWrapper> PLUGIN_COMPARATOR =
-      Comparator.comparing(PluginConfigWrapper::getName);
+  private static final Comparator<PluginConfigWrapper> PLUGIN_COMPARATOR = Comparator.comparing(PluginConfigWrapper::getName);
 
   /**
    * Regex allows the following paths:<pre><code>
@@ -124,22 +128,15 @@ public class StorageResources {
   @Produces(MediaType.APPLICATION_JSON)
   public Response getConfigsFor(@PathParam("group") String pluginGroup, @PathParam("format") String format) {
     format = StringUtils.isNotEmpty(format) ? format.replace("/", "") : JSON_FORMAT;
-    return isSupported(format)
-      ? Response.ok()
-        .entity(getConfigsFor(pluginGroup).toArray())
-        .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s_storage_plugins.%s\"",
-            pluginGroup, format))
-        .build()
-      : Response.status(Response.Status.NOT_ACCEPTABLE)
-          .entity(message("Unknown \"%s\" file format for Storage Plugin config", format))
-          .build();
+    return isSupported(format) ? Response.ok().entity(getConfigsFor(pluginGroup).toArray()).header(HttpHeaders.CONTENT_DISPOSITION,
+      String.format("attachment;filename=\"%s_storage_plugins.%s\"", pluginGroup, format)).build() : Response.status(Response.Status.NOT_ACCEPTABLE)
+      .entity(message("Unknown \"%s\" file format for Storage Plugin config", format)).build();
   }
 
   @GET
   @Path("/storage.json")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=storage%20plugin%20configurations.-,get%20%2Fstorage.json,-Get%20the%20list"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public List<PluginConfigWrapper> getPluginsJSON() {
     return getConfigsFor(ALL_PLUGINS);
   }
@@ -148,9 +145,7 @@ public class StorageResources {
   @Path("/storage")
   @Produces(MediaType.TEXT_HTML)
   public Viewable getPlugins() {
-    List<StoragePluginModel> model = getPluginsJSON().stream()
-        .map(plugin -> new StoragePluginModel(plugin, request))
-        .collect(Collectors.toList());
+    List<StoragePluginModel> model = getPluginsJSON().stream().map(plugin -> new StoragePluginModel(plugin, request)).collect(Collectors.toList());
     // Creating an empty model with CSRF token, if there are no storage plugins
     if (model.isEmpty()) {
       model.add(new StoragePluginModel(null, request));
@@ -160,19 +155,15 @@ public class StorageResources {
 
   @GET
   @Path("/storage/{name}.json")
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=get%20%2Fstorage%2F%7Bname%7D.json"))
-
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response getPluginConfig(@PathParam("name") String name) {
     try {
-      return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
-        .build();
+      return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name))).build();
     } catch (Exception e) {
       logger.error("Failure while trying to access storage config: {}", name, e);
 
-      return Response.status(Response.Status.NOT_FOUND)
-        .entity(message("Failure while trying to access storage config: %s", e.getMessage()))
-        .build();
+      return Response.status(Response.Status.NOT_FOUND).entity(message("Failure while trying to access storage config: %s", e.getMessage())).build();
     }
   }
 
@@ -180,33 +171,24 @@ public class StorageResources {
   @Path("/storage/{name}")
   @Produces(MediaType.TEXT_HTML)
   public Viewable getPlugin(@PathParam("name") String name) {
-    StoragePluginModel model = new StoragePluginModel(
-      (PluginConfigWrapper) getPluginConfig(name).getEntity(),
-      request
-    );
-    return ViewableWithPermissions.create(authEnabled.get(), "/rest/storage/update.ftl", sc,
-        model);
+    StoragePluginModel model = new StoragePluginModel((PluginConfigWrapper) getPluginConfig(name).getEntity(), request);
+    return ViewableWithPermissions.create(authEnabled.get(), "/rest/storage/update.ftl", sc, model);
   }
 
   @POST
   @Path("/storage/{name}/enable/{val}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=get%20%2Fstorage%2F%7Bname%7D%2Fenable%2F%7Bval%7D"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response enablePlugin(@PathParam("name") String name, @PathParam("val") Boolean enable) {
     try {
       storage.setEnabled(name, enable);
       return Response.ok().entity(message("Success")).build();
     } catch (PluginNotFoundException e) {
-      return Response.status(Response.Status.NOT_FOUND)
-        .entity(message("No plugin exists with the given name: " + name))
-        .build();
+      return Response.status(Response.Status.NOT_FOUND).entity(message("No plugin exists with the given name: " + name)).build();
     } catch (PluginException e) {
-      logger.info("Error when enabling storage name: {} flag: {}",  name, enable);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Unable to enable/disable plugin: %s", e.getMessage()))
-        .build();
+      logger.info("Error when enabling storage name: {} flag: {}", name, enable);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Unable to enable/disable plugin: %s", e.getMessage())).build();
     }
   }
 
@@ -224,20 +206,14 @@ public class StorageResources {
         // Set the access token
         tokenTable.setRefreshToken(tokens.getRefreshToken());
 
-        return Response.status(Status.OK)
-          .entity("Refresh token have been updated.")
-          .build();
+        return Response.status(Status.OK).entity("Refresh token have been updated.").build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add access tokens to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR)
-          .entity(message("Unable to add tokens: %s", name))
-          .build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", name)).build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding tokens to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Unable to add tokens: %s", e.getMessage()))
-        .build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", e.getMessage())).build();
     }
   }
 
@@ -255,20 +231,14 @@ public class StorageResources {
         // Set the access token
         tokenTable.setAccessToken(tokens.getAccessToken());
 
-        return Response.status(Status.OK)
-          .entity("Access tokens have been updated.")
-          .build();
+        return Response.status(Status.OK).entity("Access tokens have been updated.").build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add access tokens to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR)
-          .entity(message("Unable to add tokens: %s", name))
-          .build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", name)).build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding tokens to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Unable to add tokens: %s", e.getMessage()))
-        .build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", e.getMessage())).build();
     }
   }
 
@@ -276,8 +246,7 @@ public class StorageResources {
   @Path("/storage/{name}/update_oauth_tokens")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public Response updateOAuthTokens(@PathParam("name") String name,
-                                    OAuthTokenContainer tokenContainer) {
+  public Response updateOAuthTokens(@PathParam("name") String name, OAuthTokenContainer tokenContainer) {
     try {
       if (storage.getPlugin(name).getConfig() instanceof AbstractSecuredStoragePluginConfig) {
         DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
@@ -288,20 +257,14 @@ public class StorageResources {
         tokenTable.setAccessToken(tokenContainer.getAccessToken());
         tokenTable.setRefreshToken(tokenContainer.getRefreshToken());
 
-        return Response.status(Status.OK)
-          .entity("Access tokens have been updated.")
-          .build();
+        return Response.status(Status.OK).entity("Access tokens have been updated.").build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add access tokens to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR)
-          .entity(message("Unable to add tokens: %s", name))
-          .build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", name)).build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding tokens to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Unable to add tokens: %s", e.getMessage()))
-        .build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add tokens: %s", e.getMessage())).build();
     }
   }
 
@@ -322,10 +285,7 @@ public class StorageResources {
         Map<String, String> updatedTokens = OAuthUtils.getOAuthTokens(client, accessTokenRequest);
 
         // Add to token registry
-        TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name))
-          .getContext()
-          .getoAuthTokenProvider()
-          .getOauthTokenRegistry();
+        TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext().getoAuthTokenProvider().getOauthTokenRegistry();
 
         // Add a token registry table if none exists
         tokenRegistry.createTokenTable(name);
@@ -340,8 +300,7 @@ public class StorageResources {
         try (InputStream inputStream = Resource.newClassPathResource(OAUTH_SUCCESS_PAGE).getInputStream()) {
           InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
           BufferedReader bufferedReader = new BufferedReader(reader);
-          successPage = bufferedReader.lines()
-            .collect(Collectors.joining("\n"));
+          successPage = bufferedReader.lines().collect(Collectors.joining("\n"));
           bufferedReader.close();
           reader.close();
         } catch (IOException e) {
@@ -351,15 +310,11 @@ public class StorageResources {
         return Response.status(Status.OK).entity(successPage).build();
       } else {
         logger.error("{} is not a HTTP plugin. You can only add auth code to HTTP plugins.", name);
-        return Response.status(Status.INTERNAL_SERVER_ERROR)
-          .entity(message("Unable to add authorization code: %s", name))
-          .build();
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add authorization code: %s", name)).build();
       }
     } catch (PluginException e) {
       logger.error("Error when adding auth token to {}", name);
-      return Response.status(Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Unable to add authorization code: %s", e.getMessage()))
-        .build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(message("Unable to add authorization code: %s", e.getMessage())).build();
     }
   }
 
@@ -369,8 +324,7 @@ public class StorageResources {
   @GET
   @Path("/storage/{name}/enable/{val}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=get%20%2Fstorage%2F%7Bname%7D%2Fenable%2F%7Bval%7D"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   @Deprecated
   public Response enablePluginViaGet(@PathParam("name") String name, @PathParam("val") Boolean enable) {
     return enablePlugin(name, enable);
@@ -388,27 +342,19 @@ public class StorageResources {
   public Response exportPlugin(@PathParam("name") String name, @PathParam("format") String format) {
     format = StringUtils.isNotEmpty(format) ? format.replace("/", "") : JSON_FORMAT;
     if (!isSupported(format)) {
-      return Response.status(Response.Status.NOT_ACCEPTABLE)
-        .entity(message("Unknown \"%s\" file format for Storage Plugin config", format))
-        .build();
+      return Response.status(Response.Status.NOT_ACCEPTABLE).entity(message("Unknown \"%s\" file format for Storage Plugin config", format)).build();
     }
 
-    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
-      .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format))
-      .build();
+    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name))).header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format)).build();
   }
 
   @DELETE
   @Path("/storage/{name}.json")
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=DELETE%20%2Fstorage%2F%7Bname,storage%20plugin%20configuration."))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response deletePlugin(@PathParam("name") String name) {
     try {
-      TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name))
-        .getContext()
-        .getoAuthTokenProvider()
-        .getOauthTokenRegistry();
+      TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext().getoAuthTokenProvider().getOauthTokenRegistry();
 
       // Delete a token registry table if it exists
       tokenRegistry.deleteTokenTable(name);
@@ -416,9 +362,7 @@ public class StorageResources {
       storage.remove(name);
       return Response.ok().entity(message("Success")).build();
     } catch (PluginException e) {
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Error while deleting plugin: %s",  e.getMessage()))
-        .build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Error while deleting plugin: %s", e.getMessage())).build();
     }
   }
 
@@ -426,17 +370,14 @@ public class StorageResources {
   @Path("/storage/{name}.json")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/#:~:text=post%20%2Fstorage%2F%7Bname%7D.json"))
-
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response createOrUpdatePluginJSON(PluginConfigWrapper plugin) {
     try {
       plugin.createOrUpdateInStorage(storage);
       return Response.ok().entity(message("Success")).build();
     } catch (PluginException e) {
       logger.error("Unable to create/ update plugin: " + plugin.getName(), e);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Error while saving plugin: %s ", e.getMessage()))
-        .build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Error while saving plugin: %s ", e.getMessage())).build();
     }
   }
 
@@ -452,9 +393,7 @@ public class StorageResources {
   public Response createOrUpdatePlugin(@FormParam("name") String name, @FormParam("config") String storagePluginConfig) {
     name = name.trim();
     if (name.isEmpty()) {
-      return Response.status(Response.Status.BAD_REQUEST)
-        .entity(message("A storage config name may not be empty"))
-        .build();
+      return Response.status(Response.Status.BAD_REQUEST).entity(message("A storage config name may not be empty")).build();
     }
 
     try {
@@ -462,14 +401,10 @@ public class StorageResources {
       return Response.ok().entity(message("Success")).build();
     } catch (PluginEncodingException e) {
       logger.warn("Error in JSON mapping: {}", storagePluginConfig, e);
-      return Response.status(Response.Status.BAD_REQUEST)
-        .entity(message("Invalid JSON: %s", e.getMessage()))
-        .build();
+      return Response.status(Response.Status.BAD_REQUEST).entity(message("Invalid JSON: %s", e.getMessage())).build();
     } catch (PluginException e) {
       logger.error("Error while saving plugin", e);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-        .entity(message("Error while saving plugin: %s", e.getMessage()))
-        .build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message("Error while saving plugin: %s", e.getMessage())).build();
     }
   }
 
@@ -502,24 +437,20 @@ public class StorageResources {
   public List<PluginConfigWrapper> getConfigsFor(@PathParam("group") String pluginGroup) {
     PluginFilter filter;
     switch (pluginGroup.trim()) {
-    case ALL_PLUGINS:
-      filter = PluginFilter.ALL;
-      break;
-    case ENABLED_PLUGINS:
-      filter = PluginFilter.ENABLED;
-      break;
-    case DISABLED_PLUGINS:
-      filter = PluginFilter.DISABLED;
-      break;
-    default:
-      return Collections.emptyList();
+      case ALL_PLUGINS:
+        filter = PluginFilter.ALL;
+        break;
+      case ENABLED_PLUGINS:
+        filter = PluginFilter.ENABLED;
+        break;
+      case DISABLED_PLUGINS:
+        filter = PluginFilter.DISABLED;
+        break;
+      default:
+        return Collections.emptyList();
     }
     pluginGroup = StringUtils.isNotEmpty(pluginGroup) ? pluginGroup.replace("/", "") : ALL_PLUGINS;
-    return StreamSupport.stream(
-        Spliterators.spliteratorUnknownSize(storage.storedConfigs(filter).entrySet().iterator(), Spliterator.ORDERED), false)
-            .map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue()))
-            .sorted(PLUGIN_COMPARATOR)
-            .collect(Collectors.toList());
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(storage.storedConfigs(filter).entrySet().iterator(), Spliterator.ORDERED), false).map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue())).sorted(PLUGIN_COMPARATOR).collect(Collectors.toList());
   }
 
   /**
@@ -565,7 +496,9 @@ public class StorageResources {
    */
   public static class StoragePluginModel {
     private final PluginConfigWrapper plugin;
+
     private final String type;
+
     private final String csrfToken;
 
     public StoragePluginModel(PluginConfigWrapper plugin, HttpServletRequest request) {

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -197,6 +197,14 @@
           <groupId>io.airlift</groupId>
           <artifactId>aircompresssor</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-jaxrs2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -18,7 +18,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.drill.exec</groupId>
@@ -264,7 +265,7 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <property name="app.class.path" refid="maven.test.classpath" />
+                <property name="app.class.path" refid="maven.test.classpath"/>
               </target>
             </configuration>
           </execution>
@@ -289,9 +290,11 @@
             -Ddrill.exec.sys.store.provider.local.write=false
             -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
             -XX:MaxDirectMemorySize=3072M
-            ${junit.args} -ea</argLine>
+            ${junit.args} -ea
+          </argLine>
           <additionalClasspathElements>
-            <additionalClasspathElements>${settings.localRepository}/org/junit/vintage/junit-vintage-engine/${junit.version}/junit-vintage-engine-${junit.version}.jar</additionalClasspathElements>
+            <additionalClasspathElements>${settings.localRepository}/org/junit/vintage/junit-vintage-engine/${junit.version}/junit-vintage-engine-${junit.version}.jar
+            </additionalClasspathElements>
             <additionalClasspathElements>${settings.localRepository}/org/hamcrest/hamcrest/${hamcrest.version}/hamcrest-${hamcrest.version}.jar</additionalClasspathElements>
             <additionalClasspathElements>${project.build.directory}/test-classes/</additionalClasspathElements>
           </additionalClasspathElements>
@@ -319,7 +322,7 @@
           <!--dependencyReducedPomLocation>${project.build.directory}/generated/shade/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
           <minimizeJar>false</minimizeJar>
 
-    <!-- Exclude dependencies at artifact level. Format is "groupId:artifactId[[:type]:classifier]" -->
+          <!-- Exclude dependencies at artifact level. Format is "groupId:artifactId[[:type]:classifier]" -->
           <artifactSet>
             <includes>
               <include>*:*</include>
@@ -381,65 +384,236 @@
           </artifactSet>
           <relocations>
             <!-- Relocate Drill classes to minimize classloader hell. -->
-            <relocation><pattern>org.apache.drill.exec.</pattern><shadedPattern>oadd.org.apache.drill.exec.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.drill.common.</pattern><shadedPattern>oadd.org.apache.drill.common.</shadedPattern></relocation>
+            <relocation>
+              <pattern>org.apache.drill.exec.</pattern>
+              <shadedPattern>oadd.org.apache.drill.exec.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.drill.common.</pattern>
+              <shadedPattern>oadd.org.apache.drill.common.</shadedPattern>
+            </relocation>
 
             <!-- Move dependencies out of path -->
-            <relocation><pattern>antlr.</pattern><shadedPattern>oadd.antlr.</shadedPattern></relocation>
-            <relocation><pattern>antlr.</pattern><shadedPattern>oadd.antlr.</shadedPattern></relocation>
-            <relocation><pattern>io.</pattern><shadedPattern>oadd.io.</shadedPattern></relocation>
-            <relocation><pattern>javacc.</pattern><shadedPattern>oadd.javacc.</shadedPattern></relocation>
-            <relocation><pattern>java_cup.</pattern><shadedPattern>oadd.java_cup.</shadedPattern></relocation>
-            <relocation><pattern>javassist.</pattern><shadedPattern>oadd.javassist.</shadedPattern></relocation>
-            <relocation><pattern>jline.</pattern><shadedPattern>oadd.jline.</shadedPattern></relocation>
-            <relocation><pattern>license.</pattern><shadedPattern>oadd.license.</shadedPattern></relocation>
-            <relocation><pattern>net.</pattern><shadedPattern>oadd.net.</shadedPattern></relocation>
-            <relocation><pattern>parquet.</pattern><shadedPattern>oadd.parquet.</shadedPattern></relocation>
-            <relocation><pattern>test.</pattern><shadedPattern>oadd.test.</shadedPattern></relocation>
-            <relocation><pattern>trax.</pattern><shadedPattern>oadd.trax.</shadedPattern></relocation>
-            <relocation><pattern>org.antlr.</pattern><shadedPattern>oadd.org.antlr.</shadedPattern></relocation>
-            <relocation><pattern>org.codehaus.</pattern><shadedPattern>oadd.org.codehaus.</shadedPattern></relocation>
-            <relocation><pattern>org.eigenbase.</pattern><shadedPattern>oadd.org.eigenbase.</shadedPattern></relocation>
-            <relocation><pattern>org.hamcrest.</pattern><shadedPattern>oadd.org.hamcrest.</shadedPattern></relocation>
-            <relocation><pattern>org.jboss.</pattern><shadedPattern>oadd.org.jboss.</shadedPattern></relocation>
-            <relocation><pattern>org.joda.</pattern><shadedPattern>oadd.org.joda.</shadedPattern></relocation>
-            <relocation><pattern>org.json.</pattern><shadedPattern>oadd.org.json.</shadedPattern></relocation>
-            <relocation><pattern>org.mockito.</pattern><shadedPattern>oadd.org.mockito.</shadedPattern></relocation>
-            <relocation><pattern>org.msgpack.</pattern><shadedPattern>oadd.org.msgpack.</shadedPattern></relocation>
-            <relocation><pattern>org.objectweb.</pattern><shadedPattern>oadd.org.objectweb.</shadedPattern></relocation>
-            <relocation><pattern>org.objensis.</pattern><shadedPattern>oadd.org.objensis.</shadedPattern></relocation>
-            <relocation><pattern>org.pentaho.</pattern><shadedPattern>oadd.org.pentaho.</shadedPattern></relocation>
-            <relocation><pattern>org.reflections.</pattern><shadedPattern>oadd.org.reflections.</shadedPattern></relocation>
-            <relocation><pattern>org.tukaani.</pattern><shadedPattern>oadd.org.tukaani.</shadedPattern></relocation>
-            <relocation><pattern>org.xerial.</pattern><shadedPattern>oadd.org.xerial.</shadedPattern></relocation>
-            <relocation><pattern>com.beust.</pattern><shadedPattern>oadd.com.beust.</shadedPattern></relocation>
-            <relocation><pattern>com.carrotsearch.</pattern><shadedPattern>oadd.com.carrotsearch.</shadedPattern></relocation>
-            <relocation><pattern>com.codahale.</pattern><shadedPattern>oadd.com.codahale.</shadedPattern></relocation>
-            <relocation><pattern>com.dyuproject.</pattern><shadedPattern>oadd.com.dyuproject.</shadedPattern></relocation>
-            <relocation><pattern>com.fasterxml.</pattern><shadedPattern>oadd.com.fasterxml.</shadedPattern></relocation>
-            <relocation><pattern>com.google.</pattern><shadedPattern>oadd.com.google.</shadedPattern></relocation>
-            <relocation><pattern>com.thoughtworks.</pattern><shadedPattern>oadd.com.thoughtworks.</shadedPattern></relocation>
-            <relocation><pattern>com.typesafe.</pattern><shadedPattern>oadd.com.typesafe.</shadedPattern></relocation>
-            <relocation><pattern>com.univocity.</pattern><shadedPattern>oadd.com.univocity.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.avro.</pattern><shadedPattern>oadd.org.apache.avro.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.bcel.</pattern><shadedPattern>oadd.org.apache.bcel.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.calcite.</pattern><shadedPattern>oadd.org.apache.calcite.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.commons.</pattern><shadedPattern>oadd.org.apache.commons.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.curator.</pattern><shadedPattern>oadd.org.apache.curator.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.html.</pattern><shadedPattern>oadd.org.apache.html.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.jute.</pattern><shadedPattern>oadd.org.apache.jute.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.log4j.</pattern><shadedPattern>oadd.org.apache.log4j.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.regexp.</pattern><shadedPattern>oadd.org.apache.regexp.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.velocity.</pattern><shadedPattern>oadd.org.apache.velocity.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.wml.</pattern><shadedPattern>oadd.org.apache.wml.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.xalan.</pattern><shadedPattern>oadd.org.apache.xalan.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.xerces.</pattern><shadedPattern>oadd.org.apache.xerces.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.xml.</pattern><shadedPattern>oadd.org.apache.xml.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.xmlcommons.</pattern><shadedPattern>oadd.org.apache.xmlcommons.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.xpath.</pattern><shadedPattern>oadd.org.apache.xpath.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.zookeeper.</pattern><shadedPattern>oadd.org.apache.zookeeper.</shadedPattern></relocation>
-            <relocation><pattern>org.apache.hadoop.</pattern><shadedPattern>oadd.org.apache.hadoop.</shadedPattern></relocation>
-            <relocation><pattern>com.ctc.wstx.</pattern><shadedPattern>oadd.com.ctc.wstx.</shadedPattern></relocation>
+            <relocation>
+              <pattern>antlr.</pattern>
+              <shadedPattern>oadd.antlr.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>antlr.</pattern>
+              <shadedPattern>oadd.antlr.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>io.</pattern>
+              <shadedPattern>oadd.io.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>javacc.</pattern>
+              <shadedPattern>oadd.javacc.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>java_cup.</pattern>
+              <shadedPattern>oadd.java_cup.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>javassist.</pattern>
+              <shadedPattern>oadd.javassist.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>jline.</pattern>
+              <shadedPattern>oadd.jline.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>license.</pattern>
+              <shadedPattern>oadd.license.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>net.</pattern>
+              <shadedPattern>oadd.net.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>parquet.</pattern>
+              <shadedPattern>oadd.parquet.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>test.</pattern>
+              <shadedPattern>oadd.test.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>trax.</pattern>
+              <shadedPattern>oadd.trax.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.antlr.</pattern>
+              <shadedPattern>oadd.org.antlr.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.codehaus.</pattern>
+              <shadedPattern>oadd.org.codehaus.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.eigenbase.</pattern>
+              <shadedPattern>oadd.org.eigenbase.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.hamcrest.</pattern>
+              <shadedPattern>oadd.org.hamcrest.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.jboss.</pattern>
+              <shadedPattern>oadd.org.jboss.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.joda.</pattern>
+              <shadedPattern>oadd.org.joda.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.json.</pattern>
+              <shadedPattern>oadd.org.json.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.mockito.</pattern>
+              <shadedPattern>oadd.org.mockito.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.msgpack.</pattern>
+              <shadedPattern>oadd.org.msgpack.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.objectweb.</pattern>
+              <shadedPattern>oadd.org.objectweb.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.objensis.</pattern>
+              <shadedPattern>oadd.org.objensis.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.pentaho.</pattern>
+              <shadedPattern>oadd.org.pentaho.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.reflections.</pattern>
+              <shadedPattern>oadd.org.reflections.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.tukaani.</pattern>
+              <shadedPattern>oadd.org.tukaani.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.xerial.</pattern>
+              <shadedPattern>oadd.org.xerial.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.beust.</pattern>
+              <shadedPattern>oadd.com.beust.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.carrotsearch.</pattern>
+              <shadedPattern>oadd.com.carrotsearch.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.codahale.</pattern>
+              <shadedPattern>oadd.com.codahale.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.dyuproject.</pattern>
+              <shadedPattern>oadd.com.dyuproject.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.fasterxml.</pattern>
+              <shadedPattern>oadd.com.fasterxml.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.</pattern>
+              <shadedPattern>oadd.com.google.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.thoughtworks.</pattern>
+              <shadedPattern>oadd.com.thoughtworks.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.typesafe.</pattern>
+              <shadedPattern>oadd.com.typesafe.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.univocity.</pattern>
+              <shadedPattern>oadd.com.univocity.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.avro.</pattern>
+              <shadedPattern>oadd.org.apache.avro.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.bcel.</pattern>
+              <shadedPattern>oadd.org.apache.bcel.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.calcite.</pattern>
+              <shadedPattern>oadd.org.apache.calcite.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.</pattern>
+              <shadedPattern>oadd.org.apache.commons.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.curator.</pattern>
+              <shadedPattern>oadd.org.apache.curator.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.html.</pattern>
+              <shadedPattern>oadd.org.apache.html.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.jute.</pattern>
+              <shadedPattern>oadd.org.apache.jute.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.log4j.</pattern>
+              <shadedPattern>oadd.org.apache.log4j.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.regexp.</pattern>
+              <shadedPattern>oadd.org.apache.regexp.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.velocity.</pattern>
+              <shadedPattern>oadd.org.apache.velocity.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.wml.</pattern>
+              <shadedPattern>oadd.org.apache.wml.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.xalan.</pattern>
+              <shadedPattern>oadd.org.apache.xalan.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.xerces.</pattern>
+              <shadedPattern>oadd.org.apache.xerces.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.xml.</pattern>
+              <shadedPattern>oadd.org.apache.xml.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.xmlcommons.</pattern>
+              <shadedPattern>oadd.org.apache.xmlcommons.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.xpath.</pattern>
+              <shadedPattern>oadd.org.apache.xpath.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.zookeeper.</pattern>
+              <shadedPattern>oadd.org.apache.zookeeper.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.hadoop.</pattern>
+              <shadedPattern>oadd.org.apache.hadoop.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.ctc.wstx.</pattern>
+              <shadedPattern>oadd.com.ctc.wstx.</shadedPattern>
+            </relocation>
           </relocations>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -447,105 +621,105 @@
             </transformer>
           </transformers>
 
-         <!-- Remove the particular directory or class level dependency from final jar -->
-         <filters>
-           <filter>
-             <artifact>*:*</artifact>
-             <excludes>
-               <exclude>**/logback.xml</exclude>
-               <exclude>**/LICENSE.txt</exclude>
-               <exclude>**/*.java</exclude>
-               <exclude>META-INF/ASL2.0</exclude>
-               <exclude>META-INF/NOTICE.txt</exclude>
-               <exclude>META-INF/drill-module-scan/**</exclude>
-               <exclude>META-INF/jboss-beans.xml</exclude>
-               <exclude>META-INF/license/**</exclude>
-               <exclude>META-INF/maven/**</exclude>
-               <exclude>META-INF/native/**</exclude>
-               <exclude>META-INF/services/com.fasterxml.*</exclude>
-               <exclude>META-INF/services/javax.ws.*</exclude>
-               <exclude>META-INF/**/*.properties</exclude>
-               <exclude>**/org.codehaus.commons.compiler.properties</exclude>
-               <exclude>module-info.class</exclude>
-               <exclude>**/*.SF</exclude>
-               <exclude>**/*.RSA</exclude>
-               <exclude>**/*.DSA</exclude>
-               <exclude>javax/*</exclude>
-               <exclude>javax/activation/**</exclude>
-               <exclude>javax/annotation-api/**</exclude>
-               <exclude>javax/inject/**</exclude>
-               <exclude>javax/servlet-api/**</exclude>
-               <exclude>javax/json/**</exclude>
-               <exclude>javax/ws/**</exclude>
-               <exclude>rest/**</exclude>
-               <exclude>*.tokens</exclude>
-               <exclude>codegen/**</exclude>
-               <exclude>bootstrap-storage-plugins.json</exclude>
-               <exclude>org/apache/parquet</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/escape/**</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/eventbus/**</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/html/**</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/net/**</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/xml/**</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/io/BaseEncoding*</exclude>
-               <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
-               <exclude>com/google/common/math</exclude>
-               <exclude>com/google/common/net</exclude>
-               <exclude>com/google/common/primitives</exclude>
-               <exclude>com/google/common/reflect</exclude>
-               <exclude>com/google/common/util</exclude>
-               <exclude>com/google/common/cache</exclude>
-               <exclude>com/google/common/collect/Tree*</exclude>
-               <exclude>com/google/common/collect/Standard*</exclude>
-               <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
-               <exclude>org/apache/drill/exec/expr/fn/**</exclude>
-               <exclude>org/apache/drill/exec/proto/beans/**</exclude>
-               <exclude>org/apache/drill/exec/compile/**</exclude>
-               <exclude>org/apache/drill/exec/planner/**</exclude>
-               <exclude>org/apache/drill/exec/physical/**</exclude>
-               <exclude>org/apache/drill/exec/store/**</exclude>
-               <exclude>org/apache/drill/exec/server/rest/**</exclude>
-               <exclude>org/apache/drill/exec/rpc/data/**</exclude>
-               <exclude>org/apache/drill/exec/rpc/control/**</exclude>
-               <exclude>org/apache/drill/exec/work/**</exclude>
-               <exclude>org/apache/hadoop/crypto/**</exclude>
-               <exclude>org/apache/hadoop/ha/**</exclude>
-               <exclude>org/apache/hadoop/http/**</exclude>
-               <exclude>org/apache/hadoop/ipc/**</exclude>
-               <exclude>org/apache/hadoop/jmx/**</exclude>
-               <exclude>org/apache/hadoop/log/**</exclude>
-               <exclude>org/apache/hadoop/metrics/**</exclude>
-               <exclude>org/apache/hadoop/net/**</exclude>
-               <exclude>org/apache/hadoop/record/**</exclude>
-               <exclude>org/apache/hadoop/service/**</exclude>
-               <exclude>org/apache/hadoop/tracing/**</exclude>
-               <exclude>org/apache/hadoop/tools/**</exclude>
-               <exclude>org/apache/hadoop/yarn/**</exclude>
-               <exclude>org/apache/commons/pool2/**</exclude>
-               <exclude>org/apache/http/**</exclude>
-               <exclude>org/apache/directory/**</exclude>
-               <exclude>org/apache/drill/metastore/**</exclude>
-               <exclude>com/jcraft/**</exclude>
-               <exclude>**/mapr/**</exclude>
-               <exclude>org/yaml/**</exclude>
-               <exclude>hello/**</exclude>
-               <exclude>webapps/**</exclude>
-             </excludes>
-           </filter>
-           <!-- This file is used to automatically load given jdbc driver without calling Class.forName().
-                Excluding the Avatica service file which is conflicting with the Drill one. -->
-           <filter>
-             <artifact>org.apache.calcite.avatica:*</artifact>
-             <excludes>
-               <exclude>META-INF/services/java.sql.Driver</exclude>
-               <!-- Excludes shaded slf4j to avoid conflicts when they are put into the fat jar -->
-               <exclude>org/slf4j/**</exclude>
-             </excludes>
-           </filter>
-         </filters>
+          <!-- Remove the particular directory or class level dependency from final jar -->
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>**/logback.xml</exclude>
+                <exclude>**/LICENSE.txt</exclude>
+                <exclude>**/*.java</exclude>
+                <exclude>META-INF/ASL2.0</exclude>
+                <exclude>META-INF/NOTICE.txt</exclude>
+                <exclude>META-INF/drill-module-scan/**</exclude>
+                <exclude>META-INF/jboss-beans.xml</exclude>
+                <exclude>META-INF/license/**</exclude>
+                <exclude>META-INF/maven/**</exclude>
+                <exclude>META-INF/native/**</exclude>
+                <exclude>META-INF/services/com.fasterxml.*</exclude>
+                <exclude>META-INF/services/javax.ws.*</exclude>
+                <exclude>META-INF/**/*.properties</exclude>
+                <exclude>**/org.codehaus.commons.compiler.properties</exclude>
+                <exclude>module-info.class</exclude>
+                <exclude>**/*.SF</exclude>
+                <exclude>**/*.RSA</exclude>
+                <exclude>**/*.DSA</exclude>
+                <exclude>javax/*</exclude>
+                <exclude>javax/activation/**</exclude>
+                <exclude>javax/annotation-api/**</exclude>
+                <exclude>javax/inject/**</exclude>
+                <exclude>javax/servlet-api/**</exclude>
+                <exclude>javax/json/**</exclude>
+                <exclude>javax/ws/**</exclude>
+                <exclude>rest/**</exclude>
+                <exclude>*.tokens</exclude>
+                <exclude>codegen/**</exclude>
+                <exclude>bootstrap-storage-plugins.json</exclude>
+                <exclude>org/apache/parquet</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/escape/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/eventbus/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/html/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/net/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/xml/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/io/BaseEncoding*</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                <exclude>com/google/common/math</exclude>
+                <exclude>com/google/common/net</exclude>
+                <exclude>com/google/common/primitives</exclude>
+                <exclude>com/google/common/reflect</exclude>
+                <exclude>com/google/common/util</exclude>
+                <exclude>com/google/common/cache</exclude>
+                <exclude>com/google/common/collect/Tree*</exclude>
+                <exclude>com/google/common/collect/Standard*</exclude>
+                <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
+                <exclude>org/apache/drill/exec/expr/fn/**</exclude>
+                <exclude>org/apache/drill/exec/proto/beans/**</exclude>
+                <exclude>org/apache/drill/exec/compile/**</exclude>
+                <exclude>org/apache/drill/exec/planner/**</exclude>
+                <exclude>org/apache/drill/exec/physical/**</exclude>
+                <exclude>org/apache/drill/exec/store/**</exclude>
+                <exclude>org/apache/drill/exec/server/rest/**</exclude>
+                <exclude>org/apache/drill/exec/rpc/data/**</exclude>
+                <exclude>org/apache/drill/exec/rpc/control/**</exclude>
+                <exclude>org/apache/drill/exec/work/**</exclude>
+                <exclude>org/apache/hadoop/crypto/**</exclude>
+                <exclude>org/apache/hadoop/ha/**</exclude>
+                <exclude>org/apache/hadoop/http/**</exclude>
+                <exclude>org/apache/hadoop/ipc/**</exclude>
+                <exclude>org/apache/hadoop/jmx/**</exclude>
+                <exclude>org/apache/hadoop/log/**</exclude>
+                <exclude>org/apache/hadoop/metrics/**</exclude>
+                <exclude>org/apache/hadoop/net/**</exclude>
+                <exclude>org/apache/hadoop/record/**</exclude>
+                <exclude>org/apache/hadoop/service/**</exclude>
+                <exclude>org/apache/hadoop/tracing/**</exclude>
+                <exclude>org/apache/hadoop/tools/**</exclude>
+                <exclude>org/apache/hadoop/yarn/**</exclude>
+                <exclude>org/apache/commons/pool2/**</exclude>
+                <exclude>org/apache/http/**</exclude>
+                <exclude>org/apache/directory/**</exclude>
+                <exclude>org/apache/drill/metastore/**</exclude>
+                <exclude>com/jcraft/**</exclude>
+                <exclude>**/mapr/**</exclude>
+                <exclude>org/yaml/**</exclude>
+                <exclude>hello/**</exclude>
+                <exclude>webapps/**</exclude>
+              </excludes>
+            </filter>
+            <!-- This file is used to automatically load given jdbc driver without calling Class.forName().
+                 Excluding the Avatica service file which is conflicting with the Drill one. -->
+            <filter>
+              <artifact>org.apache.calcite.avatica:*</artifact>
+              <excludes>
+                <exclude>META-INF/services/java.sql.Driver</exclude>
+                <!-- Excludes shaded slf4j to avoid conflicts when they are put into the fat jar -->
+                <exclude>org/slf4j/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
       </plugin>
 
@@ -564,15 +738,16 @@
                 <requireFilesSize>
                   <message>
 
-                  The file drill-jdbc-all-${project.version}.jar is outside the expected size range.
+                    The file drill-jdbc-all-${project.version}.jar is outside the expected size range.
 
-                  This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
+                    This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the
+                    dependency of Drill application users.
 
                   </message>
                   <maxsize>${jdbc-all-jar.maxsize}</maxsize>
                   <minsize>15000000</minsize>
                   <files>
-                   <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>
+                    <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>
                   </files>
                 </requireFilesSize>
               </rules>
@@ -586,248 +761,413 @@
   </build>
 
   <profiles>
-      <profile>
-        <id>mapr</id>
-        <properties>
-          <package.namespace.prefix />
-        </properties>
+    <profile>
+      <id>mapr</id>
+      <properties>
+        <package.namespace.prefix/>
+      </properties>
 
-        <build>
-          <plugins>
-            <plugin>
-              <artifactId>maven-shade-plugin</artifactId>
-              <configuration>
-                <shadedArtifactAttached>false</shadedArtifactAttached>
-                <createDependencyReducedPom>true</createDependencyReducedPom>
-                <!-- TODO DRILL-4336: try to move the dependencyReducedPom out of the default location (the module root).
-                     Putting it here caused the target directory to be run as a submodule (oddly
-                     only when trying to run the maven release goal) -->
-                <!--dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
-                <!-- TODO DRILL-4336: an attempt to fix the issue by moving the file elsewhere, had issues executing
-                     but may be able to be modified to to fix the issue-->
-                <!--dependencyReducedPomLocation>${project.build.directory}/generated/shade/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
-                <minimizeJar>false</minimizeJar>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- TODO DRILL-4336: try to move the dependencyReducedPom out of the default location (the module root).
+                   Putting it here caused the target directory to be run as a submodule (oddly
+                   only when trying to run the maven release goal) -->
+              <!--dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
+              <!-- TODO DRILL-4336: an attempt to fix the issue by moving the file elsewhere, had issues executing
+                   but may be able to be modified to to fix the issue-->
+              <!--dependencyReducedPomLocation>${project.build.directory}/generated/shade/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
+              <minimizeJar>false</minimizeJar>
 
-                <!-- Exclude dependencies at artifact level. Format is "groupId:artifactId[[:type]:classifier]" -->
-                <artifactSet>
-                  <includes>
-                    <include>*:*</include>
-                  </includes>
+              <!-- Exclude dependencies at artifact level. Format is "groupId:artifactId[[:type]:classifier]" -->
+              <artifactSet>
+                <includes>
+                  <include>*:*</include>
+                </includes>
+                <excludes>
+                  <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                  <exclude>io.protostuff:*</exclude>
+                  <exclude>${calcite.groupId}:calcite-core</exclude>
+                  <exclude>${calcite.groupId}:calcite-linq4j</exclude>
+                  <exclude>org.pentaho:*</exclude>
+                  <exclude>org.msgpack:*</exclude>
+                  <exclude>xerces:*</exclude>
+                  <exclude>xalan:*</exclude>
+                  <exclude>org.apache.avro:*</exclude>
+                  <exclude>org.mongodb:*</exclude>
+                  <exclude>com.googlecode.json-simple:*</exclude>
+                  <exclude>dom4j:*</exclude>
+                  <exclude>org.hibernate:*</exclude>
+                  <exclude>antlr:*</exclude>
+                  <exclude>org.ow2.asm:*</exclude>
+                  <exclude>com.univocity:*</exclude>
+                  <exclude>net.sf.jpam:*</exclude>
+                  <exclude>com.twitter:*</exclude>
+                  <exclude>org.apache.parquet:*</exclude>
+                  <exclude>javax.inject:*</exclude>
+                  <exclude>com.beust:*</exclude>
+                  <exclude>jline:*</exclude>
+                  <exclude>org.xerial.snappy:*</exclude>
+                  <exclude>org.apache.avro:*</exclude>
+                  <exclude>org.tukaani:*</exclude>
+                  <exclude>org.apache.velocity:*</exclude>
+                  <exclude>net.hydromatic:linq4j</exclude>
+                  <exclude>org.codehaus.janino:*</exclude>
+                  <exclude>org.mortbay.jetty:*</exclude>
+                  <exclude>org.slf4j:jul-to-slf4j</exclude>
+                  <exclude>org.slf4j:log4j-over-slf4j</exclude>
+                  <exclude>org.hamcrest:hamcrest-core</exclude>
+                  <exclude>org.mockito:mockito-core</exclude>
+                  <exclude>org.objenesis:objenesis</exclude>
+                  <exclude>org.eclipse.jetty:*</exclude>
+                  <exclude>org.apache.hadoop:*</exclude>
+                  <exclude>org.jboss.netty:netty</exclude>
+                  <exclude>javax.xml.bind:jaxb-api</exclude>
+                  <exclude>javax.xml.stream:stax-api</exclude>
+                  <exclude>javax.activation:activation</exclude>
+                  <exclude>commons-cli:commons-cli</exclude>
+                  <exclude>org.apache.commons:commons-collections4</exclude>
+                  <exclude>commons-io:commons-io</exclude>
+                  <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
+                  <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
+                  <exclude>com.google.code.findbugs:jsr305:*</exclude>
+                  <exclude>com.esri.geometry:esri-geometry-api:*</exclude>
+                  <exclude>dnsjava:dnsjava:jar:*</exclude>
+                  <exclude>io.netty:netty-tcnative:jar:*</exclude>
+                  <exclude>io.netty:netty-tcnative-classes:jar:*</exclude>
+                  <exclude>com.bettercloud:vault-java-driver:jar:*</exclude>
+                  <exclude>com.tdunning:t-digest:jar:*</exclude>
+                  <exclude>io.airlift:aircompressor:jar:*</exclude>
+                  <exclude>com.rdblue:brotli-codec:jar:*</exclude>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <!-- Relocate Drill classes to minimize classloader hell. -->
+                <relocation>
+                  <pattern>org.apache.drill.exec.</pattern>
+                  <shadedPattern>oadd.org.apache.drill.exec.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.drill.common.</pattern>
+                  <shadedPattern>oadd.org.apache.drill.common.</shadedPattern>
+                </relocation>
+
+                <!-- Move dependencies out of path -->
+                <relocation>
+                  <pattern>antlr.</pattern>
+                  <shadedPattern>oadd.antlr.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>antlr.</pattern>
+                  <shadedPattern>oadd.antlr.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.</pattern>
+                  <shadedPattern>oadd.io.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javacc.</pattern>
+                  <shadedPattern>oadd.javacc.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>java_cup.</pattern>
+                  <shadedPattern>oadd.java_cup.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javassist.</pattern>
+                  <shadedPattern>oadd.javassist.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jline.</pattern>
+                  <shadedPattern>oadd.jline.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>license.</pattern>
+                  <shadedPattern>oadd.license.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.</pattern>
+                  <shadedPattern>oadd.net.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>parquet.</pattern>
+                  <shadedPattern>oadd.parquet.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>test.</pattern>
+                  <shadedPattern>oadd.test.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>trax.</pattern>
+                  <shadedPattern>oadd.trax.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.antlr.</pattern>
+                  <shadedPattern>oadd.org.antlr.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.</pattern>
+                  <shadedPattern>oadd.org.codehaus.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.eigenbase.</pattern>
+                  <shadedPattern>oadd.org.eigenbase.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.hamcrest.</pattern>
+                  <shadedPattern>oadd.org.hamcrest.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.jboss.</pattern>
+                  <shadedPattern>oadd.org.jboss.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.joda.</pattern>
+                  <shadedPattern>oadd.org.joda.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json.</pattern>
+                  <shadedPattern>oadd.org.json.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.mockito.</pattern>
+                  <shadedPattern>oadd.org.mockito.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.msgpack.</pattern>
+                  <shadedPattern>oadd.org.msgpack.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.objectweb.</pattern>
+                  <shadedPattern>oadd.org.objectweb.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.objensis.</pattern>
+                  <shadedPattern>oadd.org.objensis.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.pentaho.</pattern>
+                  <shadedPattern>oadd.org.pentaho.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.reflections.</pattern>
+                  <shadedPattern>oadd.org.reflections.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.tukaani.</pattern>
+                  <shadedPattern>oadd.org.tukaani.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.xerial.</pattern>
+                  <shadedPattern>oadd.org.xerial.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.beust.</pattern>
+                  <shadedPattern>oadd.com.beust.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.carrotsearch.</pattern>
+                  <shadedPattern>oadd.com.carrotsearch.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.codahale.</pattern>
+                  <shadedPattern>oadd.com.codahale.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.dyuproject.</pattern>
+                  <shadedPattern>oadd.com.dyuproject.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.</pattern>
+                  <shadedPattern>oadd.com.fasterxml.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.</pattern>
+                  <shadedPattern>oadd.com.google.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.thoughtworks.</pattern>
+                  <shadedPattern>oadd.com.thoughtworks.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.typesafe.</pattern>
+                  <shadedPattern>oadd.com.typesafe.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.univocity.</pattern>
+                  <shadedPattern>oadd.com.univocity.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.avro.</pattern>
+                  <shadedPattern>oadd.org.apache.avro.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.bcel.</pattern>
+                  <shadedPattern>oadd.org.apache.bcel.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.calcite.</pattern>
+                  <shadedPattern>oadd.org.apache.calcite.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.</pattern>
+                  <shadedPattern>oadd.org.apache.commons.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.curator.</pattern>
+                  <shadedPattern>oadd.org.apache.curator.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.html.</pattern>
+                  <shadedPattern>oadd.org.apache.html.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.jute.</pattern>
+                  <shadedPattern>oadd.org.apache.jute.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.log4j.</pattern>
+                  <shadedPattern>oadd.org.apache.log4j.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.regexp.</pattern>
+                  <shadedPattern>oadd.org.apache.regexp.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.velocity.</pattern>
+                  <shadedPattern>oadd.org.apache.velocity.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.wml.</pattern>
+                  <shadedPattern>oadd.org.apache.wml.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.xalan.</pattern>
+                  <shadedPattern>oadd.org.apache.xalan.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.xerces.</pattern>
+                  <shadedPattern>oadd.org.apache.xerces.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.xml.</pattern>
+                  <shadedPattern>oadd.org.apache.xml.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.xmlcommons.</pattern>
+                  <shadedPattern>oadd.org.apache.xmlcommons.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.xpath.</pattern>
+                  <shadedPattern>oadd.org.apache.xpath.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.zookeeper.</pattern>
+                  <shadedPattern>oadd.org.apache.zookeeper.</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>drill-module.conf</resource>
+                </transformer>
+              </transformers>
+
+              <!-- Remove the particular directory or class level dependency from final jar -->
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                    <exclude>io.protostuff:*</exclude>
-                    <exclude>${calcite.groupId}:calcite-core</exclude>
-                    <exclude>${calcite.groupId}:calcite-linq4j</exclude>
-                    <exclude>org.pentaho:*</exclude>
-                    <exclude>org.msgpack:*</exclude>
-                    <exclude>xerces:*</exclude>
-                    <exclude>xalan:*</exclude>
-                    <exclude>org.apache.avro:*</exclude>
-                    <exclude>org.mongodb:*</exclude>
-                    <exclude>com.googlecode.json-simple:*</exclude>
-                    <exclude>dom4j:*</exclude>
-                    <exclude>org.hibernate:*</exclude>
-                    <exclude>antlr:*</exclude>
-                    <exclude>org.ow2.asm:*</exclude>
-                    <exclude>com.univocity:*</exclude>
-                    <exclude>net.sf.jpam:*</exclude>
-                    <exclude>com.twitter:*</exclude>
-                    <exclude>org.apache.parquet:*</exclude>
-                    <exclude>javax.inject:*</exclude>
-                    <exclude>com.beust:*</exclude>
-                    <exclude>jline:*</exclude>
-                    <exclude>org.xerial.snappy:*</exclude>
-                    <exclude>org.apache.avro:*</exclude>
-                    <exclude>org.tukaani:*</exclude>
-                    <exclude>org.apache.velocity:*</exclude>
-                    <exclude>net.hydromatic:linq4j</exclude>
-                    <exclude>org.codehaus.janino:*</exclude>
-                    <exclude>org.mortbay.jetty:*</exclude>
-                    <exclude>org.slf4j:jul-to-slf4j</exclude>
-                    <exclude>org.slf4j:log4j-over-slf4j</exclude>
-                    <exclude>org.hamcrest:hamcrest-core</exclude>
-                    <exclude>org.mockito:mockito-core</exclude>
-                    <exclude>org.objenesis:objenesis</exclude>
-                    <exclude>org.eclipse.jetty:*</exclude>
-                    <exclude>org.apache.hadoop:*</exclude>
-                    <exclude>org.jboss.netty:netty</exclude>
-                    <exclude>javax.xml.bind:jaxb-api</exclude>
-                    <exclude>javax.xml.stream:stax-api</exclude>
-                    <exclude>javax.activation:activation</exclude>
-                    <exclude>commons-cli:commons-cli</exclude>
-                    <exclude>org.apache.commons:commons-collections4</exclude>
-                    <exclude>commons-io:commons-io</exclude>
-                    <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
-                    <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
-                    <exclude>com.google.code.findbugs:jsr305:*</exclude>
-                    <exclude>com.esri.geometry:esri-geometry-api:*</exclude>
-                    <exclude>dnsjava:dnsjava:jar:*</exclude>
-                    <exclude>io.netty:netty-tcnative:jar:*</exclude>
-                    <exclude>io.netty:netty-tcnative-classes:jar:*</exclude>
-                    <exclude>com.bettercloud:vault-java-driver:jar:*</exclude>
-                    <exclude>com.tdunning:t-digest:jar:*</exclude>
-                    <exclude>io.airlift:aircompressor:jar:*</exclude>
-                    <exclude>com.rdblue:brotli-codec:jar:*</exclude>
+                    <exclude>**/logback.xml</exclude>
+                    <exclude>**/LICENSE.txt</exclude>
+                    <exclude>**/*.java</exclude>
+                    <exclude>META-INF/ASL2.0</exclude>
+                    <exclude>META-INF/NOTICE.txt</exclude>
+                    <exclude>META-INF/drill-module-scan/**</exclude>
+                    <exclude>META-INF/jboss-beans.xml</exclude>
+                    <exclude>META-INF/license/**</exclude>
+                    <exclude>META-INF/maven/**</exclude>
+                    <exclude>META-INF/native/**</exclude>
+                    <exclude>META-INF/services/com.fasterxml.*</exclude>
+                    <exclude>META-INF/services/javax.ws.*</exclude>
+                    <exclude>META-INF/**/*.properties</exclude>
+                    <exclude>**/org.codehaus.commons.compiler.properties</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>**/*.SF</exclude>
+                    <exclude>**/*.RSA</exclude>
+                    <exclude>**/*.DSA</exclude>
+                    <exclude>javax/*</exclude>
+                    <exclude>javax/activation/**</exclude>
+                    <exclude>javax/annotation-api/**</exclude>
+                    <exclude>javax/inject/**</exclude>
+                    <exclude>javax/servlet-api/**</exclude>
+                    <exclude>javax/json/**</exclude>
+                    <exclude>javax/ws/**</exclude>
+                    <exclude>rest/**</exclude>
+                    <exclude>*.tokens</exclude>
+                    <exclude>codegen/**</exclude>
+                    <exclude>bootstrap-storage-plugins.json</exclude>
+                    <exclude>org/apache/parquet</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/escape/**</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/eventbus/**</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/html/**</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/net/**</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/xml/**</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
+                    <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                    <exclude>com/google/common/math</exclude>
+                    <exclude>com/google/common/net</exclude>
+                    <exclude>com/google/common/primitives</exclude>
+                    <exclude>com/google/common/reflect</exclude>
+                    <exclude>com/google/common/util</exclude>
+                    <exclude>com/google/common/cache</exclude>
+                    <exclude>com/google/common/collect/Tree*</exclude>
+                    <exclude>com/google/common/collect/Standard*</exclude>
+                    <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
+                    <exclude>org/apache/drill/exec/expr/fn/**</exclude>
+                    <exclude>org/apache/drill/exec/proto/beans/**</exclude>
+                    <exclude>org/apache/drill/exec/compile/**</exclude>
+                    <exclude>org/apache/drill/exec/planner/**</exclude>
+                    <exclude>org/apache/drill/exec/physical/**</exclude>
+                    <exclude>org/apache/drill/exec/store/**</exclude>
+                    <exclude>org/apache/drill/exec/server/rest/**</exclude>
+                    <exclude>org/apache/drill/exec/rpc/data/**</exclude>
+                    <exclude>org/apache/drill/exec/rpc/control/**</exclude>
+                    <exclude>org/apache/drill/exec/work/**</exclude>
+                    <exclude>org/apache/drill/metastore/**</exclude>
+                    <exclude>org/apache/hadoop/**</exclude>
+                    <exclude>org/apache/commons/pool2/**</exclude>
+                    <exclude>org/apache/http/**</exclude>
+                    <exclude>org/apache/directory/**</exclude>
+                    <exclude>com/jcraft/**</exclude>
+                    <exclude>**/mapr/**</exclude>
+                    <exclude>org/yaml/**</exclude>
+                    <exclude>hello/**</exclude>
+                    <exclude>webapps/**</exclude>
                   </excludes>
-                </artifactSet>
-                <relocations>
-                  <!-- Relocate Drill classes to minimize classloader hell. -->
-                  <relocation><pattern>org.apache.drill.exec.</pattern><shadedPattern>oadd.org.apache.drill.exec.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.drill.common.</pattern><shadedPattern>oadd.org.apache.drill.common.</shadedPattern></relocation>
+                </filter>
+                <!-- This file is used to automatically load given jdbc driver without calling Class.forName().
+                     Excluding the Avatica service file which is conflicting with the Drill one. -->
+                <filter>
+                  <artifact>org.apache.calcite.avatica:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/java.sql.Driver</exclude>
+                    <!-- Excludes shaded slf4j to avoid conflicts when they are put into the fat jar -->
+                    <exclude>org/slf4j/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </plugin>
+        </plugins>
 
-                  <!-- Move dependencies out of path -->
-                  <relocation><pattern>antlr.</pattern><shadedPattern>oadd.antlr.</shadedPattern></relocation>
-                  <relocation><pattern>antlr.</pattern><shadedPattern>oadd.antlr.</shadedPattern></relocation>
-                  <relocation><pattern>io.</pattern><shadedPattern>oadd.io.</shadedPattern></relocation>
-                  <relocation><pattern>javacc.</pattern><shadedPattern>oadd.javacc.</shadedPattern></relocation>
-                  <relocation><pattern>java_cup.</pattern><shadedPattern>oadd.java_cup.</shadedPattern></relocation>
-                  <relocation><pattern>javassist.</pattern><shadedPattern>oadd.javassist.</shadedPattern></relocation>
-                  <relocation><pattern>jline.</pattern><shadedPattern>oadd.jline.</shadedPattern></relocation>
-                  <relocation><pattern>license.</pattern><shadedPattern>oadd.license.</shadedPattern></relocation>
-                  <relocation><pattern>net.</pattern><shadedPattern>oadd.net.</shadedPattern></relocation>
-                  <relocation><pattern>parquet.</pattern><shadedPattern>oadd.parquet.</shadedPattern></relocation>
-                  <relocation><pattern>test.</pattern><shadedPattern>oadd.test.</shadedPattern></relocation>
-                  <relocation><pattern>trax.</pattern><shadedPattern>oadd.trax.</shadedPattern></relocation>
-                  <relocation><pattern>org.antlr.</pattern><shadedPattern>oadd.org.antlr.</shadedPattern></relocation>
-                  <relocation><pattern>org.codehaus.</pattern><shadedPattern>oadd.org.codehaus.</shadedPattern></relocation>
-                  <relocation><pattern>org.eigenbase.</pattern><shadedPattern>oadd.org.eigenbase.</shadedPattern></relocation>
-                  <relocation><pattern>org.hamcrest.</pattern><shadedPattern>oadd.org.hamcrest.</shadedPattern></relocation>
-                  <relocation><pattern>org.jboss.</pattern><shadedPattern>oadd.org.jboss.</shadedPattern></relocation>
-                  <relocation><pattern>org.joda.</pattern><shadedPattern>oadd.org.joda.</shadedPattern></relocation>
-                  <relocation><pattern>org.json.</pattern><shadedPattern>oadd.org.json.</shadedPattern></relocation>
-                  <relocation><pattern>org.mockito.</pattern><shadedPattern>oadd.org.mockito.</shadedPattern></relocation>
-                  <relocation><pattern>org.msgpack.</pattern><shadedPattern>oadd.org.msgpack.</shadedPattern></relocation>
-                  <relocation><pattern>org.objectweb.</pattern><shadedPattern>oadd.org.objectweb.</shadedPattern></relocation>
-                  <relocation><pattern>org.objensis.</pattern><shadedPattern>oadd.org.objensis.</shadedPattern></relocation>
-                  <relocation><pattern>org.pentaho.</pattern><shadedPattern>oadd.org.pentaho.</shadedPattern></relocation>
-                  <relocation><pattern>org.reflections.</pattern><shadedPattern>oadd.org.reflections.</shadedPattern></relocation>
-                  <relocation><pattern>org.tukaani.</pattern><shadedPattern>oadd.org.tukaani.</shadedPattern></relocation>
-                  <relocation><pattern>org.xerial.</pattern><shadedPattern>oadd.org.xerial.</shadedPattern></relocation>
-                  <relocation><pattern>com.beust.</pattern><shadedPattern>oadd.com.beust.</shadedPattern></relocation>
-                  <relocation><pattern>com.carrotsearch.</pattern><shadedPattern>oadd.com.carrotsearch.</shadedPattern></relocation>
-                  <relocation><pattern>com.codahale.</pattern><shadedPattern>oadd.com.codahale.</shadedPattern></relocation>
-                  <relocation><pattern>com.dyuproject.</pattern><shadedPattern>oadd.com.dyuproject.</shadedPattern></relocation>
-                  <relocation><pattern>com.fasterxml.</pattern><shadedPattern>oadd.com.fasterxml.</shadedPattern></relocation>
-                  <relocation><pattern>com.google.</pattern><shadedPattern>oadd.com.google.</shadedPattern></relocation>
-                  <relocation><pattern>com.thoughtworks.</pattern><shadedPattern>oadd.com.thoughtworks.</shadedPattern></relocation>
-                  <relocation><pattern>com.typesafe.</pattern><shadedPattern>oadd.com.typesafe.</shadedPattern></relocation>
-                  <relocation><pattern>com.univocity.</pattern><shadedPattern>oadd.com.univocity.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.avro.</pattern><shadedPattern>oadd.org.apache.avro.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.bcel.</pattern><shadedPattern>oadd.org.apache.bcel.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.calcite.</pattern><shadedPattern>oadd.org.apache.calcite.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.commons.</pattern><shadedPattern>oadd.org.apache.commons.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.curator.</pattern><shadedPattern>oadd.org.apache.curator.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.html.</pattern><shadedPattern>oadd.org.apache.html.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.jute.</pattern><shadedPattern>oadd.org.apache.jute.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.log4j.</pattern><shadedPattern>oadd.org.apache.log4j.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.regexp.</pattern><shadedPattern>oadd.org.apache.regexp.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.velocity.</pattern><shadedPattern>oadd.org.apache.velocity.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.wml.</pattern><shadedPattern>oadd.org.apache.wml.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.xalan.</pattern><shadedPattern>oadd.org.apache.xalan.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.xerces.</pattern><shadedPattern>oadd.org.apache.xerces.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.xml.</pattern><shadedPattern>oadd.org.apache.xml.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.xmlcommons.</pattern><shadedPattern>oadd.org.apache.xmlcommons.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.xpath.</pattern><shadedPattern>oadd.org.apache.xpath.</shadedPattern></relocation>
-                  <relocation><pattern>org.apache.zookeeper.</pattern><shadedPattern>oadd.org.apache.zookeeper.</shadedPattern></relocation>
-                </relocations>
-                <transformers>
-                  <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                    <resource>drill-module.conf</resource>
-                  </transformer>
-                </transformers>
-
-                <!-- Remove the particular directory or class level dependency from final jar -->
-                <filters>
-                  <filter>
-                    <artifact>*:*</artifact>
-                    <excludes>
-                      <exclude>**/logback.xml</exclude>
-                      <exclude>**/LICENSE.txt</exclude>
-                      <exclude>**/*.java</exclude>
-                      <exclude>META-INF/ASL2.0</exclude>
-                      <exclude>META-INF/NOTICE.txt</exclude>
-                      <exclude>META-INF/drill-module-scan/**</exclude>
-                      <exclude>META-INF/jboss-beans.xml</exclude>
-                      <exclude>META-INF/license/**</exclude>
-                      <exclude>META-INF/maven/**</exclude>
-                      <exclude>META-INF/native/**</exclude>
-                      <exclude>META-INF/services/com.fasterxml.*</exclude>
-                      <exclude>META-INF/services/javax.ws.*</exclude>
-                      <exclude>META-INF/**/*.properties</exclude>
-                      <exclude>**/org.codehaus.commons.compiler.properties</exclude>
-                      <exclude>module-info.class</exclude>
-                      <exclude>**/*.SF</exclude>
-                      <exclude>**/*.RSA</exclude>
-                      <exclude>**/*.DSA</exclude>
-                      <exclude>javax/*</exclude>
-                      <exclude>javax/activation/**</exclude>
-                      <exclude>javax/annotation-api/**</exclude>
-                      <exclude>javax/inject/**</exclude>
-                      <exclude>javax/servlet-api/**</exclude>
-                      <exclude>javax/json/**</exclude>
-                      <exclude>javax/ws/**</exclude>
-                      <exclude>rest/**</exclude>
-                      <exclude>*.tokens</exclude>
-                      <exclude>codegen/**</exclude>
-                      <exclude>bootstrap-storage-plugins.json</exclude>
-                      <exclude>org/apache/parquet</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/escape/**</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/eventbus/**</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/html/**</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/net/**</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/xml/**</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
-                      <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
-                      <exclude>com/google/common/math</exclude>
-                      <exclude>com/google/common/net</exclude>
-                      <exclude>com/google/common/primitives</exclude>
-                      <exclude>com/google/common/reflect</exclude>
-                      <exclude>com/google/common/util</exclude>
-                      <exclude>com/google/common/cache</exclude>
-                      <exclude>com/google/common/collect/Tree*</exclude>
-                      <exclude>com/google/common/collect/Standard*</exclude>
-                      <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
-                      <exclude>org/apache/drill/exec/expr/fn/**</exclude>
-                      <exclude>org/apache/drill/exec/proto/beans/**</exclude>
-                      <exclude>org/apache/drill/exec/compile/**</exclude>
-                      <exclude>org/apache/drill/exec/planner/**</exclude>
-                      <exclude>org/apache/drill/exec/physical/**</exclude>
-                      <exclude>org/apache/drill/exec/store/**</exclude>
-                      <exclude>org/apache/drill/exec/server/rest/**</exclude>
-                      <exclude>org/apache/drill/exec/rpc/data/**</exclude>
-                      <exclude>org/apache/drill/exec/rpc/control/**</exclude>
-                      <exclude>org/apache/drill/exec/work/**</exclude>
-                      <exclude>org/apache/drill/metastore/**</exclude>
-                      <exclude>org/apache/hadoop/**</exclude>
-                      <exclude>org/apache/commons/pool2/**</exclude>
-                      <exclude>org/apache/http/**</exclude>
-                      <exclude>org/apache/directory/**</exclude>
-                      <exclude>com/jcraft/**</exclude>
-                      <exclude>**/mapr/**</exclude>
-                      <exclude>org/yaml/**</exclude>
-                      <exclude>hello/**</exclude>
-                      <exclude>webapps/**</exclude>
-                    </excludes>
-                  </filter>
-                  <!-- This file is used to automatically load given jdbc driver without calling Class.forName().
-                       Excluding the Avatica service file which is conflicting with the Drill one. -->
-                  <filter>
-                    <artifact>org.apache.calcite.avatica:*</artifact>
-                    <excludes>
-                      <exclude>META-INF/services/java.sql.Driver</exclude>
-                      <!-- Excludes shaded slf4j to avoid conflicts when they are put into the fat jar -->
-                      <exclude>org/slf4j/**</exclude>
-                    </excludes>
-                  </filter>
-                </filters>
-              </configuration>
-            </plugin>
-          </plugins>
-
-        </build>
-      </profile>
+      </build>
+    </profile>
     <profile>
       <id>apache-release</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,15 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>24</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>org.apache.drill</groupId>
@@ -33,7 +34,7 @@
   <version>1.21.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Drill : </name>
+  <name>Drill :</name>
   <description>Apache Drill is an open source, low latency SQL query engine for Hadoop and NoSQL.</description>
   <url>https://drill.apache.org/</url>
 
@@ -70,7 +71,7 @@
     <ojai.version>3.0-mapr-1808</ojai.version>
     <kerby.version>1.0.0</kerby.version>
     <findbugs.version>3.0.0</findbugs.version>
-    <netty.tcnative.classifier />
+    <netty.tcnative.classifier/>
     <commons.io.version>2.7</commons.io.version>
     <commons.collections.version>4.4</commons.collections.version>
     <hamcrest.version>2.2</hamcrest.version>
@@ -98,7 +99,7 @@
     <jersey.version>2.34</jersey.version>
     <javax.validation.api>2.0.1.Final</javax.validation.api>
     <asm.version>9.2</asm.version>
-    <excludedGroups />
+    <excludedGroups/>
     <memoryMb>2500</memoryMb>
     <directMemoryMb>4500</directMemoryMb>
     <rat.skip>true</rat.skip>
@@ -305,20 +306,20 @@
               <version>${hadoop.version}</version>
               <classifier>tests</classifier>
             </dependency>
- <!--  Remove dependency on tests - see DRILL-6637
-            <dependency>
-              <groupId>org.apache.drill.exec</groupId>
-              <artifactId>drill-java-exec</artifactId>
-              <version>${project.version}</version>
-              <classifier>tests</classifier>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.drill</groupId>
-              <artifactId>drill-common</artifactId>
-              <version>${project.version}</version>
-              <classifier>tests</classifier>
-            </dependency>
- -->
+            <!--  Remove dependency on tests - see DRILL-6637
+                       <dependency>
+                         <groupId>org.apache.drill.exec</groupId>
+                         <artifactId>drill-java-exec</artifactId>
+                         <version>${project.version}</version>
+                         <classifier>tests</classifier>
+                       </dependency>
+                       <dependency>
+                         <groupId>org.apache.drill</groupId>
+                         <artifactId>drill-common</artifactId>
+                         <version>${project.version}</version>
+                         <classifier>tests</classifier>
+                       </dependency>
+            -->
             <dependency>
               <groupId>com.github.tomakehurst</groupId>
               <artifactId>wiremock-standalone</artifactId>
@@ -878,7 +879,7 @@
               <goals>
                 <goal>test</goal>
               </goals>
-          </execution>
+            </execution>
           </executions>
           <dependencies>
             <dependency>
@@ -953,7 +954,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -966,7 +967,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -979,7 +980,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -994,7 +995,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1007,7 +1008,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -1256,24 +1257,24 @@
         <version>${jna.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-          <version>${slf4j.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jul-to-slf4j</artifactId>
-          <version>${slf4j.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jcl-over-slf4j</artifactId>
-          <version>${slf4j.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>log4j-over-slf4j</artifactId>
-          <version>${slf4j.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>${calcite.groupId}</groupId>
@@ -1491,8 +1492,8 @@
             <artifactId>apache-curator</artifactId>
           </exclusion>
           <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -1597,8 +1598,8 @@
             <artifactId>hive-common</artifactId>
           </exclusion>
           <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -1720,8 +1721,8 @@
             <artifactId>servlet-api-2.5</artifactId>
           </exclusion>
           <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -1755,8 +1756,8 @@
             <groupId>org.slf4j</groupId>
           </exclusion>
           <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -1783,8 +1784,8 @@
             <artifactId>hadoop-common</artifactId>
           </exclusion>
           <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -2577,8 +2578,8 @@
                 <artifactId>jackson-jaxrs</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -2746,10 +2747,10 @@
             </exclusions>
           </dependency>
           <dependency>
-          	<groupId>org.apache.parquet</groupId>
-          	<artifactId>parquet-hadoop</artifactId>
-          	<version>${parquet.version}</version>
-          	<exclusions>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>${parquet.version}</version>
+            <exclusions>
               <exclusion>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>
@@ -2758,11 +2759,11 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
               </exclusion>
-          		<exclusion>
-          			<groupId>org.xerial.snappy</groupId>
-          			<artifactId>snappy-java</artifactId>
-          		</exclusion>
-          	</exclusions>
+              <exclusion>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -2770,8 +2771,8 @@
             <version>${hbase.version}</version>
             <exclusions>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -3071,8 +3072,8 @@
                 <artifactId>hadoop-core</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -3174,8 +3175,8 @@
                 <artifactId>hadoop-core</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -3284,15 +3285,15 @@
             <version>${xalan.version}</version>
           </dependency>
           <dependency>
-          	<groupId>org.apache.parquet</groupId>
-          	<artifactId>parquet-hadoop</artifactId>
-          	<version>${parquet.version}</version>
-          	<exclusions>
-          		<exclusion>
-          			<groupId>org.xerial.snappy</groupId>
-          			<artifactId>snappy-java</artifactId>
-          		</exclusion>
-          	</exclusions>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>${parquet.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <!-- Test Dependencies -->
           <dependency>
@@ -3416,8 +3417,8 @@
             <version>${hbase.version}</version>
             <exclusions>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -3493,8 +3494,8 @@
             <scope>test</scope>
             <exclusions>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -3619,12 +3620,12 @@
                 <artifactId>servlet-api-2.5</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty-all</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3650,12 +3651,12 @@
                 <artifactId>servlet-api-2.5</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty-all</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3755,12 +3756,12 @@
                 <artifactId>servlet-api-2.5</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty-all</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3786,12 +3787,12 @@
                 <artifactId>servlet-api-2.5</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty-all</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
               </exclusion>
             </exclusions>
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,8 @@
     <iceberg.version>0.12.1</iceberg.version>
     <univocity-parsers.version>2.8.3</univocity-parsers.version>
     <mongo.version>4.3.3</mongo.version>
-    <junit.args />
+    <swagger.version>2.1.12</swagger.version>
+    <junit.args/>
   </properties>
 
   <scm>


### PR DESCRIPTION
# [DRILL-8162](https://issues.apache.org/jira/browse/DRILL-8162): Add OpenAPI Specification documentation for Drill's REST API

## Description

Used Swagger Core to produce an OpenAPI specification for Drill's REST API. One can access it in JSON format by going to `localhost:8047/openapi.json` after starting Drill. 
Also, added an HTML script to produce the Swagger UI when one visits `localhost:8047/static/swagger-ui.html`.
Used Swagger annotations to populate the Swagger UI with the relevant information, including links to documentation on [https://drill.apache.org/docs/](https://drill.apache.org/docs/). More information can be added via additional annotations.

## Documentation

One can visit `localhost:8047/openapi.json` after starting Drill to find an OpenAPI specification for Drill's REST API. One can also visit `localhost:8047/static/swagger-ui.html` after starting Drill to find the Swagger UI, which clearly displays the endpoints for the REST API with their descriptions and/or links to external docs. 

## Testing

Started Drill and visited the links above.