### PR TITLE
DRILL-8177: Bump default TLS version to 1.3

### DIFF
--- a/distribution/src/main/resources/drill-override-example.conf
+++ b/distribution/src/main/resources/drill-override-example.conf
@@ -335,10 +335,10 @@ drill.exec: {
     keyPassword: "key_passwd",
     #Optional handshakeTimeout in milliseconds. Default is 10000 ms (10 seconds)
     handshakeTimeout: 10000,
-    #protocol is optional. Drill will default to TLSv1.2. Valid values depend on protocol versions
+    #protocol is optional. Drill will default to TLSv1.3. Valid values depend on protocol versions
     # enabled for tje underlying securrity provider. For JSSE these are : SSL, SSLV2, SSLV3,
-    # TLS, TLSV1, TLSv1.1, TLSv1.2
-    protocol: "TLSv1.2",
+    # TLS, TLSV1, TLSv1.1, TLSv1.2, TLSv1.3
+    protocol: "TLSv1.3",
     #ssl provider. May be "JDK" or "OPENSSL". Default is "JDK"
     provider: "JDK"
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -197,7 +197,7 @@ public final class ExecConstants {
       new OptionDescription("Linearly reduces partition sender buffer row count after this number of receivers. Default is 0 (disabled). (Since Drill 1.18)"));
 
   public static final String SSL_PROVIDER = "drill.exec.ssl.provider"; // valid values are "JDK", "OPENSSL" // default JDK
-  public static final String SSL_PROTOCOL = "drill.exec.ssl.protocol"; // valid values are SSL, SSLV2, SSLV3, TLS, TLSV1, TLSv1.1, TLSv1.2(default)
+  public static final String SSL_PROTOCOL = "drill.exec.ssl.protocol"; // valid values are SSL, SSLV2, SSLV3, TLS, TLSV1, TLSv1.1, TLSv1.2, TLSv1.3(default)
   public static final String SSL_KEYSTORE_TYPE = "drill.exec.ssl.keyStoreType";
   public static final String SSL_KEYSTORE_PATH = "drill.exec.ssl.keyStorePath";     // path to keystore. default : $JRE_HOME/lib/security/keystore.jks
   public static final String SSL_KEYSTORE_PASSWORD = "drill.exec.ssl.keyStorePassword"; // default: changeit

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfigurator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfigurator.java
@@ -94,7 +94,6 @@ public class SslContextFactoryConfigurator {
       }
     }
     sslFactory.setIncludeProtocols(sslConf.getProtocol());
-    logger.info("Web server configured to use TLS protocol '{}'", sslConf.getProtocol());
     if (config.hasPath(ExecConstants.HTTP_JETTY_SSL_CONTEXT_FACTORY_OPTIONS_PREFIX)) {
       setStringIfPresent(ExecConstants.HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_CERT_ALIAS, sslFactory::setCertAlias);
       setStringIfPresent(ExecConstants.HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_CRL_PATH, sslFactory::setCrlPath);
@@ -126,6 +125,7 @@ public class SslContextFactoryConfigurator {
       setBooleanIfPresent(ExecConstants.HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_VALIDATE_PEER_CERTS, sslFactory::setValidatePeerCerts);
       setBooleanIfPresent(ExecConstants.HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_WANT_CLIENT_AUTH, sslFactory::setWantClientAuth);
     }
+    logger.info("Web server configured to use TLS protocol '{}'", String.join(", ", sslFactory.getIncludeProtocols()));
   }
 
   private void setStringArrayIfPresent(String optKey, Consumer<String[]> optSet) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
@@ -41,7 +41,7 @@ public abstract class SSLConfig {
   private static final Logger logger = LoggerFactory.getLogger(SSLConfig.class);
 
   public static final String DEFAULT_SSL_PROVIDER = "JDK"; // JDK or OPENSSL
-  public static final String DEFAULT_SSL_PROTOCOL = "TLSv1.2";
+  public static final String DEFAULT_SSL_PROTOCOL = "TLSv1.3";
   public static final int DEFAULT_SSL_HANDSHAKE_TIMEOUT_MS = 10 * 1000; // 10 seconds
 
   // Either the Netty SSL context or the JDK SSL context will be initialized

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -210,7 +210,7 @@ drill.exec: {
     trustStorePassword =  ${?javax.net.ssl.trustStorePassword}
     # default key password to keystore password
     keyPassword = ${?javax.net.ssl.keyStorePassword},
-    protocol: "TLSv1.2",
+    protocol: "TLSv1.3",
     # if true, then Drill will read SSL parameters from the
     # Hadoop configuration files.
     useHadoopConfig : true,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSL.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSL.java
@@ -76,7 +76,7 @@ public class TestUserBitSSL extends BaseTestQuery {
         .withValue(ExecConstants.SSL_TRUSTSTORE_PASSWORD,
             ConfigValueFactory.fromAnyRef("drill123"))
         .withValue(ExecConstants.SSL_PROTOCOL,
-            ConfigValueFactory.fromAnyRef("TLSv1.2")));
+            ConfigValueFactory.fromAnyRef("TLSv1.3")));
 
     initProps = new Properties();
     initProps.setProperty(DrillProperties.ENABLE_TLS, "true");
