### PR TITLE
[MINOR UPDATE] Fix default auth mode in AuthMode.parseOrDefault

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
@@ -82,7 +82,7 @@ public class HttpStoragePluginConfig extends CredentialedStoragePluginConfig {
         normalize(proxyPassword),
         credentialsProvider),
         credentialsProvider == null,
-        AuthMode.parseOrDefault(authMode)
+        AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER)
     );
     this.cacheResults = cacheResults != null && cacheResults;
 

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
@@ -70,7 +70,7 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
     super(
       CredentialProviderUtils.getCredentialsProvider(username, password, credentialsProvider),
       credentialsProvider == null,
-      AuthMode.parseOrDefault(authMode)
+      AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER)
     );
     this.driver = driver;
     this.url = url;

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestDataSource.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestDataSource.java
@@ -55,12 +55,13 @@ public class TestDataSource extends BaseTest {
   @Test
   public void testInitWithoutUserAndPassword() {
     JdbcStorageConfig config = new JdbcStorageConfig(
-      DRIVER, url, null, null, false, false, null, null, AuthMode.SHARED_USER.name(), 1000);
+      DRIVER, url, null, null, false, false, null, null, null, 1000);
     try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config, null)) {
       assertEquals(DRIVER, dataSource.getDriverClassName());
       assertEquals(url, dataSource.getJdbcUrl());
       assertNull(dataSource.getUsername());
       assertNull(dataSource.getPassword());
+      assertEquals(config.getAuthMode(), AuthMode.SHARED_USER);
     }
   }
 

--- a/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
@@ -32,7 +32,8 @@ public abstract class StoragePluginConfig {
   // comparisons; doing so will break the plugin registry.
   protected Boolean enabled;
 
-  protected AuthMode authMode;
+  // The overridable default plugin auth mode is DRILL_PROCESS
+  protected AuthMode authMode = AuthMode.DRILL_PROCESS;
 
   /**
    * Check for enabled status of the plugin
@@ -105,8 +106,8 @@ public abstract class StoragePluginConfig {
      */
     USER_TRANSLATION;
 
-    public static AuthMode parseOrDefault(String authMode) {
-      return !Strings.isNullOrEmpty(authMode) ? AuthMode.valueOf(authMode.toUpperCase()) : DRILL_PROCESS;
+    public static AuthMode parseOrDefault(String authMode, AuthMode defavlt) {
+      return !Strings.isNullOrEmpty(authMode) ? AuthMode.valueOf(authMode.toUpperCase()) : defavlt;
     }
   }
 }


### PR DESCRIPTION
... and test the case of JDBC.

## Description

A utility method for parsing the auth mode enum incorrectly defaults to `DRILL_PROCESS`, even when called by storage plugins that desire a different default.

## Documentation
New user and dev docs for auth modes pending.

## Testing
TestDataSource#testInitWithoutUserAndPassword now checks the default authMode applied when it is missing from the storage config for the case of the JDBC plugin.
