### PR TITLE
DRILL-8191: HTTP Request Function Not Detecting JSON Config

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -831,7 +831,7 @@ public class SimpleHttp {
       throw UserException.functionError()
         .message("You must call this function with a valid endpoint name.")
         .build(logger);
-    } else if (endpointConfig.inputType() != "json") {
+    } else if (! endpointConfig.inputType().contentEquals("json")) {
       throw UserException.functionError()
         .message("Http_get only supports API endpoints which return json.")
         .build(logger);


### PR DESCRIPTION
# [DRILL-8191](https://issues.apache.org/jira/browse/DRILL-8191): HTTP Request Function Not Detecting JSON Config

## Description
The `http_request` function was ignoring the `inputType` parameter and throwing an exception.  This fixes that. 

## Documentation
No user facing changes.

## Testing
Manually tested and ran unit tests.