### PR TITLE
DRILL-8165: Upgrade liquibase because of CVE-2022-0839

### DIFF
--- a/metastore/rdbms-metastore/pom.xml
+++ b/metastore/rdbms-metastore/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <jooq.version>3.13.1</jooq.version>
-    <liquibase.version>3.8.7</liquibase.version>
+    <liquibase.version>4.8.0</liquibase.version>
     <sqlite.version>3.30.1</sqlite.version>
   </properties>
 

--- a/metastore/rdbms-metastore/src/main/java/org/apache/drill/metastore/rdbms/RdbmsMetastore.java
+++ b/metastore/rdbms-metastore/src/main/java/org/apache/drill/metastore/rdbms/RdbmsMetastore.java
@@ -117,6 +117,8 @@ public class RdbmsMetastore implements Metastore {
   private void initTables(DataSource dataSource) {
     try (Connection connection = dataSource.getConnection()) {
       JdbcConnection jdbcConnection = new JdbcConnection(connection);
+      // TODO It is recommended to use the new function if the following issue is resolved.
+      // https://github.com/liquibase/liquibase/issues/2349
       Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection);
       ClassLoaderResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor();
       try (Liquibase liquibase = new Liquibase(LIQUIBASE_CHANGELOG_FILE, resourceAccessor, database)) {


### PR DESCRIPTION
# [DRILL-8165](https://issues.apache.org/jira/browse/DRILL-8165): Upgrade liquibase because of CVE-2022-0839

## Description

Split from the #2493 

Please note that we should replace the `DatabaseFactory.getInstance()` with `Scope.getCurrentScope().getSingleton(DatabaseFactory.class)` once the following issue is resolved.

## Documentation
N/A

## Testing
Use the CI.
