### PR TITLE
DRILL-8208: Create builder for SqlSelect

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlSelectBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlSelectBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+public class SqlSelectBuilder {
+  private SqlParserPos parserPosition;
+  private SqlNodeList keywordList;
+  private SqlNodeList selectList;
+  private SqlNode from;
+  private SqlNode where;
+  private SqlNodeList groupBy;
+  private SqlNode having;
+  private SqlNodeList windowDecls;
+  private SqlNodeList orderBy;
+  private SqlNode offset;
+  private SqlNode fetch;
+
+  public SqlSelectBuilder parserPosition(SqlParserPos parserPosition) {
+    this.parserPosition = parserPosition;
+    return this;
+  }
+
+  public SqlSelectBuilder keywordList(SqlNodeList keywordList) {
+    this.keywordList = keywordList;
+    return this;
+  }
+
+  public SqlSelectBuilder selectList(SqlNodeList selectList) {
+    this.selectList = selectList;
+    return this;
+  }
+
+  public SqlSelectBuilder from(SqlNode from) {
+    this.from = from;
+    return this;
+  }
+
+  public SqlSelectBuilder where(SqlNode where) {
+    this.where = where;
+    return this;
+  }
+
+  public SqlSelectBuilder groupBy(SqlNodeList groupBy) {
+    this.groupBy = groupBy;
+    return this;
+  }
+
+  public SqlSelectBuilder having(SqlNode having) {
+    this.having = having;
+    return this;
+  }
+
+  public SqlSelectBuilder windowDecls(SqlNodeList windowDecls) {
+    this.windowDecls = windowDecls;
+    return this;
+  }
+
+  public SqlSelectBuilder orderBy(SqlNodeList orderBy) {
+    this.orderBy = orderBy;
+    return this;
+  }
+
+  public SqlSelectBuilder offset(SqlNode offset) {
+    this.offset = offset;
+    return this;
+  }
+
+  public SqlSelectBuilder fetch(SqlNode fetch) {
+    this.fetch = fetch;
+    return this;
+  }
+
+  public SqlSelect build() {
+    return new SqlSelect(parserPosition, keywordList, selectList, from, where, groupBy, having, windowDecls, orderBy, offset, fetch);
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
@@ -42,6 +42,7 @@ import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.planner.logical.DrillWriterRel;
 import org.apache.drill.exec.planner.physical.Prel;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.parser.SqlAnalyzeTable;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
@@ -70,19 +71,12 @@ public class AnalyzeTableHandler extends DefaultSqlHandler {
     verifyNoUnsupportedFunctions(sqlAnalyzeTable);
 
     SqlNode tableRef = sqlAnalyzeTable.getTableRef();
-    SqlSelect scanSql = new SqlSelect(
-        SqlParserPos.ZERO,              /* position */
-        SqlNodeList.EMPTY,              /* keyword list */
-        getColumnList(sqlAnalyzeTable), /* select list */
-        tableRef,                       /* from */
-        null,                           /* where */
-        null,                           /* group by */
-        null,                           /* having */
-        null,                           /* windowDecls */
-        null,                           /* orderBy */
-        null,                           /* offset */
-        null                            /* fetch */
-    );
+    SqlSelect scanSql = new SqlSelectBuilder()
+      .parserPosition(SqlParserPos.ZERO)
+      .keywordList(SqlNodeList.EMPTY)
+      .selectList(getColumnList(sqlAnalyzeTable))
+      .from(tableRef)
+      .build();
 
     ConvertedRelNode convertedRelNode = validateAndConvert(rewrite(scanSql));
     RelDataType validatedRowType = convertedRelNode.getValidatedRowType();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
@@ -34,7 +34,6 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.tools.RelConversionException;
@@ -44,6 +43,7 @@ import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.conversion.SqlConverter;
 import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
 import org.apache.drill.exec.planner.sql.parser.DrillSqlDescribeTable;
@@ -141,8 +141,12 @@ public class DescribeTableHandler extends DefaultSqlHandler {
 
       where = DrillParserUtil.createCondition(where, SqlStdOperatorTable.AND, columnFilter);
 
-      return new SqlSelect(SqlParserPos.ZERO, null, new SqlNodeList(selectList, SqlParserPos.ZERO),
-          fromClause, where, null, null, null, null, null, null);
+      return new SqlSelectBuilder()
+        .parserPosition(SqlParserPos.ZERO)
+        .selectList(new SqlNodeList(selectList, SqlParserPos.ZERO))
+        .from(fromClause)
+        .where(where)
+        .build();
     } catch (Exception ex) {
       throw UserException.planError(ex)
           .message("Error while rewriting DESCRIBE query: %d", ex.getMessage())

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowSchemasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowSchemasHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.util.NlsString;
+import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
 import org.apache.drill.exec.planner.sql.parser.SqlShowSchemas;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.IS_SCHEMA_NAME;
@@ -33,7 +34,6 @@ import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -67,7 +67,11 @@ public class ShowSchemasHandler extends DefaultSqlHandler {
       where = node.getWhereClause();
     }
 
-    return new SqlSelect(SqlParserPos.ZERO, null, new SqlNodeList(selectList, SqlParserPos.ZERO),
-        fromClause, where, null, null, null, null, null, null);
+    return new SqlSelectBuilder()
+      .parserPosition(SqlParserPos.ZERO)
+      .selectList(new SqlNodeList(selectList, SqlParserPos.ZERO))
+      .from(fromClause)
+      .where(where)
+      .build();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.tools.RelConversionException;
@@ -35,6 +34,7 @@ import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
 import org.apache.drill.exec.planner.sql.parser.SqlShowTables;
 import org.apache.drill.exec.store.AbstractSchema;
@@ -110,8 +110,12 @@ public class ShowTablesHandler extends DefaultSqlHandler {
 
     where = DrillParserUtil.createCondition(where, SqlStdOperatorTable.AND, filter);
 
-    return new SqlSelect(SqlParserPos.ZERO, null, new SqlNodeList(selectList, SqlParserPos.ZERO),
-        fromClause, where, null, null, null, null, null, null);
+    return new SqlSelectBuilder()
+      .parserPosition(SqlParserPos.ZERO)
+      .selectList(new SqlNodeList(selectList, SqlParserPos.ZERO))
+      .from(fromClause)
+      .where(where)
+      .build();
   }
 
   /**


### PR DESCRIPTION
# [DRILL-8208](https://issues.apache.org/jira/browse/DRILL-8208): Create builder for SqlSelect

## Description
The newer Calcite version adds more fields to the constructor of SqlSelect. In most cases, nulls are passed for these new arguments. Using builder will reduce the number of places where it should be added.

## Documentation
NA

## Testing
Unit tests pass
