### PR TITLE
DRILL-8200: Update Hadoop libs to ≥ 3.2.3 for CVE-2022-26612 (set hadoop.version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       for example parquet-hadoop-bundle and derby dependencies.
     -->
     <hive.version>3.1.2</hive.version>
-    <hadoop.version>3.2.2</hadoop.version>
+    <hadoop.version>3.2.3</hadoop.version>
     <hbase.version>2.4.9</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>


### PR DESCRIPTION
# [DRILL-8200](https://issues.apache.org/jira/browse/DRILL-8200): Update Hadoop libs to ≥ 3.2.3 for CVE-2022-26612 (set hadoop.version)

## Description

The previous PR for this update did everything except set hadoop.version = 3.2.3.

## Documentation
N/A

## Testing
Existing test coverage.
