### PR TITLE
DRILL-8035: Update Janino to 3.1.7 version

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassTransformer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassTransformer.java
@@ -240,7 +240,7 @@ public class ClassTransformer {
       Map<String, Pair<byte[], ClassNode>> classesToMerge = Maps.newHashMap();
       for (byte[] clazz : implementationClasses) {
         totalBytecodeSize += clazz.length;
-        final ClassNode node = AsmUtil.classFromBytes(clazz, ClassReader.EXPAND_FRAMES);
+        ClassNode node = AsmUtil.classFromBytes(clazz, ClassReader.SKIP_FRAMES);
         if (!AsmUtil.isClassOk(logger, "implementationClasses", node)) {
           throw new IllegalStateException("Problem found with implementationClasses");
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/bytecode/ReplacingBasicValue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/bytecode/ReplacingBasicValue.java
@@ -283,14 +283,16 @@ public class ReplacingBasicValue extends BasicValue {
     if (AssertionUtil.ASSERT_ENABLED) {
       assert associates == other.associates;
       assert flagSet == other.flagSet;
-      assert associates.containsKey(this);
-      assert associates.containsKey(other);
+      if (associates != null) {
+        assert associates.containsKey(this);
+        assert associates.containsKey(other);
 
-      // check all the other values as well
-      for(ReplacingBasicValue value : associates.keySet()) {
-        assert associates.get(value) == null; // we never use the value
-        assert value.associates == associates;
-        assert value.flagSet == flagSet;
+        // check all the other values as well
+        for(ReplacingBasicValue value : associates.keySet()) {
+          assert associates.get(value) == null; // we never use the value
+          assert value.associates == associates;
+          assert value.flagSet == flagSet;
+        }
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionInitializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionInitializer.java
@@ -150,7 +150,7 @@ public class FunctionInitializer {
       // TODO: Hack to remove annotations so Janino doesn't choke. Need to reconsider this problem...
       body = body.replaceAll("@\\w+(?:\\([^\\\\]*?\\))?", "");
       try {
-        return new Parser(new Scanner(null, new StringReader(body))).parseCompilationUnit();
+        return (CompilationUnit) new Parser(new Scanner(null, new StringReader(body))).parseAbstractCompilationUnit();
       } catch (CompileException e) {
           throw new IOException(String.format("Failure while loading class %s.", clazz.getName()), e);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/ImportGrabber.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/ImportGrabber.java
@@ -18,13 +18,14 @@
 package org.apache.drill.exec.expr.fn;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.codehaus.janino.Java;
-import org.codehaus.janino.Java.CompilationUnit.SingleStaticImportDeclaration;
-import org.codehaus.janino.Java.CompilationUnit.SingleTypeImportDeclaration;
-import org.codehaus.janino.Java.CompilationUnit.StaticImportOnDemandDeclaration;
-import org.codehaus.janino.Java.CompilationUnit.TypeImportOnDemandDeclaration;
+import org.codehaus.janino.Java.AbstractCompilationUnit.SingleStaticImportDeclaration;
+import org.codehaus.janino.Java.AbstractCompilationUnit.SingleTypeImportDeclaration;
+import org.codehaus.janino.Java.AbstractCompilationUnit.StaticImportOnDemandDeclaration;
+import org.codehaus.janino.Java.AbstractCompilationUnit.TypeImportOnDemandDeclaration;
 import org.codehaus.janino.util.AbstractTraverser;
 
 public class ImportGrabber {
@@ -45,7 +46,7 @@ public class ImportGrabber {
    */
   public static List<String> getImports(Java.CompilationUnit compilationUnit) {
     ImportGrabber visitor = new ImportGrabber();
-    compilationUnit.importDeclarations.forEach(visitor.importFinder::visitImportDeclaration);
+    Arrays.stream(compilationUnit.importDeclarations).forEach(visitor.importFinder::visitImportDeclaration);
 
     return visitor.imports;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/MethodGrabbingVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/MethodGrabbingVisitor.java
@@ -106,7 +106,7 @@ public class MethodGrabbingVisitor {
         try {
           // replaces return statements and stores the result into methodBodyBlock
           methodBodyBlock.addStatements(
-              returnStatementReplacer.copyBlockStatements(methodDeclarator.optionalStatements));
+              returnStatementReplacer.copyBlockStatements(methodDeclarator.statements));
         } catch (CompileException e) {
           throw new RuntimeException(e);
         }

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -34,7 +34,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>49400000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>50000000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <calcite.groupId>com.github.vvysotskyi.drill-calcite</calcite.groupId>
     <calcite.version>1.21.0-drill-r8</calcite.version>
     <avatica.version>1.17.0</avatica.version>
-    <janino.version>3.0.11</janino.version>
+    <janino.version>3.1.7</janino.version>
     <sqlline.version>1.12.0</sqlline.version>
     <jackson.version>2.13.2.20220328</jackson.version>
     <zookeeper.version>3.5.7</zookeeper.version>


### PR DESCRIPTION
# [DRILL-8035](https://issues.apache.org/jira/browse/DRILL-8035): Update Janino to 3.1.7 version

## Description
This update is required for the Calcite update.

## Documentation
NA

## Testing
NA
