### PR TITLE
DRILL-8164: Upgrade metadata-extractor because of CVE-2022-24613

### DIFF
--- a/contrib/format-image/pom.xml
+++ b/contrib/format-image/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>com.drewnoakes</groupId>
       <artifactId>metadata-extractor</artifactId>
+      <version>2.16.0</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/format-image/pom.xml
+++ b/contrib/format-image/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.drewnoakes</groupId>
       <artifactId>metadata-extractor</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataReader.java
+++ b/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataReader.java
@@ -145,17 +145,17 @@ public class GenericMetadataReader
           try {
             int numOfComponent = 1;
             int colorType = pngDir.getInt(PngDirectory.TAG_COLOR_TYPE);
-            if (colorType == PngColorType.IndexedColor.getNumericValue()) {
+            if (colorType == PngColorType.INDEXED_COLOR.getNumericValue()) {
               directory.setColorMode("Indexed");
-            } else if (colorType == PngColorType.Greyscale.getNumericValue()) {
+            } else if (colorType == PngColorType.GREYSCALE.getNumericValue()) {
               directory.setColorMode("Grayscale");
-            } else if (colorType == PngColorType.GreyscaleWithAlpha.getNumericValue()) {
+            } else if (colorType == PngColorType.GREYSCALE_WITH_ALPHA.getNumericValue()) {
               numOfComponent = 2;
               directory.setColorMode("Grayscale");
               directory.setAlpha(true);
-            } else if (colorType == PngColorType.TrueColor.getNumericValue()) {
+            } else if (colorType == PngColorType.TRUE_COLOR.getNumericValue()) {
               numOfComponent = 3;
-            } else if (colorType == PngColorType.TrueColorWithAlpha.getNumericValue()) {
+            } else if (colorType == PngColorType.TRUE_COLOR_WITH_ALPHA.getNumericValue()) {
               numOfComponent = 4;
               directory.setAlpha(true);
             }

--- a/contrib/format-image/src/test/resources/image/eps.json
+++ b/contrib/format-image/src/test/resources/image/eps.json
@@ -62,7 +62,7 @@
     "RenderingIntent" : "Media-Relative Colorimetric",
     "XYZValues" : "0.964 1 0.825",
     "TagCount" : "10",
-    "Copyright" : "(c) 1999 Adobe Systems Inc.",
+    "ProfileCopyright" : "(c) 1999 Adobe Systems Inc.",
     "ProfileDescription" : "GBR",
     "MediaWhitePoint" : "(0.9505, 1, 1.0891)",
     "MediaBlackPoint" : "(0, 0, 0)",

--- a/contrib/format-image/src/test/resources/image/jpeg.json
+++ b/contrib/format-image/src/test/resources/image/jpeg.json
@@ -141,7 +141,7 @@
     "DeviceModel" : "sRGB",
     "XYZValues" : "0.964 1 0.825",
     "TagCount" : "17",
-    "Copyright" : "Copyright (c) 1998 Hewlett-Packard Company",
+    "ProfileCopyright" : "Copyright (c) 1998 Hewlett-Packard Company",
     "ProfileDescription" : "sRGB IEC61966-2.1",
     "MediaWhitePoint" : "(0.9505, 1, 1.0891)",
     "MediaBlackPoint" : "(0, 0, 0)",

--- a/contrib/format-image/src/test/resources/image/mov.json
+++ b/contrib/format-image/src/test/resources/image/mov.json
@@ -1,5 +1,5 @@
 {
-  "Format" : "MOV",
+  "Format" : "QUICKTIME",
   "Duration" : "01:32:3650",
   "PixelWidth" : "560",
   "PixelHeight" : "320",
@@ -31,7 +31,8 @@
     "SelectionTime" : "0",
     "SelectionDuration" : "0",
     "CurrentTime" : "0",
-    "NextTrackID" : "3"
+    "NextTrackID" : "3",
+    "Rotation" : "0"
   },
   "QuickTimeVideo" : {
     "CreationTime" : "Fri Jan 01 00:00:00 +00:00 1904",

--- a/contrib/format-image/src/test/resources/image/tiff.json
+++ b/contrib/format-image/src/test/resources/image/tiff.json
@@ -114,7 +114,7 @@
     "DeviceModel" : "sRGB",
     "XYZValues" : "0.964 1 0.825",
     "TagCount" : "17",
-    "Copyright" : "Copyright (c) 1998 Hewlett-Packard Company",
+    "ProfileCopyright" : "Copyright (c) 1998 Hewlett-Packard Company",
     "ProfileDescription" : "sRGB IEC61966-2.1",
     "MediaWhitePoint" : "(0.9505, 1, 1.0891)",
     "MediaBlackPoint" : "(0, 0, 0)",

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
     <testcontainers.version>1.16.3</testcontainers.version>
     <typesafe.config.version>1.0.0</typesafe.config.version>
     <commons.codec.version>1.14</commons.codec.version>
-    <metadata.extractor.version>2.13.0</metadata.extractor.version>
     <xalan.version>2.7.2</xalan.version>
     <xerces.version>2.12.2</xerces.version>
     <commons.configuration.version>1.10</commons.configuration.version>
@@ -2045,11 +2044,6 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.drewnoakes</groupId>
-        <artifactId>metadata-extractor</artifactId>
-        <version>${metadata.extractor.version}</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>


### PR DESCRIPTION
# [DRILL-8164](https://issues.apache.org/jira/browse/DRILL-8164): Upgrade metadata-extractor because of CVE-2022-24613

## Description

Also included the DRILL-8165 (Upgrade liquibase because of CVE-2022-0839).

Please note that we should replace the `DatabaseFactory.getInstance()` with `Scope.getCurrentScope().getSingleton(DatabaseFactory.class)` once the following issue is resolved.

https://github.com/liquibase/liquibase/issues/2349

## Documentation
N/A

## Testing
Use the CI.