@@ -252,7 +252,7 @@ public class TestUserBitSSL extends BaseTestQuery {
           .withValue(ExecConstants.SSL_KEYSTORE_TYPE, ConfigValueFactory.fromAnyRef("JKS"))
           .withValue(ExecConstants.SSL_KEYSTORE_PATH, ConfigValueFactory.fromAnyRef(keyStorePath))
           .withValue(ExecConstants.SSL_KEYSTORE_PASSWORD, ConfigValueFactory.fromAnyRef("test_password"))
-          .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.2")));
+          .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.3")));
 
       updateTestCluster(1, sslConfig, connectionProps);
 
@@ -297,7 +297,7 @@ public class TestUserBitSSL extends BaseTestQuery {
           .withValue(ExecConstants.SSL_KEYSTORE_TYPE, ConfigValueFactory.fromAnyRef("JKS"))
           .withValue(ExecConstants.SSL_KEYSTORE_PATH, ConfigValueFactory.fromAnyRef(unknownKsPath))
           .withValue(ExecConstants.SSL_KEYSTORE_PASSWORD, ConfigValueFactory.fromAnyRef("drill123"))
-          .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.2")));
+          .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.3")));
 
       updateTestCluster(1, sslConfig, connectionProps);
 
@@ -325,7 +325,7 @@ public class TestUserBitSSL extends BaseTestQuery {
           .withValue(ExecConstants.SSL_KEYSTORE_TYPE, ConfigValueFactory.fromAnyRef("JKS"))
           .withValue(ExecConstants.SSL_KEYSTORE_PATH, ConfigValueFactory.fromAnyRef(unknownKsPath))
           .withValue(ExecConstants.SSL_KEYSTORE_PASSWORD, ConfigValueFactory.fromAnyRef("drill123"))
-          .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.2")));
+          .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.3")));
 
       updateTestCluster(1, sslConfig, connectionProps);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSLServer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSLServer.java
@@ -52,7 +52,7 @@ public class TestUserBitSSLServer extends BaseTestQuery {
         .withValue(ExecConstants.SSL_KEYSTORE_PATH, ConfigValueFactory.fromAnyRef(ksPath))
         .withValue(ExecConstants.SSL_KEYSTORE_PASSWORD, ConfigValueFactory.fromAnyRef("drill123"))
         .withValue(ExecConstants.SSL_KEY_PASSWORD, ConfigValueFactory.fromAnyRef("drill123"))
-        .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.2")));
+        .withValue(ExecConstants.SSL_PROTOCOL, ConfigValueFactory.fromAnyRef("TLSv1.3")));
     initProps = new Properties();
     initProps.setProperty(DrillProperties.ENABLE_TLS, "true");
     initProps.setProperty(DrillProperties.TRUSTSTORE_PATH, tsPath);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfiguratorTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfiguratorTest.java
@@ -42,7 +42,7 @@ public class SslContextFactoryConfiguratorTest extends ClusterTest {
   public static void setUpClass() throws Exception {
     ClusterFixtureBuilder fixtureBuilder = ClusterFixture.builder(dirTestWatcher)
         // imitate proper ssl config for embedded web
-        .configProperty(ExecConstants.SSL_PROTOCOL, "TLSv1.2")
+        .configProperty(ExecConstants.SSL_PROTOCOL, "TLSv1.3")
         .configProperty(ExecConstants.HTTP_ENABLE_SSL, true)
         .configProperty(ExecConstants.HTTP_TRUSTSTORE_PATH, "/tmp/ssl/cacerts.jks")
         .configProperty(ExecConstants.HTTP_TRUSTSTORE_PASSWORD, "passphrase")


### PR DESCRIPTION
# [DRILL-8177](https://issues.apache.org/jira/browse/DRILL-8177): Bump default TLS version to 1.3

## Description

Change default TLS version to 1.3 for Web Server and client-drillbit connection as it is more efficient and secure protocol.

## Documentation
Default TLS version for RPC layer, Web Server and JDBC driver is changed from 1.2 to 1.3:

https://github.com/apache/drill-site/pull/27

## Testing
Manual verification with commands:
```
openssl s_client -tls1_3 localnode.com:8047
openssl s_client -tls1_3 localnode.com:31010
openssl s_client -tls1_2 localnode.com:8047
openssl s_client -tls1_2 localnode.com:31010
```

Manual test with Sqlline direct connection to drillbit:
* Positive test with default TLS:
```sh
apache drill> !connect jdbc:drill:drillbit=localnode.com:31010;enableTLS=true;disableCertificateVerification=true
apache drill> select version from sys.version;
+----------------+
|    version     |
+----------------+
| 2.0.0-SNAPSHOT |
+----------------+
1 row selected (1.95 seconds)

```
* Negative test with default TLS on Drill server and TLS 1.2 on JDBC
```sh
apache drill> !connect jdbc:drill:drillbit=localnode.com:31010;enableTLS=true;disableCertificateVerification=true;TLSProtocol=TLSv1.2
Error: Failure in connecting to Drill: org.apache.drill.exec.rpc.NonTransientRpcException: Connecting to the server timed out. This is sometimes due to a mismatch in the SSL configurat
ion between client and server. [ Exception: Waited 10000 milliseconds (plus 633500 nanoseconds delay) for org.apache.drill.shaded.guava.com.google.common.util.concurrent.SettableFuture
@24eb65e3[status=PENDING]] (state=,code=0)
apache drill>
```
* Positive test with default TLS on Drill server and TLS 1.3 on JDBC
```sh
apache drill> !connect jdbc:drill:drillbit=localnode.com:31010;enableTLS=true;disableCertificateVerification=true;TLSProtocol=TLSv1.3
apache drill> select version from sys.version;
+----------------+
|    version     |
+----------------+
| 2.0.0-SNAPSHOT |
+----------------+
1 row selected (0.389 seconds)
apache drill>
```