### PR TITLE
DRILL-8213: Replace deprecated RelNode.getRows with RelNode.estimateRowCount

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillRelMdRowCount.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillRelMdRowCount.java
@@ -87,7 +87,7 @@ public class DrillRelMdRowCount extends RelMdRowCount{
   @Override
   public Double getRowCount(Filter rel, RelMetadataQuery mq) {
     // Need capped selectivity estimates. See the Filter getRows() method
-    return rel.getRows();
+    return rel.estimateRowCount(mq);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/generators/IndexIntersectPlanGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/generators/IndexIntersectPlanGenerator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner.index.generators;
 
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
@@ -204,10 +205,11 @@ public class IndexIntersectPlanGenerator extends AbstractIndexPlanGenerator {
         indexFilterPrel, indexProjectExprs, indexProjectRowType);
 
     RelTraitSet rightSideTraits = newTraitSet().plus(Prel.DRILL_PHYSICAL);
+    RelMetadataQuery mq = indexProjectPrel.getCluster().getMetadataQuery();
     // if build(right) side does not exist, this index scan is the right most.
     if (right == null) {
       if (partition == DrillDistributionTrait.RANDOM_DISTRIBUTED &&
-          settings.getSliceTarget() < indexProjectPrel.getRows()) {
+          settings.getSliceTarget() < indexProjectPrel.estimateRowCount(mq)) {
         final DrillDistributionTrait distRight =
             new DrillDistributionTrait(DistributionType.BROADCAST_DISTRIBUTED);
         rightSideTraits = newTraitSet(distRight).plus(Prel.DRILL_PHYSICAL);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/RangePartitionExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/RangePartitionExchangePrel.java
@@ -63,7 +63,7 @@ public class RangePartitionExchangePrel extends ExchangePrel {
   @Override
   public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
     if (PrelUtil.getSettings(getCluster()).useDefaultCosting()) {
-      return super.computeSelfCost(planner).multiplyBy(.1);
+      return super.computeSelfCost(planner, mq).multiplyBy(.1);
     }
     RelNode child = this.getInput();
     double inputRows = (mq == null)? ROWCOUNT_UNKNOWN : mq.getRowCount(child);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/RowKeyJoinPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/RowKeyJoinPrel.java
@@ -42,7 +42,7 @@ public class RowKeyJoinPrel extends JoinPrel implements Prel {
 
   double estimatedRowCount = -1;
   public RowKeyJoinPrel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right,
-      RexNode condition, JoinRelType joinType) throws InvalidRelException {
+      RexNode condition, JoinRelType joinType) {
     super(cluster, traits, left, right, condition, joinType);
     Preconditions.checkArgument(joinType == JoinRelType.INNER);
   }
@@ -66,7 +66,7 @@ public class RowKeyJoinPrel extends JoinPrel implements Prel {
     if (estimatedRowCount >= 0) {
       return estimatedRowCount;
     }
-    return this.getLeft().getRows();
+    return getLeft().estimateRowCount(mq);
   }
 
   @Override
@@ -85,7 +85,7 @@ public class RowKeyJoinPrel extends JoinPrel implements Prel {
   @Override
   public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
     if(PrelUtil.getSettings(getCluster()).useDefaultCosting()) {
-      return super.computeSelfCost(planner).multiplyBy(.1);
+      return super.computeSelfCost(planner, mq).multiplyBy(.1);
     }
     double rowCount = mq.getRowCount(this.getRight());
     DrillCostFactory costFactory = (DrillCostFactory) planner.getCostFactory();


### PR DESCRIPTION
# [DRILL-8213](https://issues.apache.org/jira/browse/DRILL-8213): Replace deprecated RelNode.getRows with RelNode.estimateRowCount

## Description
In the newer Calcite version RelNode.getRows was removed, so replacing its usage with RelNode.estimateRowCount

## Documentation
NA

## Testing
Unit tests pass
