### PR TITLE
DRILL-8168: Do not duplicate attempts to impersonate a user in the REST API

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -274,7 +274,7 @@ public final class ExecConstants {
   public static final String HTTP_WEB_CLIENT_RESULTSET_AUTOLIMIT_CHECKED = "drill.exec.http.web.client.resultset.autolimit.checked";
   public static final String HTTP_WEB_CLIENT_RESULTSET_AUTOLIMIT_ROWS = "drill.exec.http.web.client.resultset.autolimit.rows";
   public static final String HTTP_WEB_CLIENT_RESULTSET_ROWS_PER_PAGE_VALUES = "drill.exec.http.web.client.resultset.rowsPerPageValues";
-  //Control Heap usage runaway
+  @Deprecated // TODO: Remove any logic based on this option now that REST query results stream.
   public static final String HTTP_MEMORY_HEAP_FAILURE_THRESHOLD = "drill.exec.http.memory.heap.failure.threshold";
   //Customize filters in options
   public static final String HTTP_WEB_OPTIONS_FILTERS = "drill.exec.http.web.options.filters";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
+
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.cache.FileTemplateLoader;
@@ -321,7 +322,14 @@ public class DrillRestServer extends ResourceConfig {
      * @param config drill config
      * @param request client request
      * @return session user principal
+     *
+     * @deprecated a userName property has since been added to POST /query.json.
+     * and the web UI now never sets a User-Name header. The restriction to
+     * unauthenticated Drill is also not enough for general impersonation.
+     * Choose one way to request impersonation over HTTP, this or the other.
+     * @link{org.apache.drill.exec.server.rest.QueryResources#submitQuery}
      */
+    @Deprecated
     private Principal createSessionUserPrincipal(DrillConfig config, HttpServletRequest request) {
       if (WebServer.isOnlyImpersonationEnabled(config)) {
         final String userName = request.getHeader("User-Name");


### PR DESCRIPTION
# [DRILL-8168](https://issues.apache.org/jira/browse/DRILL-8168): Do not duplicate attempts to impersonate a user in the REST API

## Description
When authentication is enabled, the Drill UserSession is persistent and it is only appropriate to modify it for impersonation once.  This adds a check for whether the UserSession needs modifying and avoids any uneeded attempt to do so, thereby fixing the broken scenario

Request 1: UserSession user alice modified to impersonated user bob
Request 2: UserSession user bob fails to be modified to bob because bob is not authorised to impersonate bob.

## Documentation
N/A

## Testing
New test for this scenario?