### PR TITLE
DRILL-8215: Remove SecurityContext from PluginConfigWrapper

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/CredentialResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/CredentialResources.java
@@ -125,11 +125,18 @@ public class CredentialResources {
       default:
         return Collections.emptyList();
     }
-    return StreamSupport.stream(
+    List<PluginConfigWrapper> results = StreamSupport.stream(
         Spliterators.spliteratorUnknownSize(storage.storedConfigs(filter).entrySet().iterator(), Spliterator.ORDERED), false)
-      .map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue(), sc))
+      .map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue()))
       .sorted(PLUGIN_COMPARATOR)
       .collect(Collectors.toList());
+
+    if (results.isEmpty()) {
+      return Collections.emptyList();
+    } else {
+      return results;
+    }
+
   }
 
   @POST

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
@@ -19,10 +19,8 @@ package org.apache.drill.exec.server.rest;
 
 import java.util.Optional;
 
-import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.drill.common.logical.CredentialedStoragePluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -39,15 +37,12 @@ import org.apache.drill.exec.store.security.oauth.OAuthTokenCredentials;
 public class PluginConfigWrapper {
   private final String name;
   private final StoragePluginConfig config;
-  private final SecurityContext sc;
 
   @JsonCreator
   public PluginConfigWrapper(@JsonProperty("name") String name,
-                             @JsonProperty("config") StoragePluginConfig config,
-                             @JacksonInject SecurityContext sc) {
+                             @JsonProperty("config") StoragePluginConfig config) {
     this.name = name;
     this.config = config;
-    this.sc = sc;
   }
 
   public String getName() { return name; }
@@ -59,34 +54,32 @@ public class PluginConfigWrapper {
   }
 
   @JsonIgnore
-  public String getUserName() {
+  public String getUserName(String activeUser) {
     if (!(config instanceof CredentialedStoragePluginConfig)) {
       return null;
     }
 
     CredentialedStoragePluginConfig securedStoragePluginConfig = (CredentialedStoragePluginConfig) config;
     CredentialsProvider credentialsProvider = securedStoragePluginConfig.getCredentialsProvider();
-    String queryUser = sc.getUserPrincipal().getName();
     Optional<UsernamePasswordCredentials> credentials = new UsernamePasswordCredentials.Builder()
       .setCredentialsProvider(credentialsProvider)
-      .setQueryUser(queryUser)
+      .setQueryUser(activeUser)
       .build();
 
     return credentials.map(UsernamePasswordCredentials::getUsername).orElse(null);
   }
 
   @JsonIgnore
-  public String getPassword() {
+  public String getPassword(String activeUser) {
     if (!(config instanceof CredentialedStoragePluginConfig)) {
       return null;
     }
 
     CredentialedStoragePluginConfig securedStoragePluginConfig = (CredentialedStoragePluginConfig) config;
     CredentialsProvider credentialsProvider = securedStoragePluginConfig.getCredentialsProvider();
-    String queryUser = sc.getUserPrincipal().getName();
     Optional<UsernamePasswordCredentials> credentials = new UsernamePasswordCredentials.Builder()
       .setCredentialsProvider(credentialsProvider)
-      .setQueryUser(queryUser)
+      .setQueryUser(activeUser)
       .build();
 
     return credentials.map(UsernamePasswordCredentials::getPassword).orElse(null);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -163,7 +163,7 @@ public class StorageResources {
   @Operation(externalDocs = @ExternalDocumentation(description = "Apache Drill REST API documentation:", url = "https://drill.apache.org/docs/rest-api-introduction/"))
   public Response getPluginConfig(@PathParam("name") String name) {
     try {
-      return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name), sc))
+      return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
         .build();
     } catch (Exception e) {
       logger.error("Failure while trying to access storage config: {}", name, e);
@@ -389,7 +389,7 @@ public class StorageResources {
         .build();
     }
 
-    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name), sc))
+    return Response.ok(new PluginConfigWrapper(name, storage.getStoredConfig(name)))
       .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format))
       .build();
   }
@@ -511,7 +511,7 @@ public class StorageResources {
     pluginGroup = StringUtils.isNotEmpty(pluginGroup) ? pluginGroup.replace("/", "") : ALL_PLUGINS;
     return StreamSupport.stream(
       Spliterators.spliteratorUnknownSize(storage.storedConfigs(filter).entrySet().iterator(), Spliterator.ORDERED), false)
-        .map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue(), sc))
+        .map(entry -> new PluginConfigWrapper(entry.getKey(), entry.getValue()))
         .sorted(PLUGIN_COMPARATOR)
         .collect(Collectors.toList());
   }
@@ -554,7 +554,7 @@ public class StorageResources {
   }
 
   /**
-   * Model class for Storage Plugin page.
+   * Model class for Storage Plugin and Credentials page.
    * It contains a storage plugin as well as the CSRF token for the page.
    */
   public static class StoragePluginModel {
@@ -577,6 +577,26 @@ public class StorageResources {
 
     public String getActiveUser() {
       return securityContext.getUserPrincipal().getName();
+    }
+
+    public String getUserName() {
+      String username = plugin.getUserName(getActiveUser());
+      if (StringUtils.isEmpty(username)) {
+        return "";
+      }
+      else {
+        return username;
+      }
+    }
+
+    public String getPassword() {
+      String password = plugin.getPassword(getActiveUser());
+      if (StringUtils.isEmpty(password)) {
+        return "";
+      }
+      else {
+        return password;
+      }
     }
 
     public String getType() {

--- a/exec/java-exec/src/main/resources/rest/credentials/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/credentials/list.ftl
@@ -42,17 +42,19 @@
       <table class="table table-hover">
         <tbody>
         <#list model as pluginModel>
+          <#if pluginModel.getPlugin()?? >
           <tr>
             <td style="border:none; max-width: 200px; overflow: hidden; text-overflow: ellipsis;">
                 ${pluginModel.getPlugin().getName()}
             </td>
             <td style="border:none;">
               <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#new-plugin-modal" data-plugin="${pluginModel.getPlugin().getName()}"
-                      data-username="${pluginModel.getPlugin().getUserName()}" data-password="${pluginModel.getPlugin().getPassword()}">
+                      data-username="${pluginModel.getUserName()}" data-password="${pluginModel.getPassword()}">
                 Update Credentials
               </button>
             </td>
           </tr>
+          </#if>
         </#list>
         </tbody>
       </table>


### PR DESCRIPTION
# [DRILL-8215](https://issues.apache.org/jira/browse/DRILL-8215): Remove SecurityContext from PluginConfigWrapper

## Description
DRILL-8155 introduced a small regression in the `PluginConfigWrapper` which caused some serialization/deserialization errors.  This fix removes the `SecurityContext` from that class and as a result, fixes the issue.

This PR also addresses [DRILL-8217](https://issues.apache.org/jira/browse/DRILL-8217) which the page to enter user credentials throws an exception if no plugins are eligible. 

## Documentation
N/A

## Testing
Manually tested.