### PR TITLE
DRILL-8224: Fix TestHttpPlugin#testSlowResponse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ cache:
 before_install:
   - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64"
   - export PATH="$JAVA_HOME/bin:$PATH"
-  - export MEMORYMB=2048
   - export DIRECTMEMORYMB=5120
   - free -m
   - java -version
@@ -74,7 +73,7 @@ install:
   # For protobuf phase: builds Drill project, performs license checkstyle goal and regenerates Java and C++ Protobuf files
   - |
     if [ $PHASE = "tests" ]; then \
-      mvn install --batch-mode --no-transfer-progress -DforkCount=1 -DmemoryMb=$MEMORYMB -DdirectMemoryMb=$DIRECTMEMORYMB \
+      mvn install --batch-mode --no-transfer-progress -DforkCount=1 -DdirectMemoryMb=$DIRECTMEMORYMB \
         -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest"; \
     elif [ $PHASE = "build_checkstyle_protobuf" ]; then \
       MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --no-transfer-progress -Drat.skip=false -Dlicense.skip=false --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true && \

--- a/contrib/storage-http/pom.xml
+++ b/contrib/storage-http/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Storage : HTTP</name>
 
   <properties>
-    <okhttp.version>4.9.2</okhttp.version>
+    <okhttp.version>4.9.3</okhttp.version>
   </properties>
 
   <dependencies>

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -1118,7 +1118,7 @@ public class TestHttpPlugin extends ClusterTest {
       server.enqueue(
         new MockResponse().setResponseCode(200)
           .setBody(TEST_JSON_RESPONSE)
-          .throttleBody(64, 6, TimeUnit.SECONDS)
+          .setBodyDelay(6, TimeUnit.SECONDS)
       );
 
       String sql = "SELECT sunrise AS sunrise, sunset AS sunset FROM local.sunrise.`?lat=36.7201600&lng=-4.4203400&date=2019-10-02` AS t1";
@@ -1127,7 +1127,7 @@ public class TestHttpPlugin extends ClusterTest {
         client.queryBuilder().sql(sql).rowSet();
         fail();
       } catch (Exception e) {
-         assertTrue(e.getMessage().contains("DATA_READ ERROR: timeout"));
+         assertTrue("Not timeout exception, " + e, e.getMessage().contains("DATA_READ ERROR: timeout"));
       }
     }
   }
@@ -1527,8 +1527,9 @@ public class TestHttpPlugin extends ClusterTest {
    * @return Started Mock server
    * @throws IOException If the server cannot start, throws IOException
    */
-  public static MockWebServer startServer() throws IOException {
+  public static MockWebServer startServer() throws IOException, InterruptedException {
     MockWebServer server = new MockWebServer();
+//    server.takeRequest(25, TimeUnit.SECONDS);
     server.start(MOCK_SERVER_PORT);
     return server;
   }

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
@@ -138,7 +138,7 @@ public class TestOAuthProcess extends ClusterTest {
       assertEquals("refresh_me", tokenTable.getRefreshToken());
 
     } catch (Exception e) {
-      logger.debug(e.getMessage());
+      logger.error(e.getMessage());
       fail();
     }
   }
@@ -184,7 +184,7 @@ public class TestOAuthProcess extends ClusterTest {
       RowSetUtilities.verify(expected, results);
 
     } catch (Exception e) {
-      logger.debug(e.getMessage());
+      logger.error(e.getMessage());
       fail();
     }
   }

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
@@ -200,7 +200,7 @@ public class AllocationManager {
   public class BufferLedger {
 
     private final IdentityHashMap<DrillBuf, Object> buffers =
-        BaseAllocator.DEBUG ? new IdentityHashMap<DrillBuf, Object>() : null;
+        BaseAllocator.DEBUG ? new IdentityHashMap<>() : null;
 
     private final long ledgerId = LEDGER_ID_GENERATOR.incrementAndGet(); // unique ID assigned to each ledger
     private final AtomicInteger bufRefCnt = new AtomicInteger(0); // start at zero so we can manage request for retain

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -486,14 +486,13 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         if (!childAllocators.isEmpty()) {
           for (final BaseAllocator childAllocator : childAllocators.keySet()) {
             if (childAllocator.isClosed) {
-              logger.warn(String.format(
-                  "Closed child allocator[%s] on parent allocator[%s]'s child list.\n%s",
-                  childAllocator.name, name, toString()));
+              logger.warn(String.format("Closed child allocator[%s] on parent allocator[%s]'s child list.\n%s",
+                  childAllocator.name, name, this));
             }
           }
 
           throw new IllegalStateException(
-              String.format("Allocator[%s] closed with outstanding child allocators.\n%s", name, toString()));
+              String.format("Allocator[%s] closed with outstanding child allocators.\n%s", name, this));
         }
 
         // are there outstanding buffers?


### PR DESCRIPTION
# [DRILL-8224](https://issues.apache.org/jira/browse/DRILL-8224): Fix TestHttpPlugin#testSlowResponse

## Description

Fix testSlowResponse and increase heap memory for Travis build (change to default value, 2048 -> 2500 Mb)

## Documentation
NA

## Testing
This change about fixing tests
