### PR TITLE
DRILL-8156: Declare and chown a /data VOLUME in the Drill Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN mvn -Dmaven.artifact.threads=5 -T1C clean install -DskipTests
 # Get project version and copy built binaries into /opt/drill directory
 RUN VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
  && mkdir /opt/drill \
- && mv distribution/target/apache-drill-${VERSION}/apache-drill-${VERSION}/* /opt/drill
+ && mv distribution/target/apache-drill-${VERSION}/apache-drill-${VERSION}/* /opt/drill \
+ && chmod -R +r /opt/drill
 
 # Target image
 
@@ -76,7 +77,5 @@ RUN groupadd -g 999 $DRILL_USER \
 VOLUME $DATA_VOL
 
 COPY --from=build /opt/drill $DRILL_HOME
-
-RUN chmod -R +r $DRILL_HOME
 
 USER $DRILL_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,8 @@ ENV DRILL_USER_HOME=/var/lib/drill
 ENV DRILL_LOG_DIR=$DRILL_USER_HOME/log
 ENV DATA_VOL=/data
 
-RUN mkdir $DRILL_HOME $DATA_VOL
-
-RUN groupadd -g 999 $DRILL_USER \
+RUN mkdir $DRILL_HOME $DATA_VOL \
+ && groupadd -g 999 $DRILL_USER \
  && useradd -r -u 999 -g $DRILL_USER $DRILL_USER -m -d $DRILL_USER_HOME \
  && chown $DRILL_USER: $DATA_VOL
 


### PR DESCRIPTION
# [DRILL-8156](https://issues.apache.org/jira/browse/DRILL-8156): Declare and chown a /data VOLUME in the Drill Dockerfile

## Description

Some users of embedded Drill in Docker want to use a Docker volume with Drill, particularly for Drill's persistent local storage so that Drill configuration can persist across container launches.  Because Drill no longer runs as root in the Docker container as of 1.20, these users now need a mountpoint inside that container that has been chowned to drilluser.

Also remove unneeded permissions to Drill installation dir that were held by drilluser.

## Documentation
Document the existence of the volume mountpoint at /data in the container.

## Testing

1. Build an image using Drill master and the Dockerfile in this branch.
2. Launch the image with default args (no volume mounted) and run test queries.  Confirm that an option set with ALTER SYSTEM is lost across container launches.
3. Launch the image with a host volume mounted at /data and `sys.store.provider.local.path: "/data"` and run test queries.  Confirm that an option set with ALTER SYSTEM is persisted across container launches.
