### PR TITLE
DRILL-8207: Fix Username Typo and password @JsonIgnore in JDBC SerDe

### DIFF
--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
@@ -162,7 +162,10 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hash(driver, url, caseInsensitiveTableNames, sourceParameters, credentialsProvider, writable, writerBatchSize);
+    return Objects.hash(
+      driver, url, caseInsensitiveTableNames, sourceParameters,
+      credentialsProvider, writable, writerBatchSize, authMode
+    );
   }
 
   @Override
@@ -180,7 +183,8 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
         Objects.equals(writable, that.writable) &&
         Objects.equals(sourceParameters, that.sourceParameters) &&
         Objects.equals(credentialsProvider, that.credentialsProvider) &&
-        Objects.equals(writerBatchSize, that.writerBatchSize);
+        Objects.equals(writerBatchSize, that.writerBatchSize) &&
+        Objects.equals(authMode, that.authMode);
   }
 
   @Override
@@ -193,6 +197,7 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
       .field("sourceParameters", sourceParameters)
       .field("caseInsensitiveTableNames", caseInsensitiveTableNames)
       .field("credentialProvider", credentialsProvider)
+      .field("authMode", authMode)
       .toString();
   }
 }

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
@@ -101,7 +101,6 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
       .orElse(null);
   }
 
-  @JsonIgnore
   @JsonProperty("password")
   public String getPassword() {
     if (!directCredentials) {

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStorageConfig.java
@@ -51,7 +51,7 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
   private final String driver;
   private final String url;
   private final boolean caseInsensitiveTableNames;
-  private final Boolean writable;
+  private final boolean writable;
   private final Map<String, Object> sourceParameters;
   private final int writerBatchSize;
 
@@ -62,7 +62,7 @@ public class JdbcStorageConfig extends CredentialedStoragePluginConfig {
       @JsonProperty("username") String username,
       @JsonProperty("password") String password,
       @JsonProperty("caseInsensitiveTableNames") boolean caseInsensitiveTableNames,
-      @JsonProperty("writable") Boolean writable,
+      @JsonProperty("writable") boolean writable,
       @JsonProperty("sourceParameters") Map<String, Object> sourceParameters,
       @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider,
       @JsonProperty("authMode") String authMode,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/CredentialProviderUtils.java
@@ -35,13 +35,14 @@ public class CredentialProviderUtils {
     if (credentialsProvider != null) {
       return credentialsProvider;
     }
-    if (username == null) {
-      return PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER;
-    }
 
     ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
-    mapBuilder.put(UsernamePasswordCredentials.USERNAME, username);
-    mapBuilder.put(UsernamePasswordCredentials.PASSWORD, password);
+    if (username != null) {
+      mapBuilder.put(UsernamePasswordCredentials.USERNAME, username);
+    }
+    if (password != null) {
+      mapBuilder.put(UsernamePasswordCredentials.PASSWORD, password);
+    }
     return new PlainCredentialsProvider(mapBuilder.build());
   }
 


### PR DESCRIPTION
# [DRILL-8207](https://issues.apache.org/jira/browse/DRILL-8207): Fix Username Typo and password @JsonIgnore in JDBC SerDe

## Description

This second PR reverts three regressions.

1. Remove the @JsonIgnore annotation from `JsonIgnore::getPassword()`, solving a Jackson deserialisation error affecting that class.
2. Revert the type change of the `writable` property to Boolean in JdbcStorageConfig.
3. Revert null handling logic in `CredentialProviderUtils::getCredentialsProvider`.


## Documentation
N/A

## Testing
Unit tests, manually start Drill with template storage configs. Edit `rdbms` so that it holds a valid pg database config, run a query against pg, individually add and remove the username and password direct credentials from the storage config. Test info schema queries when the `writable` property is both absent and present from an enabled JDBC config.
