### PR TITLE
Fix projection of map arrays and nested maps in EVF2

### DIFF
--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -44,7 +44,6 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
   /**
    * Width of each fixed-width value.
    */
-
   public static final int VALUE_WIDTH = 1;
 
   /**
@@ -53,7 +52,6 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
    * enforced when the vector is used to hold values in a repeated
    * vector.
    */
-
   public static final int MAX_CAPACITY = MAX_BUFFER_SIZE / VALUE_WIDTH;
 
   /**
@@ -62,7 +60,6 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
    * the maximum item count. This is the limit enforced when the
    * vector is used to hold required or nullable values.
    */
-
   public static final int MAX_COUNT = Math.min(MAX_ROW_COUNT, MAX_CAPACITY);
 
   /**
@@ -70,7 +67,6 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
    * values that either fit in the maximum overall vector size, or that
    * is no larger than the maximum vector item count.
    */
-
   public static final int NET_MAX_SIZE = VALUE_WIDTH * MAX_COUNT;
 
   private final FieldReader reader = new BitReaderImpl(BitVector.this);

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractArrayWriter.java
@@ -91,13 +91,11 @@ import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
  *     are passed to both.</li>
  * </ul>
  */
-
 public abstract class AbstractArrayWriter implements ArrayWriter, WriterEvents {
 
   /**
    * Object representation of an array writer.
    */
-
   public static class ArrayObjectWriter extends AbstractObjectWriter {
 
     protected final AbstractArrayWriter arrayWriter;
@@ -130,7 +128,6 @@ public abstract class AbstractArrayWriter implements ArrayWriter, WriterEvents {
    * Keeps track of the current offset in terms of value positions.
    * Forwards overflow events to the base index.
    */
-
   public class ArrayElementWriterIndex implements ColumnWriterIndex {
 
     private int elementIndex;


### PR DESCRIPTION
# [DRILL-8185](https://issues.apache.org/jira/browse/DRILL-8185): Fix projection of map arrays and nested maps in EVF2 

## Description

Fixes the rather complex area in EVF2 that handles projection of nested maps and map arrays to properly pass along the offset vector for map arrays, and set the value count for nested maps.

## Documentation

N/A

## Testing

Added unit tests for this case. Verified against @luocooong,'s DRILL-8174 (upgrade Avro to EVF-2) branch.