### PR TITLE
DRILL-8214: Replace EnumerableTableScan usage with LogicalTableScan

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -346,6 +346,7 @@ public enum PlannerPhase {
       // Due to infinite loop in planning (DRILL-3257/CALCITE-1271), temporarily use this rule in Hep planner
       // RuleInstance.PROJECT_SET_OP_TRANSPOSE_RULE,
       RuleInstance.PROJECT_WINDOW_TRANSPOSE_RULE,
+      DrillPushProjectIntoScanRule.LOGICAL_INSTANCE,
       DrillPushProjectIntoScanRule.INSTANCE,
       DrillPushProjectIntoScanRule.DRILL_LOGICAL_INSTANCE,
 
@@ -353,7 +354,8 @@ public enum PlannerPhase {
        Convert from Calcite Logical to Drill Logical Rules.
        */
       RuleInstance.EXPAND_CONVERSION_RULE,
-      DrillScanRule.INSTANCE,
+      DrillScanRule.LOGICAL_TABLE_SCAN_TO_DRILL,
+      DrillScanRule.DIR_PRUNED_TABLE_SCAN_TO_DRILL,
       DrillFilterRule.INSTANCE,
       DrillProjectRule.INSTANCE,
       DrillWindowRule.INSTANCE,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
@@ -17,13 +17,13 @@
  */
 package org.apache.drill.exec.planner.logical;
 
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
@@ -46,15 +46,27 @@ import java.util.List;
 public class DrillPushProjectIntoScanRule extends RelOptRule {
   public static final RelOptRule INSTANCE =
       new DrillPushProjectIntoScanRule(LogicalProject.class,
-          EnumerableTableScan.class,
+          DirPrunedTableScan.class,
           "DrillPushProjectIntoScanRule:enumerable") {
 
         @Override
         protected boolean skipScanConversion(RelDataType projectRelDataType, TableScan scan) {
-          // do not allow skipping conversion of EnumerableTableScan to DrillScanRel if rule is applicable
+          // do not allow skipping conversion of DirPrunedTableScan to DrillScanRel if rule is applicable
           return false;
         }
       };
+
+  public static final RelOptRule LOGICAL_INSTANCE =
+    new DrillPushProjectIntoScanRule(LogicalProject.class,
+      LogicalTableScan.class,
+      "DrillPushProjectIntoScanRule:none") {
+
+      @Override
+      protected boolean skipScanConversion(RelDataType projectRelDataType, TableScan scan) {
+        // do not allow skipping conversion of EnumerableTableScan to DrillScanRel if rule is applicable
+        return false;
+      }
+    };
 
   public static final RelOptRule DRILL_LOGICAL_INSTANCE =
       new DrillPushProjectIntoScanRule(LogicalProject.class,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjectIntoScanRule.java
@@ -63,7 +63,7 @@ public class DrillPushProjectIntoScanRule extends RelOptRule {
 
       @Override
       protected boolean skipScanConversion(RelDataType projectRelDataType, TableScan scan) {
-        // do not allow skipping conversion of EnumerableTableScan to DrillScanRel if rule is applicable
+        // do not allow skipping conversion of LogicalTableScan to DrillScanRel if rule is applicable
         return false;
       }
     };

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillScanRule.java
@@ -17,24 +17,25 @@
  */
 package org.apache.drill.exec.planner.logical;
 
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
-
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
 
 public class DrillScanRule  extends RelOptRule {
-  public static final RelOptRule INSTANCE = new DrillScanRule();
+  public static final RelOptRule LOGICAL_TABLE_SCAN_TO_DRILL = new DrillScanRule(LogicalTableScan.class);
+  public static final RelOptRule DIR_PRUNED_TABLE_SCAN_TO_DRILL = new DrillScanRule(DirPrunedTableScan.class);
 
-  private DrillScanRule() {
-    super(RelOptHelper.any(EnumerableTableScan.class),
-        DrillRelFactories.LOGICAL_BUILDER, "DrillScanRule");
+  private DrillScanRule(Class<? extends TableScan> scan) {
+    super(RelOptHelper.any(scan),
+        DrillRelFactories.LOGICAL_BUILDER, "DrillScanRule:" + scan.getSimpleName());
   }
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    final EnumerableTableScan access = call.rel(0);
-    final RelTraitSet traits = access.getTraitSet().plus(DrillRel.DRILL_LOGICAL);
+    TableScan access = call.rel(0);
+    RelTraitSet traits = access.getTraitSet().plus(DrillRel.DRILL_LOGICAL);
     call.transformTo(new DrillScanRel(access.getCluster(), traits, access.getTable()));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
@@ -20,14 +20,15 @@ package org.apache.drill.exec.planner.logical;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.drill.common.JSONOptions;
@@ -42,7 +43,7 @@ import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.dfs.FileSelection;
 import org.apache.drill.exec.util.ImpersonationUtil;
 
-public abstract class DrillTable implements Table {
+public abstract class DrillTable implements Table, TranslatableTable {
 
   private final String storageEngineName;
   private final StoragePluginConfig storageEngineConfig;
@@ -165,10 +166,11 @@ public abstract class DrillTable implements Table {
     return Statistics.UNKNOWN;
   }
 
+  @Override
   public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable table) {
     // returns non-drill table scan to allow directory-based partition pruning
     // before table group scan is created
-    return EnumerableTableScan.create(context.getCluster(), table);
+    return LogicalTableScan.create(context.getCluster(), table);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
@@ -26,10 +26,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+import org.apache.drill.exec.planner.logical.DirPrunedTableScan;
 import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
-import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Filter;
@@ -541,7 +542,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
   public abstract PartitionDescriptor getPartitionDescriptor(PlannerSettings settings, TableScan scanRel);
 
   private static boolean isQualifiedDirPruning(final TableScan scan) {
-    if (scan instanceof EnumerableTableScan) {
+    if (supportsScan(scan)) {
       final Object selection = DrillRelOptUtil.getDrillTable(scan).getSelection();
       if (selection instanceof FormatSelection
           && ((FormatSelection)selection).supportsDirPruning()) {
@@ -767,7 +768,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
     }
 
     private static boolean isQualifiedFilePruning(final TableScan scan) {
-      if (scan instanceof EnumerableTableScan) {
+      if (supportsScan(scan)) {
         Object selection = DrillRelOptUtil.getDrillTable(scan).getSelection();
         return selection instanceof FormatSelection;
       } else if (scan instanceof DrillScanRel) {
@@ -777,5 +778,10 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
       }
       return false;
     }
+  }
+
+  private static boolean supportsScan(TableScan scan) {
+    return scan instanceof DirPrunedTableScan
+      || scan instanceof LogicalTableScan;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.planner.sql.handlers;
 
 import org.apache.calcite.schema.Table;
-import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -31,7 +30,6 @@ import org.apache.calcite.sql.validate.SqlUserDefinedTableMacro;
 import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.logical.DrillTable;
-import org.apache.drill.exec.planner.logical.DrillTranslatableTable;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
@@ -92,8 +90,7 @@ public class DrillTableInfo {
         AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
             config.getConverter().getDefaultSchema(), SchemaUtilites.getSchemaPath(tableIdentifier));
 
-        TranslatableTable translatableTable = tableMacro.getTable(config.getConverter().getTypeFactory(), prepareTableMacroOperands(call.operand(0)));
-        DrillTable table = ((DrillTranslatableTable) translatableTable).getDrillTable();
+        DrillTable table = (DrillTable) tableMacro.getTable(config.getConverter().getTypeFactory(), prepareTableMacroOperands(call.operand(0)));
         return new DrillTableInfo(table, drillSchema.getSchemaPath(), Util.last(tableIdentifier.names));
       }
       case IDENTIFIER: {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/WithOptionsTableMacro.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/WithOptionsTableMacro.java
@@ -24,7 +24,6 @@ import org.apache.calcite.schema.TableMacro;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.logical.DrillTable;
-import org.apache.drill.exec.planner.logical.DrillTranslatableTable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,9 +53,7 @@ public class WithOptionsTableMacro implements TableMacro {
         .message("Unable to find table [%s]", sig.getName())
         .build(logger);
     }
-    return drillTable instanceof TranslatableTable
-        ? (TranslatableTable) drillTable :
-        new DrillTranslatableTable(drillTable);
+    return drillTable;
   }
 
   @Override


### PR DESCRIPTION
# [DRILL-8214](https://issues.apache.org/jira/browse/DRILL-8214): Replace EnumerableTableScan usage with LogicalTableScan

## Description
The newer Calcite version returns LogicalTableScan instead of EnumerableTableScan in RelOptTableImpl, so Drill shouldn't rely on this class also and LogicalTableScan where possible to avoid planning issues.

## Documentation
NA

## Testing
Unit tests passing
