### PR TITLE
DRILL-8178: Bump AWS Libraries to Latest Version

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Packaging and Distribution Assembly</name>
 
   <properties>
-    <aws.java.sdk.version>1.11.375</aws.java.sdk.version>
+    <aws.java.sdk.version>1.12.186</aws.java.sdk.version>
     <oci.hdfs.version>3.3.0.7.0.1</oci.hdfs.version>
   </properties>
 


### PR DESCRIPTION
# [DRILL-8178](https://issues.apache.org/jira/browse/DRILL-8178): Bump AWS Libraries to Latest Version

## Description
Updated AWS libraries to latest version.  The version which shipped with Drill was 4 years old. 

## Documentation
N/A

## Testing
Tested manually. 
