### PR TITLE
DRILL-8216: Use EVF-based JSON reader for Values operator

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
@@ -18,17 +18,9 @@
 package org.apache.drill.exec.store.hive;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.drill.common.types.Types;
-import org.apache.drill.exec.planner.sql.TypeInferenceUtils;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.SchemaUtils;
 import org.apache.drill.exec.planner.types.HiveToRelDataTypeConverter;
-import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
-import org.apache.drill.exec.record.metadata.MapColumnMetadata;
-import org.apache.drill.exec.record.metadata.MetadataUtils;
-import org.apache.drill.exec.record.metadata.PrimitiveColumnMetadata;
-import org.apache.drill.exec.record.metadata.TupleMetadata;
-import org.apache.drill.exec.record.metadata.TupleSchema;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import io.netty.buffer.DrillBuf;
@@ -772,81 +764,6 @@ public class HiveUtilities {
   }
 
   /**
-   * Converts specified {@code RelDataType relDataType} into {@link ColumnMetadata}.
-   * For the case when specified relDataType is struct, map with recursively converted children
-   * will be created.
-   *
-   * @param name        filed name
-   * @param relDataType filed type
-   * @return {@link ColumnMetadata} which corresponds to specified {@code RelDataType relDataType}
-   */
-  public static ColumnMetadata getColumnMetadata(String name, RelDataType relDataType) {
-    switch (relDataType.getSqlTypeName()) {
-      case ARRAY:
-        return getArrayMetadata(name, relDataType);
-      case MAP:
-      case OTHER:
-        throw new UnsupportedOperationException(String.format("Unsupported data type: %s", relDataType.getSqlTypeName()));
-      default:
-        if (relDataType.isStruct()) {
-          return getStructMetadata(name, relDataType);
-        } else {
-          return new PrimitiveColumnMetadata(
-              MaterializedField.create(name,
-                  TypeInferenceUtils.getDrillMajorTypeFromCalciteType(relDataType)));
-        }
-    }
-  }
-
-  /**
-   * Returns {@link ColumnMetadata} instance which corresponds to specified array {@code RelDataType relDataType}.
-   *
-   * @param name        name of the filed
-   * @param relDataType the source of type information to construct the schema
-   * @return {@link ColumnMetadata} instance
-   */
-  private static ColumnMetadata getArrayMetadata(String name, RelDataType relDataType) {
-    RelDataType componentType = relDataType.getComponentType();
-    ColumnMetadata childColumnMetadata = getColumnMetadata(name, componentType);
-    switch (componentType.getSqlTypeName()) {
-      case ARRAY:
-        // for the case when nested type is array, it should be placed into repeated list
-        return MetadataUtils.newRepeatedList(name, childColumnMetadata);
-      case MAP:
-      case OTHER:
-        throw new UnsupportedOperationException(String.format("Unsupported data type: %s", relDataType.getSqlTypeName()));
-      default:
-        if (componentType.isStruct()) {
-          // for the case when nested type is struct, it should be placed into repeated map
-          return MetadataUtils.newMapArray(name, childColumnMetadata.tupleSchema());
-        } else {
-          // otherwise creates column metadata with repeated data mode
-          return new PrimitiveColumnMetadata(
-              MaterializedField.create(name,
-                  Types.overrideMode(
-                      TypeInferenceUtils.getDrillMajorTypeFromCalciteType(componentType),
-                      DataMode.REPEATED)));
-        }
-    }
-  }
-
-  /**
-   * Returns {@link MapColumnMetadata} column metadata created based on specified {@code RelDataType relDataType} with
-   * converted to {@link ColumnMetadata} {@code relDataType}'s children.
-   *
-   * @param name        name of the filed
-   * @param relDataType {@link RelDataType} the source of the children for resulting schema
-   * @return {@link MapColumnMetadata} column metadata
-   */
-  private static MapColumnMetadata getStructMetadata(String name, RelDataType relDataType) {
-    TupleMetadata mapSchema = new TupleSchema();
-    for (RelDataTypeField relDataTypeField : relDataType.getFieldList()) {
-      mapSchema.addColumn(getColumnMetadata(relDataTypeField.getName(), relDataTypeField.getType()));
-    }
-    return MetadataUtils.newMap(name, mapSchema);
-  }
-
-  /**
    * Converts specified {@code FieldSchema column} into {@link ColumnMetadata}.
    * For the case when specified relDataType is struct, map with recursively converted children
    * will be created.
@@ -857,7 +774,7 @@ public class HiveUtilities {
    */
   public static ColumnMetadata getColumnMetadata(HiveToRelDataTypeConverter dataTypeConverter, FieldSchema column) {
     RelDataType relDataType = dataTypeConverter.convertToNullableRelDataType(column);
-    return getColumnMetadata(column.getName(), relDataType);
+    return SchemaUtils.getColumnMetadata(column.getName(), relDataType);
   }
 }
 

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcWriterWithH2.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcWriterWithH2.java
@@ -117,13 +117,13 @@ public class TestJdbcWriterWithH2 extends ClusterTest {
       DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
       TupleMetadata expectedSchema = new SchemaBuilder()
-        .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-        .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+        .add("ID", MinorType.INT, DataMode.OPTIONAL)
+        .add("NAME", MinorType.INT, DataMode.OPTIONAL)
         .buildSchema();
 
       RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-        .addRow(1L, 2L)
-        .addRow(3L, 4L)
+        .addRow(1, 2)
+        .addRow(3, 4)
         .build();
 
       RowSetUtilities.verify(expected, results);
@@ -190,13 +190,13 @@ public class TestJdbcWriterWithH2 extends ClusterTest {
       DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
       TupleMetadata expectedSchema = new SchemaBuilder()
-        .add("My id", MinorType.BIGINT, DataMode.OPTIONAL)
-        .add("My name", MinorType.BIGINT, DataMode.OPTIONAL)
+        .add("My id", MinorType.INT, DataMode.OPTIONAL)
+        .add("My name", MinorType.INT, DataMode.OPTIONAL)
         .buildSchema();
 
       RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-        .addRow(1L, 2L)
-        .addRow(3L, 4L)
+        .addRow(1, 2)
+        .addRow(3, 4)
         .build();
 
       RowSetUtilities.verify(expected, results);
@@ -260,13 +260,13 @@ public class TestJdbcWriterWithH2 extends ClusterTest {
       DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
       TupleMetadata expectedSchema = new SchemaBuilder()
-        .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-        .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+        .add("ID", MinorType.INT, DataMode.OPTIONAL)
+        .add("NAME", MinorType.INT, DataMode.OPTIONAL)
         .buildSchema();
 
       RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-        .addRow(1L, 2L)
-        .addRow(3L, 4L)
+        .addRow(1, 2)
+        .addRow(3, 4)
         .build();
 
       RowSetUtilities.verify(expected, results);
@@ -290,13 +290,13 @@ public class TestJdbcWriterWithH2 extends ClusterTest {
       DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
       TupleMetadata expectedSchema = new SchemaBuilder()
-        .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-        .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+        .add("ID", MinorType.INT, DataMode.OPTIONAL)
+        .add("NAME", MinorType.INT, DataMode.OPTIONAL)
         .buildSchema();
 
       RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-        .addRow(1L, 2L)
-        .addRow(3L, 4L)
+        .addRow(1, 2)
+        .addRow(3, 4)
         .build();
 
       RowSetUtilities.verify(expected, results);

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcWriterWithMySQL.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcWriterWithMySQL.java
@@ -145,13 +145,13 @@ public class TestJdbcWriterWithMySQL extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("ID", MinorType.INT, DataMode.OPTIONAL)
+      .add("NAME", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);
@@ -174,13 +174,13 @@ public class TestJdbcWriterWithMySQL extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("ID", MinorType.INT, DataMode.OPTIONAL)
+      .add("NAME", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);
@@ -203,13 +203,13 @@ public class TestJdbcWriterWithMySQL extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("My id", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("My name", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("My id", MinorType.INT, DataMode.OPTIONAL)
+      .add("My name", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);
@@ -379,13 +379,13 @@ public class TestJdbcWriterWithMySQL extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("ID", MinorType.INT, DataMode.OPTIONAL)
+      .add("NAME", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcWriterWithPostgres.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcWriterWithPostgres.java
@@ -143,13 +143,13 @@ public class TestJdbcWriterWithPostgres extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("ID", MinorType.INT, DataMode.OPTIONAL)
+      .add("NAME", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);
@@ -216,13 +216,13 @@ public class TestJdbcWriterWithPostgres extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("ID", MinorType.INT, DataMode.OPTIONAL)
+      .add("NAME", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);
@@ -297,13 +297,13 @@ public class TestJdbcWriterWithPostgres extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("My id", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("My name", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("My id", MinorType.INT, DataMode.OPTIONAL)
+      .add("My name", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);
@@ -366,13 +366,13 @@ public class TestJdbcWriterWithPostgres extends ClusterTest {
     DirectRowSet results = queryBuilder().sql(testQuery).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
-      .add("ID", MinorType.BIGINT, DataMode.OPTIONAL)
-      .add("NAME", MinorType.BIGINT, DataMode.OPTIONAL)
+      .add("ID", MinorType.INT, DataMode.OPTIONAL)
+      .add("NAME", MinorType.INT, DataMode.OPTIONAL)
       .buildSchema();
 
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
-      .addRow(1L, 2L)
-      .addRow(3L, 4L)
+      .addRow(1, 2)
+      .addRow(3, 4)
       .build();
 
     RowSetUtilities.verify(expected, results);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Values.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Values.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.Leaf;
@@ -31,19 +30,30 @@ import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+
 public class Values extends AbstractBase implements Leaf {
 
   public static final String OPERATOR_TYPE = "VALUES";
 
-  private final JSONOptions content;
+  private final String content;
+
+  private final TupleMetadata schema;
 
   @JsonCreator
-  public Values(@JsonProperty("content") JSONOptions content){
+  public Values(
+    @JsonProperty("content") String content,
+    @JsonProperty("schema") TupleMetadata schema) {
     this.content = content;
+    this.schema = schema;
   }
 
-  public JSONOptions getContent(){
+  public String getContent() {
     return content;
+  }
+
+  public TupleMetadata getSchema() {
+    return schema;
   }
 
   @Override
@@ -54,7 +64,7 @@ public class Values extends AbstractBase implements Leaf {
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) throws ExecutionSetupException {
     assert children.isEmpty();
-    return new Values(content);
+    return new Values(content, schema);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/SchemaUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/SchemaUtils.java
@@ -17,11 +17,18 @@
  */
 package org.apache.drill.exec.physical.impl.scan.v3.schema;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.exec.physical.resultSet.project.RequestedColumn;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.planner.sql.TypeInferenceUtils;
+import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.MapColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.PrimitiveColumnMetadata;
 import org.apache.drill.exec.record.metadata.Propertied;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.metadata.TupleSchema;
@@ -96,7 +103,7 @@ public class SchemaUtils {
 
   /**
    * Perform the column-level projection as described in
-   * {@link #isConsistent(RequestedColumn, ColumnMetadata)}, and raise a
+   * {@link #isConsistent(ProjectedColumn, ColumnMetadata)}, and raise a
    * {@code UserException} if the column is not consistent with projection.
    *
    * @param colReq the column-level projection description
@@ -233,5 +240,81 @@ public class SchemaUtils {
     if (value != null) {
       dest.setProperty(ScanProjectionParser.PROJECTION_TYPE_PROP, value);
     }
+  }
+
+  /**
+   * Converts specified {@code RelDataType relDataType} into {@link ColumnMetadata}.
+   * For the case when specified relDataType is struct, map with recursively converted children
+   * will be created.
+   *
+   * @param name        filed name
+   * @param relDataType filed type
+   * @return {@link ColumnMetadata} which corresponds to specified {@code RelDataType relDataType}
+   */
+  public static ColumnMetadata getColumnMetadata(String name, RelDataType relDataType) {
+    switch (relDataType.getSqlTypeName()) {
+      case ARRAY:
+        return getArrayMetadata(name, relDataType);
+      case MAP:
+      case OTHER:
+        throw new UnsupportedOperationException(String.format("Unsupported data type: %s", relDataType.getSqlTypeName()));
+      default:
+        if (relDataType.isStruct()) {
+          return getStructMetadata(name, relDataType);
+        } else {
+          return new PrimitiveColumnMetadata(
+            MaterializedField.create(name,
+              TypeInferenceUtils.getDrillMajorTypeFromCalciteType(relDataType)));
+        }
+    }
+  }
+
+  /**
+   * Returns {@link ColumnMetadata} instance which corresponds to specified array {@code RelDataType relDataType}.
+   *
+   * @param name        name of the filed
+   * @param relDataType the source of type information to construct the schema
+   * @return {@link ColumnMetadata} instance
+   */
+  private static ColumnMetadata getArrayMetadata(String name, RelDataType relDataType) {
+    RelDataType componentType = relDataType.getComponentType();
+    ColumnMetadata childColumnMetadata = getColumnMetadata(name, componentType);
+    switch (componentType.getSqlTypeName()) {
+      case ARRAY:
+        // for the case when nested type is array, it should be placed into repeated list
+        return MetadataUtils.newRepeatedList(name, childColumnMetadata);
+      case MAP:
+      case OTHER:
+        throw new UnsupportedOperationException(String.format("Unsupported data type: %s", relDataType.getSqlTypeName()));
+      default:
+        if (componentType.isStruct()) {
+          // for the case when nested type is struct, it should be placed into repeated map
+          return MetadataUtils.newMapArray(name, childColumnMetadata.tupleSchema());
+        } else {
+          // otherwise creates column metadata with repeated data mode
+          return new PrimitiveColumnMetadata(
+            MaterializedField.create(name,
+              Types.overrideMode(
+                TypeInferenceUtils.getDrillMajorTypeFromCalciteType(componentType),
+                TypeProtos.DataMode.REPEATED)));
+        }
+    }
+  }
+
+  /**
+   * Returns {@link MapColumnMetadata} column metadata created based on specified {@code RelDataType relDataType} with
+   * converted to {@link ColumnMetadata} {@code relDataType}'s children.
+   *
+   * @param name        name of the filed
+   * @param relDataType {@link RelDataType} the source of the children for resulting schema
+   * @return {@link MapColumnMetadata} column metadata
+   */
+  private static MapColumnMetadata getStructMetadata(String name, RelDataType relDataType) {
+    TupleMetadata mapSchema = new TupleSchema();
+    relDataType.getFieldList().stream()
+      .map(field -> getColumnMetadata(field.getName(), field.getType()))
+      .filter(metadata -> metadata.type() != MinorType.LATE)
+      .forEach(mapSchema::addColumn);
+    return MetadataUtils.newMap(name, mapSchema);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/values/ValuesBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/values/ValuesBatchCreator.java
@@ -17,27 +17,57 @@
  */
 package org.apache.drill.exec.physical.impl.values;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
-import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ops.ExecutorFragmentContext;
 import org.apache.drill.exec.physical.config.Values;
 import org.apache.drill.exec.physical.impl.BatchCreator;
-import org.apache.drill.exec.physical.impl.ScanBatch;
+import org.apache.drill.exec.physical.impl.scan.framework.BasicScanFactory;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.RecordBatch;
-import org.apache.drill.exec.store.RecordReader;
-import org.apache.drill.exec.store.easy.json.JSONRecordReader;
+import org.apache.drill.exec.store.easy.json.JsonStreamBatchReader;
 
 public class ValuesBatchCreator implements BatchCreator<Values> {
-  @Override
-  public ScanBatch getBatch(ExecutorFragmentContext context, Values config, List<RecordBatch> children)
-      throws ExecutionSetupException {
-    assert children.isEmpty();
 
-    JSONRecordReader reader = new JSONRecordReader(context, config.getContent().asNode(),
-        null, Collections.singletonList(SchemaPath.STAR_COLUMN));
-    return new ScanBatch(config, context, Collections.singletonList((RecordReader) reader));
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+    Values subScan, List<RecordBatch> children) throws ExecutionSetupException {
+    assert children.isEmpty();
+    try {
+      ManagedScanFramework.ScanFrameworkBuilder builder = createBuilder(subScan);
+      return builder.buildScanOperator(context, subScan);
+    } catch (UserException e) {
+      // Rethrow user exceptions directly
+      throw e;
+    } catch (Throwable e) {
+      // Wrap all others
+      throw new ExecutionSetupException(e);
+    }
+  }
+
+  private ManagedScanFramework.ScanFrameworkBuilder createBuilder(Values subScan) {
+    ManagedScanFramework.ScanFrameworkBuilder builder = new ManagedScanFramework.ScanFrameworkBuilder();
+    builder.setUserName(subScan.getUserName());
+    builder.providedSchema(subScan.getSchema());
+
+    ManagedScanFramework.ReaderFactory readerFactory = new BasicScanFactory(Collections.singletonList(
+      getRecordReader(new ByteArrayInputStream(subScan.getContent().getBytes()))).iterator());
+    builder.setReaderFactory(readerFactory);
+    builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));
+    return builder;
+  }
+
+  private static ManagedReader<SchemaNegotiator> getRecordReader(InputStream source) {
+    return new JsonStreamBatchReader(source);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillValuesRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillValuesRel.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.planner.logical;
 
 import java.util.List;
 
-import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.logical.data.LogicalOperator;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.plan.RelOptCluster;
@@ -39,7 +38,8 @@ public class DrillValuesRel extends DrillValuesRelBase implements DrillRel {
     super(cluster, rowType, tuples, traits);
   }
 
-  public DrillValuesRel(RelOptCluster cluster, RelDataType rowType, List<? extends List<RexLiteral>> tuples, RelTraitSet traits, JSONOptions content) {
+  public DrillValuesRel(RelOptCluster cluster, RelDataType rowType, List<? extends List<RexLiteral>> tuples,
+    RelTraitSet traits, String content) {
     super(cluster, rowType, tuples, traits, content);
   }
 
@@ -52,7 +52,7 @@ public class DrillValuesRel extends DrillValuesRelBase implements DrillRel {
   @Override
   public LogicalOperator implement(DrillImplementor implementor) {
       return Values.builder()
-          .content(content.asNode())
+          .content(content)
           .build();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreAnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreAnalyzeTableHandler.java
@@ -353,7 +353,7 @@ public class MetastoreAnalyzeTableHandler extends DefaultSqlHandler {
     RelNode analyzeRel = useStatistics
         ? new DrillAnalyzeRel(
               convertedRelNode.getCluster(), convertedRelNode.getTraitSet(), convertToRawDrel(relNode), samplePercent)
-        : convertToRawDrel(relBuilder.values(new String[]{""}, "").build());
+        : convertToRawDrel(relBuilder.values(convertedRelNode.getRowType()).build());
 
     MetadataControllerContext metadataControllerContext = MetadataControllerContext.builder()
         .tableInfo(tableInfo)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonStreamBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonStreamBatchReader.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json;
+
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
+import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
+
+import java.io.InputStream;
+
+/**
+ * EVF based JSON reader which uses input stream as data source.
+ */
+public class JsonStreamBatchReader implements ManagedReader<SchemaNegotiator> {
+
+  private JsonLoader jsonLoader;
+  private final InputStream source;
+
+  public JsonStreamBatchReader(InputStream source) {
+    this.source = source;
+  }
+
+  @Override
+  public boolean open(SchemaNegotiator negotiator) {
+
+    CustomErrorContext errorContext = new ChildErrorContext(negotiator.parentErrorContext());
+    negotiator.setErrorContext(errorContext);
+
+    // Create the JSON loader (high-level parser).
+    jsonLoader = new JsonLoaderBuilder()
+        .resultSetLoader(negotiator.build())
+        .standardOptions(negotiator.queryOptions())
+        .providedSchema(negotiator.providedSchema())
+        .errorContext(errorContext)
+        .fromStream(source)
+        .build();
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+    return jsonLoader.readBatch();
+  }
+
+  @Override
+  public void close() {
+    if (jsonLoader != null) {
+      jsonLoader.close();
+      jsonLoader = null;
+    }
+  }
+
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/TestProjectWithFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestProjectWithFunctions.java
@@ -77,7 +77,7 @@ public class TestProjectWithFunctions extends ClusterTest {
             .sqlQuery(sql)
             .unOrdered()
             .baselineColumns("c", "d")
-            .baselineValues(2L, 1L)
+            .baselineValues(2, 1)
             .go();
       }
     } finally {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestValues.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestValues.java
@@ -61,8 +61,8 @@ public class TestValues extends ClusterTest {
         .sqlQuery("select id, name from (values(1, 'A'), (2, 'B')) t(id, name)")
         .unOrdered()
         .baselineColumns("id", "name")
-        .baselineValues(1L, "A")
-        .baselineValues(2L, "B")
+        .baselineValues(1, "A")
+        .baselineValues(2, "B")
         .go();
     } finally {
       client.resetSession(ExecConstants.SLICE_TARGET);

--- a/logical/src/main/java/org/apache/drill/common/logical/data/Values.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/Values.java
@@ -17,29 +17,26 @@
  */
 package org.apache.drill.common.logical.data;
 
-import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.logical.data.visitors.LogicalVisitor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 @JsonTypeName("values")
 public class Values extends SourceOperator {
 
-    private final JSONOptions content;
+    private final String content;
 
     @JsonCreator
-    public Values(@JsonProperty("content") JSONOptions content){
+    public Values(@JsonProperty("content") String content){
         super();
         this.content = content;
         Preconditions.checkNotNull(content, "content attribute is required for source operator 'constant'.");
     }
 
-    public JSONOptions getContent() {
+    public String getContent() {
         return content;
     }
 
@@ -53,10 +50,10 @@ public class Values extends SourceOperator {
     }
 
     public static class Builder extends AbstractBuilder<Values>{
-      private JSONOptions content;
+      private String content;
 
-      public Builder content(JsonNode n){
-        content = new JSONOptions(n, JsonLocation.NA);
+      public Builder content(String content) {
+        this.content = content;
         return this;
       }
 


### PR DESCRIPTION
# [DRILL-8216](https://issues.apache.org/jira/browse/DRILL-8216): Use EVF-based JSON reader for Values operator

## Description
The newer Calcite version simplifies and removes casts for literals. It causes wrong results for `drillTypeOf` and `sqlTypeOf` functions since the Values operator uses an old JSON reader which reads integers with bigInt type.
This PR uses EVF-based JSON reader for the Values operator and passes actual data types discovered during planning as the provided schema.

## Documentation
NA

## Testing
Unit tests pass