### PR TITLE
DRILL-8219: Handle null catalog names returned by DB2 in storage-jdbc

### DIFF
--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcCatalogSchema.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcCatalogSchema.java
@@ -55,6 +55,11 @@ class JdbcCatalogSchema extends AbstractSchema {
       connectionSchemaName = con.getSchema();
       while (set.next()) {
         final String catalogName = set.getString(1);
+        if (catalogName == null) {
+          // DB2 is an example of why of this escape is needed.
+          continue;
+        }
+
         CapitalizingJdbcSchema schema = new CapitalizingJdbcSchema(
             getSchemaPath(), catalogName, source, dialect, convention, catalogName, null, caseSensitive);
         schemaMap.put(schema.getName(), schema);


### PR DESCRIPTION
# [DRILL-8219](https://issues.apache.org/jira/browse/DRILL-8219): Handle null catalog names returned by DB2 in storage-jdbc

## Description

DB2 is another DBMS in which clients must connect to a named database, not just to the DBMS. A JDBC connection that does the same will receive a single record containing a null string from a call to Connection::getMetaData::getCatalogs. We need to ignore such a record in order to query DB2 correctly.

## Documentation
N/A

## Testing
Install DB2 using the Docker container ibmcom/db2. Create a test schema and table in the existing `testdb`. Configure a new Drill JDBC storage config to connect to the DB2 `testdb` database. Test info schema queries and direct querying of the test table.
