### PR TITLE
DRILL-8172: Use the specified memory usage for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ cache:
 before_install:
   - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64"
   - export PATH="$JAVA_HOME/bin:$PATH"
+  - export MEMORYMB=2048
+  - export DIRECTMEMORYMB=5120
+  - free -m
   - java -version
   - mvn -version
   - git fetch --unshallow
@@ -71,7 +74,7 @@ install:
   # For protobuf phase: builds Drill project, performs license checkstyle goal and regenerates Java and C++ Protobuf files
   - |
     if [ $PHASE = "tests" ]; then \
-      mvn install --batch-mode --no-transfer-progress -DforkCount=1 \
+      mvn install --batch-mode --no-transfer-progress -DforkCount=1 -DmemoryMb=$MEMORYMB -DdirectMemoryMb=$DIRECTMEMORYMB \
         -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest"; \
     elif [ $PHASE = "build_checkstyle_protobuf" ]; then \
       MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --no-transfer-progress -Drat.skip=false -Dlicense.skip=false --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true && \

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -651,14 +651,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.rdblue</groupId>
-      <artifactId>brotli-codec</artifactId>
-      <version>0.1.1</version>
-      <!-- brotli-codec bundles natives for linux and darwin, amd64 only so
-      we don't ship it so as not to break startup on windows or arm -->
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-jaxrs2</artifactId>
       <version>${swagger.version}</version>
@@ -778,12 +770,11 @@
       </dependencies>
     </profile>
     <profile>
-      <!-- Only include a Brotli codec in test scope on Linux / amd64, see PARQUET-1975 -->
-      <id>linux-amd64</id>
+      <!-- Only include a Brotli codec in test scope on AMD64 and x86_64, see PARQUET-1975 -->
+      <id>brotli-amd64</id>
       <activation>
         <os>
           <arch>amd64</arch>
-          <name>Linux</name>
         </os>
       </activation>
       <dependencies>
@@ -792,6 +783,22 @@
           <artifactId>brotli-codec</artifactId>
           <version>0.1.1</version>
           <!-- this codec is not shipped because it breaks startup on unsupported platforms -->
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>brotli-x86_64</id>
+      <activation>
+        <os>
+          <arch>x86_64</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.rdblue</groupId>
+          <artifactId>brotli-codec</artifactId>
+          <version>0.1.1</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -52,7 +52,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -1001,8 +1003,8 @@ public class TestParquetWriter extends ClusterTest {
   // Only attempt this test on Linux / amd64 because com.rdblue.brotli-codec
   // only bundles natives for Mac and Linux on AMD64.  See PARQUET-1975.
   @Test
-  @EnabledIfSystemProperty(named = "os.name", matches = "Linux")
-  @EnabledIfSystemProperty(named = "os.arch", matches = "amd64")
+  @EnabledIfSystemProperty(named = "os.arch", matches = "(amd64|x86_64)")
+  @DisabledOnOs({ OS.WINDOWS })
   public void testTPCHReadWriteBrotli() throws Exception {
     try {
       client.alterSession(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, "brotli");


### PR DESCRIPTION
# [DRILL-8172](https://issues.apache.org/jira/browse/DRILL-8172): Use the specified memory usage for Travis CI

## Description
Unlike GitHub CI, Travis CI may have more memory. If so, we can run unit tests using various policies to prevent failure.

* This patch also fixes an brotli dependency test failure.

## Documentation
N/A

## Testing
Done.
