### PR TITLE
DRILL-8212: Join queries fail with StackOverflowError

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillRelMdSelectivity.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillRelMdSelectivity.java
@@ -372,7 +372,7 @@ public class DrillRelMdSelectivity extends RelMdSelectivity {
     int[] adjustments = new int[rel.getRowType().getFieldCount()];
 
     if (DrillRelOptUtil.guessRows(rel)) {
-      return super.getSelectivity(rel, mq, predicate);
+      return RelMdUtil.guessSelectivity(predicate);
     }
 
     if (predicate != null) {


### PR DESCRIPTION
# [DRILL-8212](https://issues.apache.org/jira/browse/DRILL-8212): Join queries fail with StackOverflowError

## Description
With the newer Calcite version, some join queries fail with StackOverflowError. In the new version, Calcite uses selectivity code for computing cost for some conditions.

## Documentation
NA

## Testing
Unit tests that were failing pass
