### PR TITLE
DRILL-8181: Accept nullable args in HTTP plugin UDFs, fix HikariCP default parm names

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -868,7 +868,8 @@ public class SimpleHttp {
    * This function makes an API call and returns a string of the parsed results. It is used in the http_get() UDF
    * and retrieves all the configuration parameters contained in the storage plugin and endpoint configuration. The exception
    * is pagination.  This does not support pagination.
-   * @param schemaPath The path of storage_plugin.endpoint from which the data will be retrieved
+   * @param plugin The HTTP storage plugin upon which the API call is based.
+   * @param endpointConfig The configuration of the API endpoint upon which the API call is based.
    * @param context {@link DrillbitContext} The context from the current query
    * @param args An optional list of parameter arguments which will be included in the URL
    * @return A String of the results.

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStoragePlugin.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStoragePlugin.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.jdbc;
 
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -134,16 +135,16 @@ public class JdbcStoragePlugin extends AbstractStoragePlugin {
       storage config.
       */
 
-      // maximum amount of time that a connection is allowed to sit idle in the pool, 0 = forever
-      properties.setProperty("dataSource.idleTimeout", String.format("%d000", 1*60*60)); // 1 hour
-      // how frequently HikariCP will attempt to keep a connection alive, 0 = disabled
-      properties.setProperty("dataSource.keepaliveTime", String.format("%d000", 0));
-      // maximum lifetime of a connection in the pool, 0 = forever
-      properties.setProperty("dataSource.maxLifetime", String.format("%d000", 6*60*60)); // 6 hours
-      // minimum number of idle connections that HikariCP tries to maintain in the pool, 0 = none
-      properties.setProperty("dataSource.minimumIdle", "0");
+      // maximum amount of time that a connection is allowed to sit idle in the pool, 0 ⇒ forever
+      properties.setProperty("idleTimeout", String.valueOf(TimeUnit.HOURS.toMillis(2)));
+      // how frequently HikariCP will attempt to keep a connection alive, 0 ⇒ disabled
+      properties.setProperty("keepaliveTime", String.valueOf(TimeUnit.MINUTES.toMillis(5)));
+      // maximum lifetime of a connection in the pool, 0 ⇒ forever
+      properties.setProperty("maxLifetime", String.valueOf(TimeUnit.HOURS.toMillis(12)));
+      // minimum number of idle connections that HikariCP tries to maintain in the pool, 0 ⇒ none
+      properties.setProperty("minimumIdle", "0");
       // maximum size that the pool is allowed to reach, including both idle and in-use connections
-      properties.setProperty("dataSource.maximumPoolSize", "10");
+      properties.setProperty("maximumPoolSize", "10");
 
       // apply any HikariCP parameters the user may have set, overwriting defaults
       properties.putAll(config.getSourceParameters());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -306,7 +306,8 @@ public class SSLConfigServer extends SSLConfig {
 
   @Override
   public int getHandshakeTimeout() {
-    // TODO: why do we hard code this when we provide {@link ExecConstants.SSL_HANDSHAKE_TIMEOUT}?
+    // TODO: (DRILL-8183) why do we hard code this when we provide
+    // {@link ExecConstants.SSL_HANDSHAKE_TIMEOUT}?
     // A value of 0 is interpreted by Netty as "no timeout".
     return 0;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -306,6 +306,8 @@ public class SSLConfigServer extends SSLConfig {
 
   @Override
   public int getHandshakeTimeout() {
+    // TODO: why do we hard code this when we provide {@link ExecConstants.SSL_HANDSHAKE_TIMEOUT}?
+    // A value of 0 is interpreted by Netty as "no timeout".
     return 0;
   }
 


### PR DESCRIPTION
# [DRILL-8181](https://issues.apache.org/jira/browse/DRILL-8181): Accept nullable args in HTTP plugin UDFs, fix HikariCP default parm names

## Description

Accept nullable parameter types in the UDFs in the HTTP storage plugin returning an empty MAP when a null argument is present.

When default HikariCP pool parameters are set in the JDBC storage plugin, the parameter names are incorrectly prefixed with "dataSource.".  Remove this.

## Documentation
None

## Testing
TestDataSource#testInitWithSourceParameters()
TestHttpUDFFunctions#testNullParam()
