### PR TITLE
DRILL-8192: Cassandra queries fail when enabled Mongo plugin

### DIFF
--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/plan/IcebergPluginImplementor.java
@@ -32,6 +32,8 @@ import org.apache.drill.exec.planner.common.DrillLimitRelBase;
 import org.apache.drill.exec.planner.logical.DrillOptiq;
 import org.apache.drill.exec.planner.logical.DrillParseContext;
 import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.store.StoragePlugin;
+import org.apache.drill.exec.store.dfs.FileSystemPlugin;
 import org.apache.drill.exec.store.iceberg.IcebergGroupScan;
 import org.apache.drill.exec.store.plan.AbstractPluginImplementor;
 import org.apache.drill.exec.store.plan.rel.PluginFilterRel;
@@ -132,6 +134,11 @@ public class IcebergPluginImplementor extends AbstractPluginImplementor {
   @Override
   public boolean artificialLimit() {
     return true;
+  }
+
+  @Override
+  protected Class<? extends StoragePlugin> supportedPlugin() {
+    return FileSystemPlugin.class;
   }
 
   @Override

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/MongoPluginImplementor.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/plan/MongoPluginImplementor.java
@@ -40,10 +40,12 @@ import org.apache.drill.exec.planner.common.DrillLimitRelBase;
 import org.apache.drill.exec.planner.logical.DrillOptiq;
 import org.apache.drill.exec.planner.logical.DrillParseContext;
 import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.mongo.MongoAggregateUtils;
 import org.apache.drill.exec.store.mongo.MongoFilterBuilder;
 import org.apache.drill.exec.store.mongo.MongoGroupScan;
 import org.apache.drill.exec.store.mongo.MongoScanSpec;
+import org.apache.drill.exec.store.mongo.MongoStoragePlugin;
 import org.apache.drill.exec.store.plan.AbstractPluginImplementor;
 import org.apache.drill.exec.store.plan.PluginImplementor;
 import org.apache.drill.exec.store.plan.rel.PluginAggregateRel;
@@ -280,6 +282,11 @@ public class MongoPluginImplementor extends AbstractPluginImplementor {
   @Override
   public boolean canImplement(TableScan scan) {
     return hasPluginGroupScan(scan);
+  }
+
+  @Override
+  protected Class<? extends StoragePlugin> supportedPlugin() {
+    return MongoStoragePlugin.class;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/AbstractPluginImplementor.java
@@ -31,6 +31,7 @@ import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.planner.common.DrillLimitRelBase;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
 import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.plan.rel.PluginAggregateRel;
 import org.apache.drill.exec.store.plan.rel.PluginFilterRel;
 import org.apache.drill.exec.store.plan.rel.PluginJoinRel;
@@ -152,9 +153,16 @@ public abstract class AbstractPluginImplementor implements PluginImplementor {
     CheckedFunction<DrillTable, GroupScan, IOException> groupScanFunction = DrillTable::getGroupScan;
     return Optional.ofNullable(DrillRelOptUtil.findScan(node))
       .map(DrillRelOptUtil::getDrillTable)
+      .filter(this::supportsDrillTable)
       .map(groupScanFunction)
       .orElse(null);
   }
+
+  private boolean supportsDrillTable(DrillTable table) {
+    return supportedPlugin().isInstance(table.getPlugin());
+  }
+
+  protected abstract Class<? extends StoragePlugin> supportedPlugin();
 
   protected abstract boolean hasPluginGroupScan(RelNode node);
 }


### PR DESCRIPTION
# [DRILL-8192](https://issues.apache.org/jira/browse/DRILL-8192): Cassandra queries fail when enabled Mongo plugin

## Description
Some storage plugin instances like Cassandra don't support obtaining group scan using the `StoragePlugin.getPhysicalScan()` method. Added extra check to ensure that plugin implementor can obtain group scan safely.

## Documentation
NA

## Testing
Checked manually.
