### PR TITLE
DRILL-8211: Replace deprecated RelNode.getChildExps with Project.getProjects

### DIFF
--- a/contrib/storage-elasticsearch/src/main/java/org/apache/drill/exec/store/elasticsearch/plan/ElasticsearchProjectRule.java
+++ b/contrib/storage-elasticsearch/src/main/java/org/apache/drill/exec/store/elasticsearch/plan/ElasticsearchProjectRule.java
@@ -65,7 +65,7 @@ public class ElasticsearchProjectRule extends ConverterRule {
 
     // check for literals only without input exprs
     DrillRelOptUtil.InputRefVisitor collectRefs = new DrillRelOptUtil.InputRefVisitor();
-    project.getChildExps().forEach(exp -> exp.accept(collectRefs));
+    project.getProjects().forEach(exp -> exp.accept(collectRefs));
 
     if (!collectRefs.getInputRefs().isEmpty()) {
       for (RelDataTypeField relDataTypeField : rowType.getFieldList()) {
@@ -73,7 +73,7 @@ public class ElasticsearchProjectRule extends ConverterRule {
       }
     }
 
-    boolean allExprsInputRefs = project.getChildExps().stream().allMatch(rexNode -> rexNode instanceof RexInputRef);
+    boolean allExprsInputRefs = project.getProjects().stream().allMatch(rexNode -> rexNode instanceof RexInputRef);
     if (collectRefs.getInputRefs().isEmpty() || allExprsInputRefs) {
       return CalciteUtils.createProject(traitSet,
           convert(project.getInput(), out), project.getProjects(), project.getRowType());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
@@ -444,12 +444,12 @@ public abstract class DrillRelOptUtil {
     }
   }
 
-  @SuppressWarnings("deprecation")
-  public static boolean isProjectFlatten(RelNode project) {
+  public static boolean isProjectFlatten(RelNode relNode) {
 
-    assert project instanceof Project : "Rel is NOT an instance of project!";
+    assert relNode instanceof Project : "Rel is NOT an instance of Project";
 
-    for (RexNode rex : project.getChildExps()) {
+    Project project = (Project) relNode;
+    for (RexNode rex : project.getProjects()) {
       if (rex instanceof RexCall) {
         RexCall function = (RexCall) rex;
         String functionName = function.getOperator().getName();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillFilterItemStarReWriterRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillFilterItemStarReWriterRule.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.drill.exec.planner.logical.FieldsReWriterUtil.DesiredField;
 import static org.apache.drill.exec.planner.logical.FieldsReWriterUtil.FieldsReWriter;
@@ -99,10 +100,9 @@ public class DrillFilterItemStarReWriterRule {
       // re-write projects
       Map<RexNode, Integer> fieldMapper = createFieldMapper(itemStarFields.values(), scanRel.getRowType().getFieldCount());
       FieldsReWriter fieldsReWriter = new FieldsReWriter(fieldMapper);
-      List<RexNode> newProjects = new ArrayList<>();
-      for (RexNode node : projectRel.getChildExps()) {
-        newProjects.add(node.accept(fieldsReWriter));
-      }
+      List<RexNode> newProjects = projectRel.getProjects().stream()
+        .map(node -> node.accept(fieldsReWriter))
+        .collect(Collectors.toList());
 
       DrillProjectRel newProject = new DrillProjectRel(
           projectRel.getCluster(),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillMergeProjectRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillMergeProjectRule.java
@@ -46,7 +46,7 @@ import java.util.List;
  */
 public class DrillMergeProjectRule extends RelOptRule {
 
-  private FunctionImplementationRegistry functionRegistry;
+  private final FunctionImplementationRegistry functionRegistry;
   private final boolean force;
 
   public static DrillMergeProjectRule getInstance(boolean force, ProjectFactory pFactory,
@@ -71,15 +71,11 @@ public class DrillMergeProjectRule extends RelOptRule {
     Project bottomProject = call.rel(1);
 
     // We have a complex output type do not fire the merge project rule
-    if (checkComplexOutput(topProject) || checkComplexOutput(bottomProject)) {
-      return false;
-    }
-
-    return true;
+    return !checkComplexOutput(topProject) && !checkComplexOutput(bottomProject);
   }
 
   private boolean checkComplexOutput(Project project) {
-    for (RexNode expr: project.getChildExps()) {
+    for (RexNode expr: project.getProjects()) {
       if (expr instanceof RexCall) {
         if (functionRegistry.isFunctionComplexOutput(((RexCall) expr).getOperator().getName())) {
           return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillProjectPushIntoLateralJoinRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillProjectPushIntoLateralJoinRule.java
@@ -54,7 +54,7 @@ public class DrillProjectPushIntoLateralJoinRule extends RelOptRule {
       return;
     }
     DrillRelOptUtil.InputRefVisitor collectRefs = new DrillRelOptUtil.InputRefVisitor();
-    for (RexNode exp: origProj.getChildExps()) {
+    for (RexNode exp: origProj.getProjects()) {
       exp.accept(collectRefs);
     }
 
@@ -78,7 +78,7 @@ public class DrillProjectPushIntoLateralJoinRule extends RelOptRule {
 
     if (!trivial) {
       Map<Integer, Integer> mapWithoutCorr = buildMapWithoutCorrColumn(corr, correlationIndex);
-      List<RexNode> outputExprs = DrillRelOptUtil.transformExprs(origProj.getCluster().getRexBuilder(), origProj.getChildExps(), mapWithoutCorr);
+      List<RexNode> outputExprs = DrillRelOptUtil.transformExprs(origProj.getCluster().getRexBuilder(), origProj.getProjects(), mapWithoutCorr);
 
       relNode = new DrillProjectRel(origProj.getCluster(),
                                     left.getTraitSet().plus(DrillRel.DRILL_LOGICAL),
@@ -89,11 +89,9 @@ public class DrillProjectPushIntoLateralJoinRule extends RelOptRule {
 
   private Map<Integer, Integer> buildMapWithoutCorrColumn(RelNode corr, int correlationIndex) {
     int index = 0;
-    Map<Integer, Integer> result = new HashMap();
-    for (int i=0;i<corr.getRowType().getFieldList().size();i++) {
-      if (i == correlationIndex) {
-        continue;
-      } else {
+    Map<Integer, Integer> result = new HashMap<>();
+    for (int i = 0; i < corr.getRowType().getFieldList().size(); i++) {
+      if (i != correlationIndex) {
         result.put(i, index++);
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
@@ -36,8 +36,8 @@ import org.apache.drill.exec.planner.physical.ScanPrel;
 import org.apache.drill.exec.util.Utilities;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * When table support project push down, rule can be applied to reduce number of read columns
@@ -110,10 +110,9 @@ public class DrillPushProjectIntoScanRule extends RelOptRule {
 
       TableScan newScan = createScan(scan, projectPushInfo);
 
-      List<RexNode> newProjects = new ArrayList<>();
-      for (RexNode n : project.getChildExps()) {
-        newProjects.add(n.accept(projectPushInfo.getInputReWriter()));
-      }
+      List<RexNode> newProjects = project.getProjects().stream()
+        .map(n -> n.accept(projectPushInfo.getInputReWriter()))
+        .collect(Collectors.toList());
 
       Project newProject =
           createProject(project, newScan, newProjects);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushRowKeyJoinToScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushRowKeyJoinToScanRule.java
@@ -463,8 +463,9 @@ public class DrillPushRowKeyJoinToScanRule extends RelOptRule {
       }
       // If no exprs present in projection the column index remains the same in the child.
       // Otherwise, the column index is the `RexInputRef` index.
-      if (curRel != null && curRel instanceof DrillProjectRel) {
-        List<RexNode> childExprs = curRel.getChildExps();
+      if (curRel instanceof DrillProjectRel) {
+        DrillProjectRel projectRel = (DrillProjectRel) curRel;
+        List<RexNode> childExprs = projectRel.getProjects();
         if (childExprs != null && childExprs.size() > 0) {
           if (childExprs.get(curIndex) instanceof RexInputRef) {
             curIndex = ((RexInputRef) childExprs.get(curIndex)).getIndex();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/PreProcessLogicalRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/PreProcessLogicalRel.java
@@ -58,9 +58,9 @@ public class PreProcessLogicalRel extends RelShuttleImpl {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PreProcessLogicalRel.class);
 
-  private RelDataTypeFactory factory;
-  private DrillOperatorTable table;
-  private UnsupportedOperatorCollector unsupportedOperatorCollector;
+  private final RelDataTypeFactory factory;
+  private final DrillOperatorTable table;
+  private final UnsupportedOperatorCollector unsupportedOperatorCollector;
   private final UnwrappingExpressionVisitor unwrappingExpressionVisitor;
 
   public static PreProcessLogicalRel createVisitor(RelDataTypeFactory factory, DrillOperatorTable table, RexBuilder rexBuilder) {
@@ -78,7 +78,7 @@ public class PreProcessLogicalRel extends RelShuttleImpl {
   @Override
   public RelNode visit(LogicalProject project) {
     final List<RexNode> projExpr = Lists.newArrayList();
-    for(RexNode rexNode : project.getChildExps()) {
+    for(RexNode rexNode : project.getProjects()) {
       projExpr.add(rexNode.accept(unwrappingExpressionVisitor));
     }
 
@@ -90,7 +90,7 @@ public class PreProcessLogicalRel extends RelShuttleImpl {
     List<RexNode> exprList = new ArrayList<>();
     boolean rewrite = false;
 
-    for (RexNode rex : project.getChildExps()) {
+    for (RexNode rex : project.getProjects()) {
       RexNode newExpr = rex;
       if (rex instanceof RexCall) {
         RexCall function = (RexCall) rex;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
@@ -28,7 +28,6 @@ import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.util.Pair;
@@ -209,7 +208,6 @@ class NumberingRelWriter implements RelWriter {
     return this;
   }
 
-  @SuppressWarnings("deprecation")
   public RelWriter done(RelNode node) {
     int i = 0;
     if (values.size() > 0 && values.get(0).left.equals("subset")) {
@@ -219,11 +217,7 @@ class NumberingRelWriter implements RelWriter {
       assert values.get(i).right == input;
       ++i;
     }
-    for (RexNode expr : node.getChildExps()) {
-      assert values.get(i).right == expr;
-      ++i;
-    }
-    final List<Pair<String, Object>> valuesCopy =
+    List<Pair<String, Object>> valuesCopy =
         ImmutableList.copyOf(values);
     values.clear();
     explain_(node, valuesCopy);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RewriteProjectToFlatten.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RewriteProjectToFlatten.java
@@ -70,7 +70,7 @@ public class RewriteProjectToFlatten extends BasePrelVisitor<Prel, Object, RelCo
     List<RelDataTypeField> relDataTypes = new ArrayList<>();
     int i = 0;
     RexNode flatttenExpr = null;
-    for (RexNode rex : project.getChildExps()) {
+    for (RexNode rex : project.getProjects()) {
       RexNode newExpr = rex;
       if (rex instanceof RexCall) {
         RexCall function = (RexCall) rex;
@@ -99,7 +99,7 @@ public class RewriteProjectToFlatten extends BasePrelVisitor<Prel, Object, RelCo
     }
 
     Prel child = ((Prel)project.getInput()).accept(this, null);
-    if (child == project.getInput() && exprList.equals(project.getChildExps())) {
+    if (child == project.getInput() && exprList.equals(project.getProjects())) {
       return project;
     }
     return (Prel) project.copy(project.getTraitSet(), child, exprList, new RelRecordType(relDataTypes));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
@@ -87,7 +87,7 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
     final int lastRexInput = lastColumnReferenced + 1;
     RexVisitorComplexExprSplitter exprSplitter = new RexVisitorComplexExprSplitter(funcReg, rexBuilder, lastRexInput);
     int i = 0;
-    for (RexNode rex : newProject.getChildExps()) {
+    for (RexNode rex : newProject.getProjects()) {
       RelDataTypeField originField = projectFields.get(i++);
       RexNode splitRex = rex.accept(exprSplitter);
       origRelDataTypes.add(originField);
@@ -95,7 +95,7 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
     }
 
     final List<RexNode> complexExprs = exprSplitter.getComplexExprs();
-    if (complexExprs.size() == 1 && findTopComplexFunc(newProject.getChildExps()).size() == 1) {
+    if (complexExprs.size() == 1 && findTopComplexFunc(newProject.getProjects()).size() == 1) {
       return newProject;
     }
 
@@ -132,8 +132,7 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
         relDataTypes.add(new RelDataTypeFieldImpl(getExprName(exprIndex), allExprs.size(), factory.createSqlType(SqlTypeName.ANY)));
 
         RelRecordType childProjectType = new RelRecordType(relDataTypes);
-        ProjectPrel childProject  = new ProjectPrel(newProject.getCluster(), newProject.getTraitSet(), newInput, ImmutableList.copyOf(allExprs), childProjectType);
-        newInput = childProject;
+        newInput = new ProjectPrel(newProject.getCluster(), newProject.getTraitSet(), newInput, ImmutableList.copyOf(allExprs), childProjectType);
       }
 
       allExprs.set(allExprs.size() - 1,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ComplexUnnestVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ComplexUnnestVisitor.java
@@ -118,7 +118,7 @@ public class ComplexUnnestVisitor extends RelShuttleImpl {
 
     Project project = (Project) uncollect.getInput();
     // If project below uncollect contains only field references, no need to rewrite it
-    List<RexNode> projectChildExps = project.getChildExps();
+    List<RexNode> projectChildExps = project.getProjects();
     assert projectChildExps.size() == 1 : "Uncollect does not support multiple expressions";
 
     RexNode projectExpr = projectChildExps.iterator().next();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcRuleBase.java
@@ -78,7 +78,7 @@ public abstract class DrillJdbcRuleBase extends ConverterRule {
       try {
 
         final LogicalProject project = call.rel(0);
-        for (RexNode node : project.getChildExps()) {
+        for (RexNode node : project.getProjects()) {
           if (!checkedExpressions.get(node)) {
             return false;
           }
@@ -108,15 +108,8 @@ public abstract class DrillJdbcRuleBase extends ConverterRule {
     @Override
     public boolean matches(RelOptRuleCall call) {
       try {
-
-        final LogicalFilter filter = call.rel(0);
-        for (RexNode node : filter.getChildExps()) {
-          if (!checkedExpressions.get(node)) {
-            return false;
-          }
-        }
-        return true;
-
+        LogicalFilter filter = call.rel(0);
+        return checkedExpressions.get(filter.getCondition());
       } catch (ExecutionException e) {
         throw new IllegalStateException("Failure while trying to evaluate push down.", e);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginProjectRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/plan/rule/PluginProjectRule.java
@@ -71,7 +71,7 @@ public class PluginProjectRule extends PluginConverterRule {
       return null;
     }
 
-    List<RexNode> newProjects = project.getChildExps().stream()
+    List<RexNode> newProjects = project.getProjects().stream()
       .map(n -> n.accept(projectPushInfo.getInputReWriter()))
       .collect(Collectors.toList());
 


### PR DESCRIPTION
# [DRILL-8211](https://issues.apache.org/jira/browse/DRILL-8211): Replace deprecated RelNode.getChildExps with Project.getProjects

## Description
In the newer Calcite version `RelNode.getChildExps` was removed, so replacing it with `Project.getProjects`

## Documentation
NA

## Testing
Unit tests pass.
