### PR TITLE
[DRILL-8230] upgrade to POI 5.2.2

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Format : Excel</name>
 
   <properties>
-    <poi.version>5.2.1</poi.version>
+    <poi.version>5.2.2</poi.version>
   </properties>
   <dependencies>
     <dependency>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>3.6.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
# [DRILL-8230](https://issues.apache.org/jira/browse/DRILL-8230): upgrade to POI 5.2.2

## Description

Upgrade POI libs used for excel support

## Documentation
n/a

## Testing
unit tests - CI build