### PR TITLE
DRILL-8166: Add List of Supported File Format Extensions

### DIFF
--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPluginConfig.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/format/IcebergFormatPluginConfig.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.iceberg.format;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -31,6 +32,7 @@ import java.util.Objects;
 
 @JsonTypeName(IcebergFormatPluginConfig.NAME)
 @JsonDeserialize(builder=IcebergFormatPluginConfig.IcebergFormatPluginConfigBuilder.class)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class IcebergFormatPluginConfig implements FormatPluginConfig {
 
   public static final String NAME = "iceberg";

--- a/contrib/format-pdf/src/main/java/org/apache/drill/exec/store/pdf/PdfFormatConfig.java
+++ b/contrib/format-pdf/src/main/java/org/apache/drill/exec/store/pdf/PdfFormatConfig.java
@@ -96,7 +96,7 @@ public class PdfFormatConfig implements FormatPluginConfig {
     }
   }
 
-  public List<String> extensions() {
+  public List<String> getExtensions() {
     return this.extensions;
   }
 

--- a/contrib/format-pdf/src/main/java/org/apache/drill/exec/store/pdf/PdfFormatPlugin.java
+++ b/contrib/format-pdf/src/main/java/org/apache/drill/exec/store/pdf/PdfFormatPlugin.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
-import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin.ScanFrameworkVersion;
 import org.apache.hadoop.conf.Configuration;
 
 
@@ -65,7 +64,7 @@ public class PdfFormatPlugin extends EasyFormatPlugin<PdfFormatConfig> {
       .blockSplittable(false)
       .compressible(true)
       .supportsProjectPushdown(true)
-      .extensions(pluginConfig.extensions())
+      .extensions(pluginConfig.getExtensions())
       .fsConf(fsConf)
       .defaultName(DEFAULT_NAME)
       .scanVersion(ScanFrameworkVersion.EVF_V1)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -180,6 +180,7 @@ public class StorageResources {
 
   @GET
   @Path("/storage/extension_list.json")
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   @Produces(MediaType.APPLICATION_JSON)
   public Response getAllSupportedFormats() {
     LinkedHashSet<String> registeredExtensions = new LinkedHashSet<>();
@@ -201,6 +202,7 @@ public class StorageResources {
   @GET
   @Path("/storage/{name}/extension_list.json")
   @Produces(MediaType.APPLICATION_JSON)
+  @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response getFormatList(@PathParam("name") String name) {
     LinkedHashSet<String> registeredExtensions = new LinkedHashSet<>();
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatConfig.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.log;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.drill.common.PlanStringBuilder;
@@ -34,18 +35,18 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class LogFormatConfig implements FormatPluginConfig {
 
   private final String regex;
-  private final String extension;
+  private final List<String> extensions;
   private final int maxErrors;
   private final List<LogFormatField> schema;
 
   @JsonCreator
   public LogFormatConfig(
       @JsonProperty("regex") String regex,
-      @JsonProperty("extension") String extension,
+      @JsonProperty("extension") List<String> extensions,
       @JsonProperty("maxErrors") Integer maxErrors,
       @JsonProperty("schema") List<LogFormatField> schema) {
+    this.extensions = extensions == null ? Collections.singletonList("log") : ImmutableList.copyOf(extensions);
     this.regex = regex;
-    this.extension = extension;
     this.maxErrors = maxErrors == null ? 10 : maxErrors;
     this.schema = schema == null
         ? ImmutableList.of() : schema;
@@ -55,8 +56,8 @@ public class LogFormatConfig implements FormatPluginConfig {
     return regex;
   }
 
-  public String getExtension() {
-    return extension;
+  public List<String> getExtensions() {
+    return extensions;
   }
 
   public int getMaxErrors() {
@@ -79,12 +80,12 @@ public class LogFormatConfig implements FormatPluginConfig {
     return Objects.equal(regex, other.regex) &&
            Objects.equal(maxErrors, other.maxErrors) &&
            Objects.equal(schema, other.schema) &&
-           Objects.equal(extension, other.extension);
+           Objects.equal(extensions, other.extensions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(regex, maxErrors, schema, extension);
+    return Objects.hashCode(regex, maxErrors, schema, extensions);
   }
 
   @JsonIgnore
@@ -129,7 +130,7 @@ public class LogFormatConfig implements FormatPluginConfig {
   public String toString() {
     return new PlanStringBuilder(this)
         .field("regex", regex)
-        .field("extension", extension)
+        .field("extension", extensions)
         .field("schema", schema)
         .field("maxErrors", maxErrors)
         .toString();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatPlugin.java
@@ -87,7 +87,7 @@ public class LogFormatPlugin extends EasyFormatPlugin<LogFormatConfig> {
         .blockSplittable(false) // Should be block splitable, but logic not yet implemented.
         .compressible(true)
         .supportsProjectPushdown(true)
-        .extensions(pluginConfig.getExtension())
+        .extensions(pluginConfig.getExtensions())
         .fsConf(fsConf)
         .defaultName(PLUGIN_NAME)
         .readerOperatorType(OPERATOR_TYPE)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestFileExtensions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestFileExtensions.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 
 public class TestFileExtensions extends ClusterTest {
-  
   private static final int TIMEOUT = 30;
   private static String hostname;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestFileExtensions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestFileExtensions.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.server.rest;
+
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestFileExtensions extends ClusterTest {
+  
+  private static final int TIMEOUT = 30;
+  private static String hostname;
+
+  private final OkHttpClient httpClient = new OkHttpClient.Builder()
+    .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
+    .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
+    .readTimeout(TIMEOUT, TimeUnit.SECONDS).build();
+
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher)
+      .configProperty(ExecConstants.HTTP_ENABLE, true)
+      .configProperty(ExecConstants.HTTP_PORT_HUNT, true);
+    startCluster(builder);
+    int portNumber = cluster.drillbit().getWebServerPort();
+    hostname = "http://localhost:" + portNumber + "/storage/";
+  }
+
+  @Test
+  public void testGetAllFileExtensions() throws Exception {
+    Request request = new Request.Builder()
+      .url(hostname + "extension_list.json")
+      .build();
+
+    Call call = httpClient.newCall(request);
+    Response response = call.execute();
+    assertEquals(response.code(), 200);
+    assertEquals("{\n" + "  \"result\" : \"[seq, txt, tbl, tsv, csv, ssv, csvh-test, json, csvh, avro]\"\n" + "}", response.body().string());
+  }
+
+  @Test
+  public void testGetPluginFileExtensions() throws Exception {
+    Request request = new Request.Builder()
+      .url(hostname + "dfs/extension_list.json")
+      .build();
+
+    Call call = httpClient.newCall(request);
+    Response response = call.execute();
+    assertEquals(response.code(), 200);
+    assertEquals("{\n" + "  \"result\" : \"[seq, txt, tbl, tsv, csv, ssv, csvh-test, json, csvh, avro]\"\n" + "}", response.body().string());
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFormatPluginOptionExtractor.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFormatPluginOptionExtractor.java
@@ -79,7 +79,7 @@ public class TestFormatPluginOptionExtractor extends BaseTest {
           assertEquals("(type: String, logFormat: String, timestampFormat: String)", d.presentParams());
           break;
         case "logRegex":
-          assertEquals(d.typeName, "(type: String, regex: String, extension: String, maxErrors: int, schema: List)", d.presentParams());
+          assertEquals(d.typeName, "(type: String, regex: String, maxErrors: int, schema: List)", d.presentParams());
           break;
         default:
           fail("add validation for format plugin type " + d.typeName);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReader.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.log;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,7 +98,7 @@ public class TestLogReader extends ClusterTest {
     // Empty configuration: regex and columns defined in the
     // provided schema
     LogFormatConfig emptyConfig = new LogFormatConfig(
-        null, "loge", null, null);
+        null, Collections.singletonList("loge"), null, null);
     schemaOnlyDir = cluster.makeDataDir("SOnly", "loge", emptyConfig);
     tableFuncDir = cluster.makeDataDir("tf", "logf", emptyConfig);
   }
@@ -108,7 +109,7 @@ public class TestLogReader extends ClusterTest {
         new LogFormatField("month", "INT"),
         new LogFormatField("day", "INT"));
     return new LogFormatConfig(
-        DATE_ONLY_PATTERN, "log1", null, schema);
+        DATE_ONLY_PATTERN, Collections.singletonList("log1"), null, schema);
   }
 
   // Config similar to the above, but with no type info. Types
@@ -120,7 +121,7 @@ public class TestLogReader extends ClusterTest {
         new LogFormatField("month"),
         new LogFormatField("day"));
     return new LogFormatConfig(
-        DATE_ONLY_PATTERN, "logu", null, schema);
+        DATE_ONLY_PATTERN, Collections.singletonList("logu"), null, schema);
   }
 
   // Full Drill log parser definition.
@@ -140,7 +141,7 @@ public class TestLogReader extends ClusterTest {
         new LogFormatField("module"),
         new LogFormatField("message"));
     return new LogFormatConfig(
-        regex, "log1", null, schema);
+        regex, Collections.singletonList("log1"), null, schema);
   }
 
   //Set up additional configs to check the time/date formats
@@ -153,13 +154,13 @@ public class TestLogReader extends ClusterTest {
         new LogFormatField("message_type"),
         new LogFormatField("message"));
     return new LogFormatConfig(
-        regex, "log2", 3, schema);
+        regex, Collections.singletonList("log2"), 3, schema);
   }
 
   private static LogFormatConfig mySqlConfig() {
     String regex = "(\\d{6})\\s(\\d{2}:\\d{2}:\\d{2})\\s+(\\d+)\\s(\\w+)\\s+(.+)";
     return new LogFormatConfig(
-        regex, "sqllog", null, null);
+        regex, Collections.singletonList("sqllog"), null, null);
   }
 
   // Firewall log file that requires date parsing
@@ -174,7 +175,7 @@ public class TestLogReader extends ClusterTest {
         new LogFormatField("message"),
         new LogFormatField("src_ip"));
     return new LogFormatConfig(
-        regex, "ssdlog", null, schema);
+        regex, Collections.singletonList("ssdlog"), null, schema);
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReaderIssue.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReaderIssue.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.log;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +75,7 @@ public class TestLogReaderIssue extends BaseCsvTest {
     List<LogFormatField> schema = Lists.newArrayList(
         new LogFormatField("type", "VARCHAR"),
         new LogFormatField("time", "TIMESTAMP", "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")); // valid
-    return new LogFormatConfig(regex_issue7853, "log", null, schema);
+    return new LogFormatConfig(regex_issue7853, Collections.singletonList("log"), null, schema);
   }
 
   // DRILL-7853
@@ -82,7 +83,7 @@ public class TestLogReaderIssue extends BaseCsvTest {
     List<LogFormatField> schema = Lists.newArrayList(
         new LogFormatField("type", "VARCHAR"),
         new LogFormatField("time", "TIMESTAMP", "yyyy-MM-dd''T''HH:mm:ss.SSSSSSZ")); // invalid
-    return new LogFormatConfig(regex_issue7853, "log2", null, schema);
+    return new LogFormatConfig(regex_issue7853, Collections.singletonList("log2"), null, schema);
   }
 
   @Test

--- a/logical/src/main/java/org/apache/drill/common/logical/FormatPluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/FormatPluginConfig.java
@@ -19,6 +19,9 @@ package org.apache.drill.common.logical;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Interface for defining a Drill format plugin.
  *
@@ -34,4 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface FormatPluginConfig {
+  default List<String> getExtensions() {
+     return Collections.emptyList();
+   }
 }


### PR DESCRIPTION
# [DRILL-8166](https://issues.apache.org/jira/browse/DRILL-8166): Add List of Supported File Format Extensions

## Description

## Documentation
This PR adds two REST endpoints which allow a user to retrieve a list of supported file extensions.  You can either do this for an individual storage plugin or all.  Once merged, I will update the Drill public facing docs.

Specifically, this adds:

* `/storage/{name}/extension_list.json`:  Returns a list of supported file extensions for a given storage plugin
* `/storage/extension_list.json`:  Returns a list of all supported file extensions

### Other notes:
I had to add a `getExtensions()` method to the interface for `FormatPluginConfig` which returns an empty list by default.  Most formats had a list of supported extensions with the exception of the PDF format, Iceberg and the log format.  I modified them so that they now accept a list of possible extensions rather than a String.  In the case of Iceberg, I modified that so that  the extensions is present but ignorable. 

## Testing
Added unit tests