### PR TITLE
DRILL-8207: Fix typo in JDBC config

### DIFF
--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
@@ -91,7 +91,7 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
     this.writerBatchSize = that.writerBatchSize;
   }
 
-  @JsonProperty("userName")
+  @JsonProperty("username")
   public String getUsername() {
     if (!directCredentials) {
       return null;


### PR DESCRIPTION
# [DRILL-8207](https://issues.apache.org/jira/browse/DRILL-8207): Fix Username Typo in JDBC SerDe

## Description
Fixes a Serialization/Deserialization bug in the JDBC plugin

## Documentation
No user facing changes.

## Testing
Ran unit tests