### PR TITLE
DRILL-8225: Update LogParser and Yauaa to support User-Agent Client Hints

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -32,7 +32,6 @@
 
   <properties>
     <poi.version>5.2.1</poi.version>
-    <log4j.version>2.17.2</log4j.version>
   </properties>
   <dependencies>
     <dependency>

--- a/contrib/format-httpd/pom.xml
+++ b/contrib/format-httpd/pom.xml
@@ -60,7 +60,27 @@
           <groupId>nl.basjes.parse.httpdlog</groupId>
           <artifactId>httpdlog-parser</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.ben-manes.caffeine</groupId>
+          <artifactId>caffeine</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- The default logging implementation for Yauaa -->
+    <!-- Send all Log4j2 calls to SLF4J -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <!-- The default logging implementation for Yauaa -->
+    <!-- Send all Log4j2 calls to SLF4J -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -86,6 +86,15 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- The default logging implementation for Yauaa -->
+    <!-- Send all Log4j2 call to SLF4J -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -94,7 +94,7 @@
     </dependency>
 
     <!-- The default logging implementation for Yauaa -->
-    <!-- Send all Log4j2 call to SLF4J -->
+    <!-- Send all Log4j2 calls to SLF4J -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -68,6 +68,12 @@
       <groupId>nl.basjes.parse.useragent</groupId>
       <artifactId>yauaa</artifactId>
       <version>${yauaa.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.ben-manes.caffeine</groupId>
+          <artifactId>caffeine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
@@ -18,11 +18,14 @@
 
 package org.apache.drill.exec.udfs;
 
+import nl.basjes.parse.useragent.AbstractUserAgentAnalyzer;
 import nl.basjes.parse.useragent.AnalyzerUtilities.ParsedArguments;
 import nl.basjes.parse.useragent.UserAgentAnalyzer;
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static nl.basjes.parse.useragent.AnalyzerUtilities.parseArguments;
@@ -54,7 +57,15 @@ public class UserAgentAnalyzerProvider {
     private static final UserAgentAnalyzer INSTANCE = UserAgentAnalyzer.newBuilder()
             .dropTests()
             .hideMatcherLoadStats()
-            .immediateInitialization()
+            // Caffeine is a Java 11+ library.
+            // This is one is Java 8 compatible.
+            .withCacheInstantiator(
+              (AbstractUserAgentAnalyzer.CacheInstantiator) size ->
+                Collections.synchronizedMap(new LRUMap<>(size)))
+            .withClientHintCacheInstantiator(
+              (AbstractUserAgentAnalyzer.ClientHintsCacheInstantiator<?>) size ->
+                Collections.synchronizedMap(new LRUMap<>(size)))
+                  .immediateInitialization()
             .build();
   }
 

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
@@ -18,14 +18,11 @@
 
 package org.apache.drill.exec.udfs;
 
-import nl.basjes.parse.useragent.AbstractUserAgentAnalyzer;
 import nl.basjes.parse.useragent.AnalyzerUtilities.ParsedArguments;
 import nl.basjes.parse.useragent.UserAgentAnalyzer;
-import org.apache.commons.collections4.map.LRUMap;
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static nl.basjes.parse.useragent.AnalyzerUtilities.parseArguments;
@@ -58,14 +55,8 @@ public class UserAgentAnalyzerProvider {
             .dropTests()
             .hideMatcherLoadStats()
             // Caffeine is a Java 11+ library.
-            // This is one is Java 8 compatible.
-            .withCacheInstantiator(
-              (AbstractUserAgentAnalyzer.CacheInstantiator) size ->
-                Collections.synchronizedMap(new LRUMap<>(size)))
-            .withClientHintCacheInstantiator(
-              (AbstractUserAgentAnalyzer.ClientHintsCacheInstantiator<?>) size ->
-                Collections.synchronizedMap(new LRUMap<>(size)))
-                  .immediateInitialization()
+            .useJava8CompatibleCaching()
+            .immediateInitialization()
             .build();
   }
 

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
@@ -18,8 +18,11 @@
 
 package org.apache.drill.exec.udfs;
 
+import nl.basjes.parse.useragent.UserAgentAnalyzer;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.common.expression.ExpressionStringBuilder;
+import org.apache.drill.exec.util.Text;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
@@ -28,7 +31,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
+
+import static org.apache.drill.test.TestBuilder.parsePath;
+import static org.junit.Assert.assertEquals;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
 public class TestUserAgentFunctions extends ClusterTest {
@@ -41,44 +49,77 @@ public class TestUserAgentFunctions extends ClusterTest {
 
   @Test
   public void testParseUserAgentString() throws Exception {
-    String query = "SELECT t1.ua.DeviceClass AS DeviceClass,\n" +
-      "t1.ua.DeviceName AS DeviceName,\n" +
-      "t1.ua.DeviceBrand AS DeviceBrand,\n" +
-      "t1.ua.DeviceCpuBits AS DeviceCpuBits,\n" +
-      "t1.ua.OperatingSystemClass AS OperatingSystemClass,\n" +
-      "t1.ua.OperatingSystemName AS OperatingSystemName,\n" +
-      "t1.ua.OperatingSystemVersion AS OperatingSystemVersion,\n" +
-      "t1.ua.OperatingSystemVersionMajor AS OperatingSystemVersionMajor,\n" +
-      "t1.ua.OperatingSystemNameVersion AS OperatingSystemNameVersion,\n" +
-      "t1.ua.OperatingSystemNameVersionMajor AS OperatingSystemNameVersionMajor,\n" +
-      "t1.ua.LayoutEngineClass AS LayoutEngineClass,\n" +
-      "t1.ua.LayoutEngineName AS LayoutEngineName,\n" +
-      "t1.ua.LayoutEngineVersion AS LayoutEngineVersion,\n" +
-      "t1.ua.LayoutEngineVersionMajor AS LayoutEngineVersionMajor,\n" +
-      "t1.ua.LayoutEngineNameVersion AS LayoutEngineNameVersion,\n" +
-      "t1.ua.LayoutEngineBuild AS LayoutEngineBuild,\n" +
-      "t1.ua.AgentClass AS AgentClass,\n" +
-      "t1.ua.AgentName AS AgentName,\n" +
-      "t1.ua.AgentVersion AS AgentVersion,\n" +
-      "t1.ua.AgentVersionMajor AS AgentVersionMajor,\n" +
-      "t1.ua.AgentNameVersionMajor AS AgentNameVersionMajor,\n" +
-      "t1.ua.AgentLanguage AS AgentLanguage,\n" +
-      "t1.ua.AgentLanguageCode AS AgentLanguageCode,\n" +
-      "t1.ua.AgentSecurity AS AgentSecurity\n" +
-      "FROM (SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11') AS ua FROM (values(1))) AS t1";
+    String query =
+      "SELECT t1.ua.DeviceClass                     AS DeviceClass," +
+      "       t1.ua.DeviceName                      AS DeviceName," +
+      "       t1.ua.DeviceBrand                     AS DeviceBrand," +
+      "       t1.ua.DeviceCpuBits                   AS DeviceCpuBits," +
+      "       t1.ua.OperatingSystemClass            AS OperatingSystemClass," +
+      "       t1.ua.OperatingSystemName             AS OperatingSystemName," +
+      "       t1.ua.OperatingSystemVersion          AS OperatingSystemVersion," +
+      "       t1.ua.OperatingSystemVersionMajor     AS OperatingSystemVersionMajor," +
+      "       t1.ua.OperatingSystemNameVersion      AS OperatingSystemNameVersion," +
+      "       t1.ua.OperatingSystemNameVersionMajor AS OperatingSystemNameVersionMajor," +
+      "       t1.ua.LayoutEngineClass               AS LayoutEngineClass," +
+      "       t1.ua.LayoutEngineName                AS LayoutEngineName," +
+      "       t1.ua.LayoutEngineVersion             AS LayoutEngineVersion," +
+      "       t1.ua.LayoutEngineVersionMajor        AS LayoutEngineVersionMajor," +
+      "       t1.ua.LayoutEngineNameVersion         AS LayoutEngineNameVersion," +
+      "       t1.ua.LayoutEngineBuild               AS LayoutEngineBuild," +
+      "       t1.ua.AgentClass                      AS AgentClass," +
+      "       t1.ua.AgentName                       AS AgentName," +
+      "       t1.ua.AgentVersion                    AS AgentVersion," +
+      "       t1.ua.AgentVersionMajor               AS AgentVersionMajor," +
+      "       t1.ua.AgentNameVersionMajor           AS AgentNameVersionMajor," +
+      "       t1.ua.AgentLanguage                   AS AgentLanguage," +
+      "       t1.ua.AgentLanguageCode               AS AgentLanguageCode," +
+      "       t1.ua.AgentSecurity                   AS AgentSecurity " +
+      "FROM (" +
+      "    SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11') AS ua" +
+      "    FROM (values(1))" +
+      ") AS t1";
 
     testBuilder()
       .sqlQuery(query)
       .unOrdered()
-      .baselineColumns("DeviceClass", "DeviceName", "DeviceBrand", "DeviceCpuBits", "OperatingSystemClass", "OperatingSystemName", "OperatingSystemVersion", "OperatingSystemVersionMajor", "OperatingSystemNameVersion", "OperatingSystemNameVersionMajor", "LayoutEngineClass", "LayoutEngineName", "LayoutEngineVersion", "LayoutEngineVersionMajor", "LayoutEngineNameVersion", "LayoutEngineBuild", "AgentClass", "AgentName", "AgentVersion", "AgentVersionMajor", "AgentNameVersionMajor", "AgentLanguage", "AgentLanguageCode", "AgentSecurity")
-      .baselineValues("Desktop", "Desktop", "Unknown", "32", "Desktop", "Windows NT", "XP", "XP", "Windows XP", "Windows XP", "Browser", "Gecko", "1.8.1.11", "1", "Gecko 1.8.1.11", "20071127", "Browser", "Firefox", "2.0.0.11", "2", "Firefox 2", "English (United States)", "en-us", "Strong security")
+      .baselineRecords(
+        Collections.singletonList(// Singleton list because we expect 1 record
+          expectations(
+            "DeviceClass",                     "Desktop",
+            "DeviceName",                      "Desktop",
+            "DeviceBrand",                     "Unknown",
+            "DeviceCpuBits",                   "32",
+            "OperatingSystemClass",            "Desktop",
+            "OperatingSystemName",             "Windows NT",
+            "OperatingSystemVersion",          "XP",
+            "OperatingSystemVersionMajor",     "XP",
+            "OperatingSystemNameVersion",      "Windows XP",
+            "OperatingSystemNameVersionMajor", "Windows XP",
+            "LayoutEngineClass",               "Browser",
+            "LayoutEngineName",                "Gecko",
+            "LayoutEngineVersion",             "1.8.1.11",
+            "LayoutEngineVersionMajor",        "1",
+            "LayoutEngineNameVersion",         "Gecko 1.8.1.11",
+            "LayoutEngineBuild",               "20071127",
+            "AgentClass",                      "Browser",
+            "AgentName",                       "Firefox",
+            "AgentVersion",                    "2.0.0.11",
+            "AgentVersionMajor",               "2",
+            "AgentNameVersionMajor",           "Firefox 2",
+            "AgentLanguage",                   "English (United States)",
+            "AgentLanguageCode",               "en-us",
+            "AgentSecurity",                   "Strong security"
+          )
+        )
+      )
       .go();
   }
 
   @Test
-  public void testGetHostName() throws Exception {
-    String query = "SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11', 'AgentSecurity') AS agent FROM "
-      + "(values(1))";
+  public void testValidFieldName() throws Exception {
+    String query =
+      "SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11', 'AgentSecurity') AS agent " +
+      "FROM (values(1))";
     testBuilder()
       .sqlQuery(query)
       .ordered()
@@ -89,8 +130,22 @@ public class TestUserAgentFunctions extends ClusterTest {
 
   @Test
   public void testEmptyFieldName() throws Exception {
-    String query = "SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11', '') AS agent FROM " + "(values" +
-      "(1))";
+    String query =
+      "SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11', '') AS agent " +
+      "FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("agent")
+      .baselineValues("Unknown")
+      .go();
+  }
+
+  @Test
+  public void testBadFieldName() throws Exception {
+    String query =
+      "SELECT parse_user_agent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.11) Gecko/20071127 Firefox/2.0.0.11', 'NoSuchField') AS agent " +
+      "FROM (values(1))";
     testBuilder()
       .sqlQuery(query)
       .ordered()
@@ -101,16 +156,23 @@ public class TestUserAgentFunctions extends ClusterTest {
 
   @Test
   public void testNullUserAgent() throws Exception {
+    // If a null value is provided then the UserAgentAnalyzer will classify this as a Hacker because all requests normally have a User-Agent.
+    UserAgentAnalyzer analyzer = UserAgentAnalyzer.newBuilder().showMinimalVersion().dropTests().immediateInitialization().build();
+    Map<String, String> expected = analyzer.parse((String)null).toMap(analyzer.getAllPossibleFieldNamesSorted());
+
+    Map<String, Text> expectedRecord = new TreeMap<>();
+    for (Map.Entry<String, String> entry : expected.entrySet()) {
+      expectedRecord.put(entry.getKey(), new Text(entry.getValue()));
+    }
+
     String query = "SELECT parse_user_agent(CAST(null as VARCHAR)) AS agent FROM (values(1))";
-    Map<?, ?> emptyMap = Collections.emptyMap();
     testBuilder()
       .sqlQuery(query)
       .ordered()
       .baselineColumns("agent")
-      .baselineValues(emptyMap)
+      .baselineValues(expectedRecord)
       .go();
   }
-
 
   @Test
   public void testEmptyUAStringAndFieldName() throws Exception {
@@ -126,6 +188,17 @@ public class TestUserAgentFunctions extends ClusterTest {
   @Test
   public void testNullUAStringAndEmptyFieldName() throws Exception {
     String query = "SELECT parse_user_agent(CAST(null as VARCHAR), '') AS agent FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("agent")
+      .baselineValues((String) null)
+      .go();
+  }
+
+  @Test
+  public void testNullUAStringAndBadFieldName() throws Exception {
+    String query = "SELECT parse_user_agent(CAST(null as VARCHAR), 'NoSuchField') AS agent FROM (values(1))";
     testBuilder()
       .sqlQuery(query)
       .ordered()
@@ -168,4 +241,185 @@ public class TestUserAgentFunctions extends ClusterTest {
       .baselineValues("Hacker")
       .go();
   }
+
+  @Test
+  public void testClientHints() throws Exception {
+    String query =
+      "SELECT " +
+      "   t1.ua.DeviceClass                               AS DeviceClass,\n" +
+      "   t1.ua.DeviceName                                AS DeviceName,\n" +
+      "   t1.ua.DeviceBrand                               AS DeviceBrand,\n" +
+      "   t1.ua.DeviceCpu                                 AS DeviceCpu,\n" +
+      "   t1.ua.DeviceCpuBits                             AS DeviceCpuBits,\n" +
+      "   t1.ua.OperatingSystemClass                      AS OperatingSystemClass,\n" +
+      "   t1.ua.OperatingSystemName                       AS OperatingSystemName,\n" +
+      "   t1.ua.OperatingSystemVersion                    AS OperatingSystemVersion,\n" +
+      "   t1.ua.OperatingSystemVersionMajor               AS OperatingSystemVersionMajor,\n" +
+      "   t1.ua.OperatingSystemNameVersion                AS OperatingSystemNameVersion,\n" +
+      "   t1.ua.OperatingSystemNameVersionMajor           AS OperatingSystemNameVersionMajor,\n" +
+      "   t1.ua.LayoutEngineClass                         AS LayoutEngineClass,\n" +
+      "   t1.ua.LayoutEngineName                          AS LayoutEngineName,\n" +
+      "   t1.ua.LayoutEngineVersion                       AS LayoutEngineVersion,\n" +
+      "   t1.ua.LayoutEngineVersionMajor                  AS LayoutEngineVersionMajor,\n" +
+      "   t1.ua.LayoutEngineNameVersion                   AS LayoutEngineNameVersion,\n" +
+      "   t1.ua.LayoutEngineNameVersionMajor              AS LayoutEngineNameVersionMajor,\n" +
+      "   t1.ua.AgentClass                                AS AgentClass,\n" +
+      "   t1.ua.AgentName                                 AS AgentName,\n" +
+      "   t1.ua.AgentVersion                              AS AgentVersion,\n" +
+      "   t1.ua.AgentVersionMajor                         AS AgentVersionMajor,\n" +
+      "   t1.ua.AgentNameVersion                          AS AgentNameVersion,\n" +
+      "   t1.ua.AgentNameVersionMajor                     AS AgentNameVersionMajor\n" +
+      "FROM (" +
+      "   SELECT" +
+      "       parse_user_agent(" +
+      "           'User-Agent',                   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36'," +
+      "           'Sec-Ch-Ua',                    '\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"100\", \"Google Chrome\";v=\"100\"'," +
+      "           'Sec-Ch-Ua-Arch',               '\"x86\"'," +
+      "           'Sec-Ch-Ua-Bitness',            '\"64\"'," +
+      "           'Sec-Ch-Ua-Full-Version',       '\"100.0.4896.127\"'," +
+      "           'Sec-Ch-Ua-Full-Version-List',  '\" Not A;Brand\";v=\"99.0.0.0\", \"Chromium\";v=\"100.0.4896.127\", \"Google Chrome\";v=\"100.0.4896.127\"'," +
+      "           'Sec-Ch-Ua-Mobile',             '?0'," +
+      "           'Sec-Ch-Ua-Model',              '\"\"'," +
+      "           'Sec-Ch-Ua-Platform',           '\"Linux\"'," +
+      "           'Sec-Ch-Ua-Platform-Version',   '\"5.13.0\"'," +
+      "           'Sec-Ch-Ua-Wow64',              '?0'" +
+      "       ) AS ua " +
+      "   FROM (values(1))" +
+      ") AS t1";
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineRecords(
+        Collections.singletonList(// Singleton list because we expect 1 record
+          expectations(
+            "DeviceClass",                      "Desktop",
+            "DeviceName",                       "Linux Desktop",
+            "DeviceBrand",                      "Unknown",
+            "DeviceCpu",                        "Intel x86_64",
+            "DeviceCpuBits",                    "64",
+            "OperatingSystemClass",             "Desktop",
+            "OperatingSystemName",              "Linux",
+            "OperatingSystemVersion",           "5.13.0",
+            "OperatingSystemVersionMajor",      "5",
+            "OperatingSystemNameVersion",       "Linux 5.13.0",
+            "OperatingSystemNameVersionMajor",  "Linux 5",
+            "LayoutEngineClass",                "Browser",
+            "LayoutEngineName",                 "Blink",
+            "LayoutEngineVersion",              "100.0",
+            "LayoutEngineVersionMajor",         "100",
+            "LayoutEngineNameVersion",          "Blink 100.0",
+            "LayoutEngineNameVersionMajor",     "Blink 100",
+            "AgentClass",                       "Browser",
+            "AgentName",                        "Chrome",
+            "AgentVersion",                     "100.0.4896.127",
+            "AgentVersionMajor",                "100",
+            "AgentNameVersion",                 "Chrome 100.0.4896.127",
+            "AgentNameVersionMajor",            "Chrome 100"
+          )
+        )
+      )
+      .go();
+  }
+
+  // ====================================================================
+
+  @Test
+  public void testEmptyClientHints() throws Exception {
+    String query =
+      "SELECT " +
+      "   t1.ua.DeviceClass                               AS DeviceClass,\n" +
+      "   t1.ua.DeviceName                                AS DeviceName,\n" +
+      "   t1.ua.DeviceBrand                               AS DeviceBrand,\n" +
+      "   t1.ua.DeviceCpu                                 AS DeviceCpu,\n" +
+      "   t1.ua.DeviceCpuBits                             AS DeviceCpuBits,\n" +
+      "   t1.ua.OperatingSystemClass                      AS OperatingSystemClass,\n" +
+      "   t1.ua.OperatingSystemName                       AS OperatingSystemName,\n" +
+      "   t1.ua.OperatingSystemVersion                    AS OperatingSystemVersion,\n" +
+      "   t1.ua.OperatingSystemVersionMajor               AS OperatingSystemVersionMajor,\n" +
+      "   t1.ua.OperatingSystemNameVersion                AS OperatingSystemNameVersion,\n" +
+      "   t1.ua.OperatingSystemNameVersionMajor           AS OperatingSystemNameVersionMajor,\n" +
+      "   t1.ua.LayoutEngineClass                         AS LayoutEngineClass,\n" +
+      "   t1.ua.LayoutEngineName                          AS LayoutEngineName,\n" +
+      "   t1.ua.LayoutEngineVersion                       AS LayoutEngineVersion,\n" +
+      "   t1.ua.LayoutEngineVersionMajor                  AS LayoutEngineVersionMajor,\n" +
+      "   t1.ua.LayoutEngineNameVersion                   AS LayoutEngineNameVersion,\n" +
+      "   t1.ua.LayoutEngineNameVersionMajor              AS LayoutEngineNameVersionMajor,\n" +
+      "   t1.ua.AgentClass                                AS AgentClass,\n" +
+      "   t1.ua.AgentName                                 AS AgentName,\n" +
+      "   t1.ua.AgentVersion                              AS AgentVersion,\n" +
+      "   t1.ua.AgentVersionMajor                         AS AgentVersionMajor,\n" +
+      "   t1.ua.AgentNameVersion                          AS AgentNameVersion,\n" +
+      "   t1.ua.AgentNameVersionMajor                     AS AgentNameVersionMajor\n" +
+      "FROM (" +
+      "   SELECT" +
+      "       parse_user_agent(" +
+      // NOTE: Here we do NOT say "User-Agent" --> It is just the first one in the list.
+      "           'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36'," +
+      "           'Sec-Ch-Ua',                    ''," +
+      "           'Sec-Ch-Ua-Arch',               ''," +
+      "           'Sec-Ch-Ua-Bitness',            ''," +
+      "           'Sec-Ch-Ua-Full-Version',       ''," +
+      "           'Sec-Ch-Ua-Full-Version-List',  ''," +
+      "           'Sec-Ch-Ua-Mobile',             ''," +
+      "           'Sec-Ch-Ua-Model',              ''," +
+      "           'Sec-Ch-Ua-Platform',           ''," +
+      "           'Sec-Ch-Ua-Platform-Version',   ''," +
+      "           'Sec-Ch-Ua-Wow64',              ''" +
+      "       ) AS ua " +
+      "   FROM (values(1))" +
+      ") AS t1";
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineRecords(
+        Collections.singletonList(// Singleton list because we expect 1 record
+          expectations(
+            "DeviceClass",                      "Desktop",
+            "DeviceName",                       "Linux Desktop",
+            "DeviceBrand",                      "Unknown",
+            "DeviceCpu",                        "Intel x86_64",
+            "DeviceCpuBits",                    "64",
+            "OperatingSystemClass",             "Desktop",
+            "OperatingSystemName",              "Linux",
+            "OperatingSystemVersion",           "??",
+            "OperatingSystemVersionMajor",      "??",
+            "OperatingSystemNameVersion",       "Linux ??",
+            "OperatingSystemNameVersionMajor",  "Linux ??",
+            "LayoutEngineClass",                "Browser",
+            "LayoutEngineName",                 "Blink",
+            "LayoutEngineVersion",              "100.0",
+            "LayoutEngineVersionMajor",         "100",
+            "LayoutEngineNameVersion",          "Blink 100.0",
+            "LayoutEngineNameVersionMajor",     "Blink 100",
+            "AgentClass",                       "Browser",
+            "AgentName",                        "Chrome",
+            "AgentVersion",                     "100.0.4896.127",
+            "AgentVersionMajor",                "100",
+            "AgentNameVersion",                 "Chrome 100.0.4896.127",
+            "AgentNameVersionMajor",            "Chrome 100"
+          )
+        )
+      )
+      .go();
+  }
+
+  /**
+   * Converts a more readable list of keys and values into what the ClusterTest supports.
+   * @param strings List of  ["key", "value"]
+   * @return A Map of the same keys and values that is in the right format.
+   */
+  private Map<String, Object> expectations(String... strings) {
+    Map<String, Object> expectations = new LinkedHashMap<>();
+    int index = 0;
+    assertEquals("The number of arguments for 'expectations' must be even", 0, strings.length % 2);
+
+    while (index < strings.length) {
+      expectations.put(ExpressionStringBuilder.toString(parsePath(strings[index])), strings[index+1]);
+      index+=2;
+    }
+    return expectations;
+  }
+
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
@@ -157,7 +157,7 @@ public class TestUserAgentFunctions extends ClusterTest {
   @Test
   public void testNullUserAgent() throws Exception {
     // If a null value is provided then the UserAgentAnalyzer will classify this as a Hacker because all requests normally have a User-Agent.
-    UserAgentAnalyzer analyzer = UserAgentAnalyzer.newBuilder().showMinimalVersion().dropTests().immediateInitialization().build();
+    UserAgentAnalyzer analyzer = UserAgentAnalyzer.newBuilder().showMinimalVersion().withoutCache().dropTests().immediateInitialization().build();
     Map<String, String> expected = analyzer.parse((String)null).toMap(analyzer.getAllPossibleFieldNamesSorted());
 
     Map<String, Text> expectedRecord = new TreeMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <httpdlog-parser.version>5.8</httpdlog-parser.version>
-    <yauaa.version>7.0.0</yauaa.version>
+    <yauaa.version>7.1.0</yauaa.version>
     <log4j.version>2.17.2</log4j.version>
     <aircompressor.version>0.20</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,9 @@
     <xerces.version>2.12.2</xerces.version>
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
-    <httpdlog-parser.version>5.7</httpdlog-parser.version>
-    <yauaa.version>5.20</yauaa.version>
+    <httpdlog-parser.version>5.8</httpdlog-parser.version>
+    <yauaa.version>7.0.0</yauaa.version>
+    <log4j.version>2.17.2</log4j.version>
     <aircompressor.version>0.20</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>
     <univocity-parsers.version>2.8.3</univocity-parsers.version>


### PR DESCRIPTION
# [DRILL-8225](https://issues.apache.org/jira/browse/DRILL-8225): Update LogParser and Yauaa to support User-Agent Client Hints

## Description

In order to support logging, parsing and analyzing the User-Agent Client Hints it was needed to update the LogParser to fix a parsing bug and to update Yauaa to support actually analyzing them.

See https://yauaa.basjes.nl/using/clienthints/

## Documentation
The change includes the updated Readme for the UDFs.

## Testing
The change includes the original tests and additional tests for the new functionality.
For some of the existing tests the readability of the test has been improved.

For specific edge cases (like passing a null value and empty string) the parse results have changed.
