### PR TITLE
DRILL-8218: Add unit tests for StorageResource REST endpoints

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
@@ -57,7 +57,6 @@ public class StatusResourcesTest extends BaseTest {
       client.alterSystem(MOCK_PROPERTY, "c");
 
       Assert.assertNull(restClientFixture.getStatusOption(MOCK_PROPERTY));
-      option = restClientFixture.getStatusInternalOption(MOCK_PROPERTY);
       Assert.assertEquals("c", option.getValueAsString());
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
@@ -57,6 +57,7 @@ public class StatusResourcesTest extends BaseTest {
       client.alterSystem(MOCK_PROPERTY, "c");
 
       Assert.assertNull(restClientFixture.getStatusOption(MOCK_PROPERTY));
+      option = restClientFixture.getStatusInternalOption(MOCK_PROPERTY);
       Assert.assertEquals("c", option.getValueAsString());
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StorageResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StorageResourcesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest;
+
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.store.mock.MockStorageEngineConfig;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.apache.drill.test.RestClientFixture;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StorageResourcesTest extends ClusterTest {
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
+      .configProperty(ExecConstants.HTTP_ENABLE, true)
+      .configProperty(ExecConstants.HTTP_PORT_HUNT, true);
+
+      startCluster(builder);
+  }
+
+  @Test
+  public void testCreateStorageConfig() throws Exception {
+    try (RestClientFixture restClientFixture = cluster.restClientFixture()) {
+      PluginConfigWrapper pcw = new PluginConfigWrapper(MockStorageEngineConfig.NAME, MockStorageEngineConfig.INSTANCE);
+      restClientFixture.postStorageConfig(pcw);
+      StoragePluginConfig config_server = cluster.storageRegistry().getDefinedConfig(MockStorageEngineConfig.NAME);
+      Assert.assertEquals(MockStorageEngineConfig.INSTANCE, config_server);
+      Assert.assertTrue(config_server.isEnabled());
+    } finally {
+      cluster.storageRegistry().remove(MockStorageEngineConfig.NAME);
+    }
+  }
+
+  @Test
+  public void testEnabledToggle() throws Exception {
+    try (RestClientFixture restClientFixture = cluster.restClientFixture()) {
+      PluginConfigWrapper pcw = new PluginConfigWrapper(MockStorageEngineConfig.NAME, MockStorageEngineConfig.INSTANCE);
+      restClientFixture.postStorageConfig(pcw);
+      restClientFixture.toggleEnabled(MockStorageEngineConfig.NAME, false);
+      StoragePluginConfig config_server = cluster.storageRegistry().getStoredConfig(MockStorageEngineConfig.NAME);
+      Assert.assertEquals(pcw.getConfig(), config_server);
+      Assert.assertFalse(config_server.isEnabled());
+    } finally {
+      cluster.storageRegistry().remove(MockStorageEngineConfig.NAME);
+    }
+  }
+
+  @Test
+  public void testDeleteStorageConfig() throws Exception {
+    try (RestClientFixture restClientFixture = cluster.restClientFixture()) {
+      PluginConfigWrapper pcw = new PluginConfigWrapper(MockStorageEngineConfig.NAME, MockStorageEngineConfig.INSTANCE);
+      restClientFixture.postStorageConfig(pcw);
+      restClientFixture.deleteStorageConfig(MockStorageEngineConfig.NAME);
+      StoragePluginConfig config_server = cluster.storageRegistry().getStoredConfig(MockStorageEngineConfig.NAME);
+      Assert.assertNull(config_server);
+    } finally {
+      cluster.storageRegistry().remove(MockStorageEngineConfig.NAME);
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StorageResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StorageResourcesTest.java
@@ -24,25 +24,31 @@ import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.RestClientFixture;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class StorageResourcesTest extends ClusterTest {
   @BeforeClass
-  public static void setup() throws Exception {
+  public static void setUp() throws Exception {
     ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
       .configProperty(ExecConstants.HTTP_ENABLE, true)
       .configProperty(ExecConstants.HTTP_PORT_HUNT, true);
 
-      startCluster(builder);
+    startCluster(builder);
+  }
+
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    cluster.close();
   }
 
   @Test
   public void testCreateStorageConfig() throws Exception {
-    try (RestClientFixture restClientFixture = cluster.restClientFixture()) {
+    try {
       PluginConfigWrapper pcw = new PluginConfigWrapper(MockStorageEngineConfig.NAME, MockStorageEngineConfig.INSTANCE);
-      restClientFixture.postStorageConfig(pcw);
+      cluster.restClientFixture().postStorageConfig(pcw);
       StoragePluginConfig config_server = cluster.storageRegistry().getDefinedConfig(MockStorageEngineConfig.NAME);
       Assert.assertEquals(MockStorageEngineConfig.INSTANCE, config_server);
       Assert.assertTrue(config_server.isEnabled());
@@ -53,10 +59,10 @@ public class StorageResourcesTest extends ClusterTest {
 
   @Test
   public void testEnabledToggle() throws Exception {
-    try (RestClientFixture restClientFixture = cluster.restClientFixture()) {
+    try {
       PluginConfigWrapper pcw = new PluginConfigWrapper(MockStorageEngineConfig.NAME, MockStorageEngineConfig.INSTANCE);
-      restClientFixture.postStorageConfig(pcw);
-      restClientFixture.toggleEnabled(MockStorageEngineConfig.NAME, false);
+      cluster.restClientFixture().postStorageConfig(pcw);
+      cluster.restClientFixture().toggleEnabled(MockStorageEngineConfig.NAME, false);
       StoragePluginConfig config_server = cluster.storageRegistry().getStoredConfig(MockStorageEngineConfig.NAME);
       Assert.assertEquals(pcw.getConfig(), config_server);
       Assert.assertFalse(config_server.isEnabled());
@@ -67,10 +73,10 @@ public class StorageResourcesTest extends ClusterTest {
 
   @Test
   public void testDeleteStorageConfig() throws Exception {
-    try (RestClientFixture restClientFixture = cluster.restClientFixture()) {
+    try {
       PluginConfigWrapper pcw = new PluginConfigWrapper(MockStorageEngineConfig.NAME, MockStorageEngineConfig.INSTANCE);
-      restClientFixture.postStorageConfig(pcw);
-      restClientFixture.deleteStorageConfig(MockStorageEngineConfig.NAME);
+      cluster.restClientFixture().postStorageConfig(pcw);
+      cluster.restClientFixture().deleteStorageConfig(MockStorageEngineConfig.NAME);
       StoragePluginConfig config_server = cluster.storageRegistry().getStoredConfig(MockStorageEngineConfig.NAME);
       Assert.assertNull(config_server);
     } finally {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StorageResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StorageResourcesTest.java
@@ -23,7 +23,6 @@ import org.apache.drill.exec.store.mock.MockStorageEngineConfig;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
-import org.apache.drill.test.RestClientFixture;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.apache.drill.exec.server.rest.PluginConfigWrapper;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.exec.server.rest.StatusResources;
-import org.apache.drill.exec.server.rest.StorageResources;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 
@@ -124,8 +123,8 @@ public class RestClientFixture implements AutoCloseable {
   }
 
   public PluginConfigWrapper getStorageConfig(String name) {
-		return baseTarget.path(String.format("/storage/%s.json", name))
-		  .request(MediaType.APPLICATION_JSON)
+    return baseTarget.path(String.format("/storage/%s.json", name))
+      .request(MediaType.APPLICATION_JSON)
       .get(new GenericType<PluginConfigWrapper>() {});
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
@@ -18,13 +18,16 @@
 package org.apache.drill.test;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import org.apache.drill.exec.server.rest.PluginConfigWrapper;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.exec.server.rest.StatusResources;
+import org.apache.drill.exec.server.rest.StorageResources;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
@@ -118,6 +121,30 @@ public class RestClientFixture implements AutoCloseable {
     }
 
     return null;
+  }
+
+  public PluginConfigWrapper getStorageConfig(String name) {
+		return baseTarget.path(String.format("/storage/%s.json", name))
+		  .request(MediaType.APPLICATION_JSON)
+      .get(new GenericType<PluginConfigWrapper>() {});
+  }
+
+  public void postStorageConfig(PluginConfigWrapper pcw) {
+    baseTarget.path(String.format("/storage/%s.json", pcw.getName()))
+      .request(MediaType.APPLICATION_JSON)
+      .post(Entity.entity(pcw, MediaType.APPLICATION_JSON));
+  }
+
+  public void toggleEnabled(String name, boolean b) {
+    baseTarget.path(String.format("/storage/%s/enable/%b", name, b))
+      .request(MediaType.APPLICATION_JSON)
+      .post(Entity.json(""));
+  }
+
+  public void deleteStorageConfig(String name) {
+    baseTarget.path(String.format("/storage/%s.json", name))
+      .request(MediaType.APPLICATION_JSON)
+      .delete();
   }
 
   @Override


### PR DESCRIPTION
# [DRILL-8218](https://issues.apache.org/jira/browse/DRILL-8218): Add unit tests for StorageResource REST endpoints

## Description

Use the RestClientFixture to test the function of API endpoints in StorageResources

## Documentation
N/A

## Testing
N/A
