### PR TITLE
DRILL-8194: Fix the function of REPLACE throws IndexOutOfBoundsException, if text's length is more than previously applied

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -894,10 +894,15 @@ public class StringFunctions{
 
     @Override
     public void eval() {
-      out.buffer = buffer;
       out.start = out.end = 0;
       int fromL = from.end - from.start;
       int textL = text.end - text.start;
+      if (buffer.capacity() < textL) {
+        // We realloc buffer, if actual length is more than previously applied.
+        out.buffer = buffer.reallocIfNeeded(textL);
+      } else {
+        out.buffer = buffer;
+      }
 
       if (fromL > 0 && fromL <= textL) {
         //If "from" is not empty and it's length is no longer than text's length

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.categories.SqlFunctionTest;
@@ -333,6 +334,19 @@ public class TestStringFunctions extends BaseTestQuery {
         .baselineValues("bxd", "abc")
         .build()
         .run();
+  }
+
+  @Test
+  public void testReplaceOutBuffer() throws Exception {
+    String originValue = RandomStringUtils.randomAlphabetic(8192).toLowerCase() + "12345";
+    String expectValue = originValue.replace("12345", "67890");
+    String sql = "select replace(c1, '12345', '67890') as col from (values('" + originValue + "')) as t(c1)";
+    testBuilder()
+      .sqlQuery(sql)
+      .ordered()
+      .baselineColumns("col")
+      .baselineValues(expectValue)
+      .go();
   }
 
   @Test


### PR DESCRIPTION


# [DRILL-8194](https://issues.apache.org/jira/browse/DRILL-8194): Function of REPLACE throws IndexOutOfBoundsException, if text's length is more than previously applied

(Please replace `PR Title` with actual PR Title)

## Description

Add code to check buffer's capacity with text's length.
We realloc buffer, if actual length is more than previously applied.

## Documentation
NA

## Testing
Add test case: org.apache.drill.exec.expr.fn.impl.TestStringFunctions#testReplaceOutBuffer
