### PR TITLE
DRILL-8222: Fix wrong func impl of concat_delim, when null-value exist in middle args

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestVarArgFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestVarArgFunctions.java
@@ -97,6 +97,16 @@ public class TestVarArgFunctions extends ClusterTest {
   }
 
   @Test
+  public void testConcatDelimVarArgsWithNullValue() throws Exception {
+    testBuilder()
+      .sqlQuery("select concat_delim(',', 'a', null, 'b') as c")
+      .unOrdered()
+      .baselineColumns("c")
+      .baselineValues("a,b")
+      .go();
+  }
+
+  @Test
   public void testVarargUdfWithDifferentDataModes() throws Exception {
     testBuilder()
         .sqlQuery("SELECT concat_varchar(first_name, ' ', last_name) as c1\n" +

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/testing/VarCharConcatFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/testing/VarCharConcatFunctions.java
@@ -165,12 +165,12 @@ public class VarCharConcatFunctions {
       boolean addSeparator = false;
 
       for (NullableVarCharHolder input : inputs) {
-        if (addSeparator) {
-          for (int id = separator.start; id < separator.end; id++) {
-            out.buffer.setByte(out.end++, separator.buffer.getByte(id));
-          }
-        }
         if (input.isSet > 0) {
+          if (addSeparator) {
+            for (int id = separator.start; id < separator.end; id++) {
+              out.buffer.setByte(out.end++, separator.buffer.getByte(id));
+            }
+          }
           addSeparator = true;
           for (int id = input.start; id < input.end; id++) {
             out.buffer.setByte(out.end++, input.buffer.getByte(id));
@@ -258,12 +258,12 @@ public class VarCharConcatFunctions {
       boolean addSeparator = false;
 
       for (NullableVarCharHolder input : inputs) {
-        if (addSeparator) {
-          for (int id = separator.start; id < separator.end; id++) {
-            out.buffer.setByte(out.end++, separator.buffer.getByte(id));
-          }
-        }
         if (input.isSet > 0) {
+          if (addSeparator) {
+            for (int id = separator.start; id < separator.end; id++) {
+              out.buffer.setByte(out.end++, separator.buffer.getByte(id));
+            }
+          }
           addSeparator = true;
           for (int id = input.start; id < input.end; id++) {
             out.buffer.setByte(out.end++, input.buffer.getByte(id));


### PR DESCRIPTION
# [DRILL-8222](https://issues.apache.org/jira/browse/DRILL-8222): Wrong function's implementation of concat_delim


## Description

Current function implementation of `concat_delim` is wrong.
`select concat_delim(',', 'a', null, 'b') as c `
The result of this query should be `'a,b'`, but current result is `'a,,b'
`
## Documentation


## Testing
org.apache.drill.exec.fn.impl.TestVarArgFunctions#testConcatDelimVarArgsWithNullValue
