### PR TITLE
DRILL-8229: Add Parameter to Skip Malformed Records to HTTP UDF

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -67,7 +67,7 @@ public class HttpHelperFunctions {
         .build();
 
       jsonReader.setIgnoreJSONParseErrors(
-        options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG).bool_val);
+        options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG));
     }
 
     @Override
@@ -155,7 +155,7 @@ public class HttpHelperFunctions {
         .build();
 
       jsonReader.setIgnoreJSONParseErrors(
-        options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG).bool_val);
+        options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG));
 
       String schemaPath = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
       // Get the plugin name and endpoint name

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -65,6 +65,9 @@ public class HttpHelperFunctions {
         .allTextMode(options.getOption(org.apache.drill.exec.ExecConstants.JSON_ALL_TEXT_MODE).bool_val)
         .enableNanInf(options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_NAN_INF_NUMBERS).bool_val)
         .build();
+
+      jsonReader.setIgnoreJSONParseErrors(
+        options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG).bool_val);
     }
 
     @Override
@@ -150,6 +153,9 @@ public class HttpHelperFunctions {
         .allTextMode(options.getOption(org.apache.drill.exec.ExecConstants.JSON_ALL_TEXT_MODE).bool_val)
         .enableNanInf(options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_NAN_INF_NUMBERS).bool_val)
         .build();
+
+      jsonReader.setIgnoreJSONParseErrors(
+        options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG).bool_val);
 
       String schemaPath = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
       // Get the plugin name and endpoint name


### PR DESCRIPTION
# [DRILL-8229](https://issues.apache.org/jira/browse/DRILL-8229): Add Parameter to Skip Malformed Records to HTTP UDF

## Description
The `http_get` and `http_request` UDFs were not using the JSON parameter to skip malformed records.  This PR fixes that.

## Documentation
N/A

## Testing
Manually tested.