### PR TITLE
DRILL-8167: Add JSON Config Options to Format Config

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -85,7 +85,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
                                       FileWork fileWork,
                                       List<SchemaPath> columns,
                                       String userName) {
-    return new JSONRecordReader(context, fileWork.getPath(), dfs, columns);
+    return new JSONRecordReader(context, fileWork.getPath(), dfs, columns, formatConfig);
   }
 
   @Override
@@ -178,10 +178,15 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
     private static final List<String> DEFAULT_EXTS = ImmutableList.of("json");
 
     private final List<String> extensions;
+    private final Boolean allTextMode;
+    private final Boolean readNumbersAsDouble;
+    private final Boolean skipMalformedJSONRecords;
+    private final Boolean nanInf;
 
     @JsonCreator
     public JSONFormatConfig(
-        @JsonProperty("extensions") List<String> extensions) {
+        @JsonProperty("extensions") List<String> extensions,
+        @JsonProperty("allTextMode")) {
       this.extensions = extensions == null ?
           DEFAULT_EXTS : ImmutableList.copyOf(extensions);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -70,7 +70,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
 
   public JSONFormatPlugin(String name, DrillbitContext context,
       Configuration fsConf, StoragePluginConfig storageConfig) {
-    this(name, context, fsConf, storageConfig, new JSONFormatConfig(null));
+    this(name, context, fsConf, storageConfig, new JSONFormatConfig(null, null, null, null, null));
   }
 
   public JSONFormatPlugin(String name, DrillbitContext context,
@@ -186,9 +186,16 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
     @JsonCreator
     public JSONFormatConfig(
         @JsonProperty("extensions") List<String> extensions,
-        @JsonProperty("allTextMode")) {
+        @JsonProperty("allTextMode") Boolean allTextMode,
+        @JsonProperty("readNumbersAsDouble") Boolean readNumbersAsDouble,
+        @JsonProperty("skipMalformedJSONRecords") Boolean skipMalformedJSONRecords,
+        @JsonProperty("nanInf") Boolean nanInf) {
       this.extensions = extensions == null ?
           DEFAULT_EXTS : ImmutableList.copyOf(extensions);
+      this.allTextMode = allTextMode;
+      this.readNumbersAsDouble = readNumbersAsDouble;
+      this.skipMalformedJSONRecords = skipMalformedJSONRecords;
+      this.nanInf = nanInf;
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -196,9 +203,29 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
       return extensions;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Boolean getAllTextMode() {
+      return allTextMode;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Boolean getReadNumbersAsDouble() {
+      return readNumbersAsDouble;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Boolean getSkipMalformedJSONRecords() {
+      return skipMalformedJSONRecords;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Boolean getNanInf() {
+      return nanInf;
+    }
+
     @Override
     public int hashCode() {
-      return Objects.hash(extensions);
+      return Objects.hash(extensions, allTextMode, readNumbersAsDouble, skipMalformedJSONRecords, nanInf);
     }
 
     @Override
@@ -210,14 +237,22 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
         return false;
       }
       JSONFormatConfig other = (JSONFormatConfig) obj;
-      return Objects.deepEquals(extensions, other.extensions);
+      return Objects.deepEquals(extensions, other.extensions) &&
+        Objects.equals(allTextMode, other.allTextMode) &&
+        Objects.equals(readNumbersAsDouble, other.readNumbersAsDouble) &&
+        Objects.equals(skipMalformedJSONRecords, other.skipMalformedJSONRecords) &&
+        Objects.equals(nanInf, other.nanInf);
     }
 
     @Override
     public String toString() {
       return new PlanStringBuilder(this)
-          .field("extensions", extensions)
-          .toString();
+        .field("extensions", extensions)
+        .field("allTextMode", allTextMode)
+        .field("readNumbersAsDouble", readNumbersAsDouble)
+        .field("skipMalformedRecords", skipMalformedJSONRecords)
+        .field("nanInf", nanInf)
+        .toString();
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
@@ -70,7 +71,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
 
   public JSONFormatPlugin(String name, DrillbitContext context,
       Configuration fsConf, StoragePluginConfig storageConfig) {
-    this(name, context, fsConf, storageConfig, new JSONFormatConfig(null, null, null, null, null));
+    this(name, context, fsConf, storageConfig, new JSONFormatConfig(null, null, null, null, null, null));
   }
 
   public JSONFormatPlugin(String name, DrillbitContext context,
@@ -181,6 +182,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
     private final Boolean allTextMode;
     private final Boolean readNumbersAsDouble;
     private final Boolean skipMalformedJSONRecords;
+    private final Boolean escapeAnyChar;
     private final Boolean nanInf;
 
     @JsonCreator
@@ -189,12 +191,14 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
         @JsonProperty("allTextMode") Boolean allTextMode,
         @JsonProperty("readNumbersAsDouble") Boolean readNumbersAsDouble,
         @JsonProperty("skipMalformedJSONRecords") Boolean skipMalformedJSONRecords,
+        @JsonProperty("escapeAnyChar") Boolean escapeAnyChar,
         @JsonProperty("nanInf") Boolean nanInf) {
       this.extensions = extensions == null ?
           DEFAULT_EXTS : ImmutableList.copyOf(extensions);
       this.allTextMode = allTextMode;
       this.readNumbersAsDouble = readNumbersAsDouble;
       this.skipMalformedJSONRecords = skipMalformedJSONRecords;
+      this.escapeAnyChar = escapeAnyChar;
       this.nanInf = nanInf;
     }
 
@@ -218,6 +222,11 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
       return skipMalformedJSONRecords;
     }
 
+    @JsonInclude(Include.NON_ABSENT)
+    public Boolean getEscapeAnyChar() {
+      return escapeAnyChar;
+    }
+
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Boolean getNanInf() {
       return nanInf;
@@ -225,7 +234,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
 
     @Override
     public int hashCode() {
-      return Objects.hash(extensions, allTextMode, readNumbersAsDouble, skipMalformedJSONRecords, nanInf);
+      return Objects.hash(extensions, allTextMode, readNumbersAsDouble, skipMalformedJSONRecords, escapeAnyChar, nanInf);
     }
 
     @Override
@@ -241,6 +250,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
         Objects.equals(allTextMode, other.allTextMode) &&
         Objects.equals(readNumbersAsDouble, other.readNumbersAsDouble) &&
         Objects.equals(skipMalformedJSONRecords, other.skipMalformedJSONRecords) &&
+        Objects.equals(escapeAnyChar, other.escapeAnyChar) &&
         Objects.equals(nanInf, other.nanInf);
     }
 
@@ -251,6 +261,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
         .field("allTextMode", allTextMode)
         .field("readNumbersAsDouble", readNumbersAsDouble)
         .field("skipMalformedRecords", skipMalformedJSONRecords)
+        .field("escapeAnyChar", escapeAnyChar)
         .field("nanInf", nanInf)
         .toString();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -150,7 +150,7 @@ public class JSONRecordReader extends AbstractRecordReader {
 
     this.fileSystem = fileSystem;
     this.fragmentContext = fragmentContext;
-    // only enable all text mode if we aren't using embedded content mode.
+
     this.enableAllTextMode = allTextMode();
     this.enableNanInf = nanInf();
     this.enableEscapeAnyChar = fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR);
@@ -161,7 +161,12 @@ public class JSONRecordReader extends AbstractRecordReader {
     setColumns(columns);
   }
 
+  /**
+   * Returns the value of the all text mode.  Values set in the format config will override global values.
+   * @return The value of allTextMode
+   */
   private boolean allTextMode() {
+    // only enable all text mode if we aren't using embedded content mode.
     if (config.getAllTextMode() == null) {
       return embeddedContent == null && fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ALL_TEXT_MODE_VALIDATOR);
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -81,7 +81,7 @@ public class JSONRecordReader extends AbstractRecordReader {
    * @param fileSystem a Drill file system wrapper around the file system implementation
    * @param columns path names of columns/subfields to read
    * @param config The JSONFormatConfig for the storage plugin
-   * @throws OutOfMemoryException
+   * @throws OutOfMemoryException If there is insufficient memory, Drill will throw an Out of Memory Exception
    */
   public JSONRecordReader(FragmentContext fragmentContext, Path inputPath, DrillFileSystem fileSystem,
       List<SchemaPath> columns, JSONFormatConfig config) throws OutOfMemoryException {
@@ -94,7 +94,7 @@ public class JSONRecordReader extends AbstractRecordReader {
    * @param embeddedContent embedded content
    * @param fileSystem a Drill file system wrapper around the file system implementation
    * @param columns path names of columns/subfields to read
-   * @throws OutOfMemoryException
+   * @throws OutOfMemoryException If Drill runs out of memory, OME will be thrown
    */
   public JSONRecordReader(FragmentContext fragmentContext, JsonNode embeddedContent, DrillFileSystem fileSystem,
       List<SchemaPath> columns) throws OutOfMemoryException {
@@ -103,6 +103,7 @@ public class JSONRecordReader extends AbstractRecordReader {
         embeddedContent == null && fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ALL_TEXT_MODE_VALIDATOR),
         embeddedContent == null && fragmentContext.getOptions().getOption(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_SKIP_MALFORMED_RECORDS_VALIDATOR),
+        fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_NAN_INF_NUMBERS_VALIDATOR)));
   }
 
@@ -110,7 +111,7 @@ public class JSONRecordReader extends AbstractRecordReader {
    * Create a JSON Record Reader that uses an InputStream directly
    * @param fragmentContext the Drill fragment
    * @param columns path names of columns/subfields to read
-   * @throws OutOfMemoryException
+   * @throws OutOfMemoryException If there is insufficient memory, Drill will throw an Out of Memory Exception
    */
   public JSONRecordReader(FragmentContext fragmentContext, List<SchemaPath> columns) throws OutOfMemoryException {
     this(fragmentContext, null, null, null, columns, true,
@@ -118,6 +119,7 @@ public class JSONRecordReader extends AbstractRecordReader {
         fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ALL_TEXT_MODE_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_SKIP_MALFORMED_RECORDS_VALIDATOR),
+        fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_NAN_INF_NUMBERS_VALIDATOR)));
   }
 
@@ -143,6 +145,7 @@ public class JSONRecordReader extends AbstractRecordReader {
         embeddedContent == null && fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ALL_TEXT_MODE_VALIDATOR),
         embeddedContent == null && fragmentContext.getOptions().getOption(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_SKIP_MALFORMED_RECORDS_VALIDATOR),
+        fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR),
         fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_NAN_INF_NUMBERS_VALIDATOR));
     } else {
       this.config = config;
@@ -153,7 +156,7 @@ public class JSONRecordReader extends AbstractRecordReader {
 
     this.enableAllTextMode = allTextMode();
     this.enableNanInf = nanInf();
-    this.enableEscapeAnyChar = fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR);
+    this.enableEscapeAnyChar = escapeAnyChar();
     this.readNumbersAsDouble = readNumbersAsDouble();
     this.unionEnabled = embeddedContent == null && fragmentContext.getOptions().getBoolean(ExecConstants.ENABLE_UNION_TYPE_KEY);
     this.skipMalformedJSONRecords = skipMalformedJSONRecords();
@@ -187,6 +190,14 @@ public class JSONRecordReader extends AbstractRecordReader {
       return fragmentContext.getOptions().getOption(ExecConstants.JSON_SKIP_MALFORMED_RECORDS_VALIDATOR);
     } else {
       return config.getSkipMalformedJSONRecords();
+    }
+  }
+
+  private boolean escapeAnyChar() {
+    if (config.getEscapeAnyChar() == null) {
+      return fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR);
+    } else {
+      return config.getEscapeAnyChar();
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/DropboxFileSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/DropboxFileSystemTest.java
@@ -79,7 +79,7 @@ public class DropboxFileSystemTest extends ClusterTest {
     Map<String, FormatPluginConfig> formats = new HashMap<>();
     List<String> jsonExtensions = new ArrayList<>();
     jsonExtensions.add("json");
-    FormatPluginConfig jsonFormatConfig = new JSONFormatConfig(jsonExtensions);
+    FormatPluginConfig jsonFormatConfig = new JSONFormatConfig(jsonExtensions, null, null, null, null);
 
     // CSV Format
     List<String> csvExtensions = new ArrayList<>();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/DropboxFileSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/DropboxFileSystemTest.java
@@ -79,7 +79,7 @@ public class DropboxFileSystemTest extends ClusterTest {
     Map<String, FormatPluginConfig> formats = new HashMap<>();
     List<String> jsonExtensions = new ArrayList<>();
     jsonExtensions.add("json");
-    FormatPluginConfig jsonFormatConfig = new JSONFormatConfig(jsonExtensions, null, null, null, null);
+    FormatPluginConfig jsonFormatConfig = new JSONFormatConfig(jsonExtensions, null, null, null, null, null);
 
     // CSV Format
     List<String> csvExtensions = new ArrayList<>();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFormatPluginOptionExtractor.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFormatPluginOptionExtractor.java
@@ -64,7 +64,7 @@ public class TestFormatPluginOptionExtractor extends BaseTest {
           );
           break;
         case "json":
-          assertEquals(d.typeName, "(type: String)", d.presentParams());
+          assertEquals(d.typeName, "(type: String, allTextMode: Boolean, readNumbersAsDouble: Boolean, skipMalformedJSONRecords: Boolean, escapeAnyChar: Boolean, nanInf: Boolean)", d.presentParams());
           break;
         case "sequencefile":
           assertEquals(d.typeName, "(type: String)", d.presentParams());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonModes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonModes.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.json;
+
+import org.apache.drill.categories.RowSetTests;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+import static org.junit.Assert.assertEquals;
+
+@Category(RowSetTests.class)
+public class TestJsonModes extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterTest.startCluster(ClusterFixture.builder(dirTestWatcher));
+  }
+
+  @Test
+  public void testAllTextMode() throws Exception {
+    String sql = "SELECT `integer`, `float` FROM cp.`jsoninput/input2.json`";
+    RowSet results  = client.queryBuilder().sql(sql).rowSet();
+    TupleMetadata expectedSchema = new SchemaBuilder()
+      .addNullable("integer", MinorType.BIGINT)
+      .addNullable("float", MinorType.FLOAT8)
+      .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+      .addRow(2010, 17.4)
+      .addRow(-2002, -1.2)
+      .addRow(2001, 1.2)
+      .addRow(6005, 1.2)
+      .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+
+    // Now try with all text mode
+    sql = "SELECT `integer`, `float` FROM table(cp.`jsoninput/input2.json` (type => 'json', allTextMode => True))";
+    results  = client.queryBuilder().sql(sql).rowSet();
+    expectedSchema = new SchemaBuilder()
+      .addNullable("integer", MinorType.VARCHAR)
+      .addNullable("float", MinorType.VARCHAR)
+      .build();
+
+    expected = new RowSetBuilder(client.allocator(), expectedSchema)
+      .addRow("2010", "17.4")
+      .addRow("-2002", "-1.2")
+      .addRow("2001", "1.2")
+      .addRow("6005", "1.2")
+      .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testReadDoubles() throws Exception {
+    String sql = "SELECT `integer`, `float` FROM table(cp.`jsoninput/input2.json` (type => 'json', readNumbersAsDouble => True))";
+    DirectRowSet results = client.queryBuilder().sql(sql).rowSet();
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+      .addNullable("integer", MinorType.FLOAT8)
+      .addNullable("float", MinorType.FLOAT8)
+      .build();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+      .addRow(2010.0, 17.4)
+      .addRow(-2002.0, -1.2)
+      .addRow(2001.0, 1.2)
+      .addRow(6005.0, 1.2)
+      .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testSerDe() throws Exception {
+    String sql = "SELECT COUNT(*) as cnt FROM cp.`jsoninput/input2.json`";
+    String plan = queryBuilder().sql(sql).explainJson();
+    long cnt = queryBuilder().physical(plan).singletonLong();
+    assertEquals("Counts should match", 4L, cnt);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
@@ -399,7 +399,7 @@ public class PhysicalOpUnitTestBase extends ExecTest {
   public static Iterator<RecordReader> getJsonReadersFromInputFiles(DrillFileSystem fs, List<Path> inputPaths, FragmentContext fragContext, List<SchemaPath> columnsToRead) {
     List<RecordReader> readers = new ArrayList<>();
     for (Path inputPath : inputPaths) {
-      readers.add(new JSONRecordReader(fragContext, inputPath, fs, columnsToRead));
+      readers.add(new JSONRecordReader(fragContext, inputPath, fs, columnsToRead, null));
     }
     return readers.iterator();
   }

--- a/exec/java-exec/src/test/resources/jsoninput/nan_test.json
+++ b/exec/java-exec/src/test/resources/jsoninput/nan_test.json
@@ -1,0 +1,1 @@
+{"nan_col":NaN, "inf_col":Infinity}


### PR DESCRIPTION
# [DRILL-8167](https://issues.apache.org/jira/browse/DRILL-8167): Add JSON Config Options to Format Config

## Description
Most all Drill format plugins allow the user to configure various options for that plugin as part of the format config.  The one glaring exception is the JSON reader which has several configuration options which can only be set globally.  This PR moves these to the format config so that users can set these options when they configure a storage plugin.  

This PR does not eliminate the global settings for JSON.  It simply adds another place where a user can update the settings.  If the settings in the config file are not defined (`null`) Drill will use the global settings.

The config is set to only include these values when they are not `null`, so there are no breaking changes.

## Documentation
Drill's JSON reader can be configured with various global configuration variables.  However these variables can also be overridden in an individual storage plugin configuration.  The parameters are:

* `allTextMode`:  When `true`, Drill will read all fields in a given JSON file as text.
* `readNumbersAsDouble`:  When `true`, Drill will read all numbers as Doubles.  This is useful if your data contains fields with a mix of integers and floating point numbers.  A very common place this happens is when the record contains `0`.
* `skipMalformedJSONRecords`:  When set to `true`, Drill will attempt to skip malformed JSON records.  When `false`, Drill will throw an exception for bad records.
* `escapeAnyChar`:  Allows escaping of any character when set to `true`. 
* `nanInf`:  Allows `NaN` and `Infinity` in JSON data when set to `true`. 

A JSON config could look like this:

```json
...
"json": {
   "type": "json",
   "extensions": ["json"],
   "allTextMode": true,
   "readNumbersAsDouble": true,
   "skipMalformedJSONRecords": true,
   "escapeAnyChar": false,
   "nanInf": true
}
...
```

You can also include these values at query time:

```sql
SELECT `integer`, `float` 
FROM table(cp.`jsoninput/input2.json` (type => 'json', allTextMode => True))"
```

## Testing
Added unit tests.