### PR TITLE
DRILL-8232: Add support for user credentials to VaultCredentialsProvider

### DIFF
--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
@@ -172,7 +172,7 @@ public class TestUserTranslationInHttpPlugin extends ClusterTest {
     StoragePluginRegistry registry = cluster.storageRegistry();
     StoragePlugin plugin = registry.getPlugin("local");
     PlainCredentialsProvider credentialsProvider = (PlainCredentialsProvider) plugin.getConfig().getCredentialsProvider();
-    Map<String, String> credentials = credentialsProvider.getCredentials(TEST_USER_1);
+    Map<String, String> credentials = credentialsProvider.getUserCredentials(TEST_USER_1);
     assertNotNull(credentials);
     assertNull(credentials.get("username"));
     assertNull(credentials.get("password"));

--- a/docs/dev/PluginCredentialsProvider.md
+++ b/docs/dev/PluginCredentialsProvider.md
@@ -93,13 +93,16 @@ In this case, the storage `jdbc` plugin will use `user1` value as the `username`
 
 ## Using credentials managed by Vault
 
-`VaultCredentialsProvider` credentials provider implementation allows using Vault secrets as plugin credentials.
+`VaultCredentialsProvider` credentials provider implementation allows using Vault secrets as plugin credentials. Currently, this credentials provider authenticates itself to Vault using the [AppRole](https://www.vaultproject.io/docs/auth/approle) auth method which is intended for use by applications and services. In future, it may be able to use the Vault token of the Drill query user instead, in the event that the `VaultUserAuthenticator` is also in use.
 
 Before using this credential provider, the following Drill properties should be configured in `drill-override.conf`:
 ```
-"drill.exec.storage.vault.address" - address of the Vault server
-"drill.exec.storage.vault.token" - token used to access Vault
+"drill.exec.storage.vault.address" - host name or address of the Vault server.
+"drill.exec.storage.vault.app_role_id" - the role ID belonging to the AppRole Drill will use
+"drill.exec.storage.vault.secret_id" - the secret ID belonging to the AppRole Drill will use
 ```
+
+Note that you will generally need to create and assign a [Vault policy](https://www.hashicorp.com/resources/policies-vault) to grant the AppRole used by Drill read access to Vault secrets.
 
 Once it is set, we can configure storage plugin to use this way of obtaining credentials:
 ```json
@@ -118,7 +121,7 @@ Once it is set, we can configure storage plugin to use this way of obtaining cre
 }
 ```
 
-`secretPath` property specifies the Vault key value from which to read
+`secretPath` property specifies the Vault key value from which to read. If the plugin's `authMode` is set to `user_translation` then the `secretPath` may include a variable named `$user` which will be replaced with the Drill query username at query execution time.
 `propertyNames` map contains keys that specify which credential will be obtained from the Vault secret with the secret name of the `propertyNames` value.
 
 For example, user may store the following secrets in the Vault:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
@@ -64,22 +64,22 @@ public class PluginConfigWrapper {
   }
 
   @JsonIgnore
-  public String getUserName(String activeUser) {
+  public String getUserName(String queryUser) {
     CredentialsProvider credentialsProvider = config.getCredentialsProvider();
     Optional<UsernamePasswordCredentials> credentials = new UsernamePasswordCredentials.Builder()
       .setCredentialsProvider(credentialsProvider)
-      .setQueryUser(activeUser)
+      .setQueryUser(queryUser)
       .build();
 
     return credentials.map(UsernamePasswordCredentials::getUsername).orElse(null);
   }
 
   @JsonIgnore
-  public String getPassword(String activeUser) {
+  public String getPassword(String queryUser) {
     CredentialsProvider credentialsProvider = config.getCredentialsProvider();
     Optional<UsernamePasswordCredentials> credentials = new UsernamePasswordCredentials.Builder()
       .setCredentialsProvider(credentialsProvider)
-      .setQueryUser(activeUser)
+      .setQueryUser(queryUser)
       .build();
 
     return credentials.map(UsernamePasswordCredentials::getPassword).orElse(null);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/EnvCredentialsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/EnvCredentialsProvider.java
@@ -42,8 +42,12 @@ public class EnvCredentialsProvider implements CredentialsProvider {
   @Override
   public Map<String, String> getCredentials() {
     Map<String, String> credentials = new HashMap<>();
-    envVariables.forEach((key, value) -> credentials.put(key, System.getenv(value)));
-
+    envVariables.forEach((key, value) -> {
+      String cred = System.getenv(value);
+      if (cred != null) {
+        credentials.put(key, cred);
+      }
+    });
     return credentials;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordCredentials.java
@@ -19,15 +19,12 @@ package org.apache.drill.exec.store.security;
 
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.logical.security.CredentialsProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 public class UsernamePasswordCredentials {
-  private static final Logger logger = LoggerFactory.getLogger(UsernamePasswordCredentials.class);
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
 
@@ -58,7 +55,7 @@ public class UsernamePasswordCredentials {
       }
 
       Map<String, String> credentials = queryUser != null
-        ? credentialsProvider.getCredentials(queryUser)
+        ? credentialsProvider.getUserCredentials(queryUser)
         : credentialsProvider.getCredentials();
 
       if (credentials.size() == 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordWithProxyCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/UsernamePasswordWithProxyCredentials.java
@@ -52,7 +52,7 @@ public class UsernamePasswordWithProxyCredentials extends UsernamePasswordCreden
       }
 
       Map<String, String> credentials = queryUser != null
-        ? credentialsProvider.getCredentials(queryUser)
+        ? credentialsProvider.getUserCredentials(queryUser)
         : credentialsProvider.getCredentials();
 
       if (credentials.size() == 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/oauth/OAuthTokenCredentials.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/oauth/OAuthTokenCredentials.java
@@ -70,7 +70,7 @@ public class OAuthTokenCredentials extends UsernamePasswordCredentials {
       }
 
       Map<String, String> credentials = queryUser != null
-        ? credentialsProvider.getCredentials(queryUser)
+        ? credentialsProvider.getUserCredentials(queryUser)
         : credentialsProvider.getCredentials();
 
       if (credentials.size() == 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/vault/VaultCredentialsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/security/vault/VaultCredentialsProvider.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  */
 public class VaultCredentialsProvider implements CredentialsProvider {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(VaultCredentialsProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(VaultCredentialsProvider.class);
   // Drill boot options used to configure a Vault credentials provider
   public static final String VAULT_ADDRESS = "drill.exec.storage.vault.address";
   public static final String VAULT_TOKEN = "drill.exec.storage.vault.token";
@@ -96,7 +96,7 @@ public class VaultCredentialsProvider implements CredentialsProvider {
     } catch (VaultException e) {
       throw UserException.systemError(e)
         .message("Error while fetching credentials from vault")
-        .build(LOGGER);
+        .build(logger);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestVaultUserAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestVaultUserAuthenticator.java
@@ -42,15 +42,15 @@ import static org.junit.Assert.fail;
 @Category(SecurityTest.class)
 public class TestVaultUserAuthenticator extends ClusterTest {
 
-  private static final String ROOT_TOKEN_VALUE = "vault-token";
+  private static final String VAULT_ROOT_TOKEN = "vault-token";
 
   private static String vaultAddr;
 
   @ClassRule
   public static final VaultContainer<?> vaultContainer =
-      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.1.3"))
+      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.10.3"))
           .withLogLevel(VaultLogLevel.Debug)
-          .withVaultToken(ROOT_TOKEN_VALUE)
+          .withVaultToken(VAULT_ROOT_TOKEN)
           .withInitCommand(
             "auth enable userpass",
             "write auth/userpass/users/alice password=pass1 policies=admins",
@@ -93,7 +93,7 @@ public class TestVaultUserAuthenticator extends ClusterTest {
     // Use the Vault client lib to obtain Vault tokens for our test users.
     VaultConfig vaultConfig = new VaultConfig()
       .address(vaultAddr)
-      .token(ROOT_TOKEN_VALUE)
+      .token(VAULT_ROOT_TOKEN)
       .build();
 
     Vault vault = new Vault(vaultConfig);

--- a/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderImplementationsTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderImplementationsTest.java
@@ -17,7 +17,12 @@
  */
 package org.apache.drill.storage;
 
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Logical;
+import com.bettercloud.vault.response.LogicalResponse;
+
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.apache.drill.exec.store.security.EnvCredentialsProvider;
@@ -31,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.vault.VaultContainer;
 
@@ -41,29 +47,61 @@ import static org.junit.Assert.assertEquals;
 
 public class CredentialsProviderImplementationsTest extends ClusterTest {
 
-  private static final String VAULT_TOKEN_VALUE = "vault-token";
+  private static final String VAULT_ROOT_TOKEN = "vault-token";
+  private static final String VAULT_APP_ROLE_PATH = "auth/approle/role/drill-role";
   private static final String SHARED_SECRET_PATH = "secret/testing";
   private static final String USER_SECRET_PATH = "secret/testing/$user";
+  private static final String CONTAINER_POLICY_PATH = "/tmp/read-vault-secrets.hcl";
+  private static String vaultAddr;
 
   @ClassRule
   public static final VaultContainer<?> vaultContainer =
-      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.1.3"))
-          .withVaultToken(VAULT_TOKEN_VALUE)
-          .withSecretInVault(SHARED_SECRET_PATH,
-              "top_secret=password1",
-              "db_password=dbpassword1")
-          .withSecretInVault(USER_SECRET_PATH.replace(VaultCredentialsProvider.QUERY_USER_VAR, "alice"),
-              "top_secret=password1",
-              "db_password=dbpassword1");
+    new VaultContainer<>(DockerImageName.parse("vault").withTag("1.10.3"))
+      .withVaultToken(VAULT_ROOT_TOKEN)
+      .withSecretInVault(SHARED_SECRET_PATH,
+          "top_secret=password1",
+          "db_password=dbpassword1")
+      .withSecretInVault(USER_SECRET_PATH.replace(VaultCredentialsProvider.QUERY_USER_VAR, "alice"),
+          "top_secret=password1",
+          "db_password=dbpassword1")
+      .withClasspathResourceMapping("vault/read-vault-secrets.hcl", CONTAINER_POLICY_PATH, BindMode.READ_ONLY)
+      .withInitCommand(
+        "auth enable approle",
+        String.format("policy write read-secrets %s", CONTAINER_POLICY_PATH),
+        String.format("write %s policies=read-secrets", VAULT_APP_ROLE_PATH)
+      );
 
   @BeforeClass
   public static void init() throws Exception {
+    vaultAddr = String.format(
+      "http://%s:%d",
+      vaultContainer.getHost(),
+      vaultContainer.getFirstMappedPort()
+    );
+
+    VaultConfig vaultConfig = new VaultConfig()
+      .address(vaultAddr)
+      .token(VAULT_ROOT_TOKEN)
+      .build();
+
+    // While other Vault paths in the test container seem to work fine with KV engine v2,
+    // the AppRole paths produced 404s and forced the specification of version 1 in the
+    // BetterCloud client used to perform AppRole operations.
+    Vault vault = new Vault(vaultConfig, 1);
+    LogicalResponse resp = vault.logical()
+      .read(String.format("%s/role-id", VAULT_APP_ROLE_PATH));
+		String appRoleId = resp.getData().get("role_id");
+
+    resp = vault.logical().write(
+      String.format("%s/secret-id", VAULT_APP_ROLE_PATH),
+      Collections.emptyMap()
+    );
+    String secretId = resp.getData().get("secret_id");
+
     startCluster(ClusterFixture.builder(dirTestWatcher)
-      .configProperty(
-        VaultCredentialsProvider.VAULT_ADDRESS,
-        "http://" + vaultContainer.getHost() + ":" + vaultContainer.getFirstMappedPort()
-      )
-      .configProperty(VaultCredentialsProvider.VAULT_TOKEN, VAULT_TOKEN_VALUE)
+      .configProperty(VaultCredentialsProvider.VAULT_ADDRESS, vaultAddr)
+      .configProperty(VaultCredentialsProvider.VAULT_APP_ROLE_ID, appRoleId)
+      .configProperty(VaultCredentialsProvider.VAULT_SECRET_ID, secretId)
     );
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderImplementationsTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderImplementationsTest.java
@@ -20,7 +20,6 @@ package org.apache.drill.storage;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
-import com.bettercloud.vault.api.Logical;
 import com.bettercloud.vault.response.LogicalResponse;
 
 import org.apache.drill.common.config.DrillConfig;
@@ -52,7 +51,6 @@ public class CredentialsProviderImplementationsTest extends ClusterTest {
   private static final String SHARED_SECRET_PATH = "secret/testing";
   private static final String USER_SECRET_PATH = "secret/testing/$user";
   private static final String CONTAINER_POLICY_PATH = "/tmp/read-vault-secrets.hcl";
-  private static String vaultAddr;
 
   @ClassRule
   public static final VaultContainer<?> vaultContainer =
@@ -73,7 +71,7 @@ public class CredentialsProviderImplementationsTest extends ClusterTest {
 
   @BeforeClass
   public static void init() throws Exception {
-    vaultAddr = String.format(
+    String vaultAddr = String.format(
       "http://%s:%d",
       vaultContainer.getHost(),
       vaultContainer.getFirstMappedPort()
@@ -88,9 +86,10 @@ public class CredentialsProviderImplementationsTest extends ClusterTest {
     // the AppRole paths produced 404s and forced the specification of version 1 in the
     // BetterCloud client used to perform AppRole operations.
     Vault vault = new Vault(vaultConfig, 1);
+
     LogicalResponse resp = vault.logical()
       .read(String.format("%s/role-id", VAULT_APP_ROLE_PATH));
-		String appRoleId = resp.getData().get("role_id");
+    String appRoleId = resp.getData().get("role_id");
 
     resp = vault.logical().write(
       String.format("%s/secret-id", VAULT_APP_ROLE_PATH),

--- a/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderSerDeTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderSerDeTest.java
@@ -40,23 +40,16 @@ import static org.junit.Assert.assertEquals;
 
 public class CredentialsProviderSerDeTest extends ClusterTest {
 
-  private static final String VAULT_TOKEN_VALUE = "vault-token";
-
   private static final String SECRET_PATH = "secret/testing";
-
-  @ClassRule
-  public static final VaultContainer<?> vaultContainer =
-      new VaultContainer<>(DockerImageName.parse("vault").withTag("1.1.3"))
-          .withVaultToken(VAULT_TOKEN_VALUE)
-          .withSecretInVault(SECRET_PATH,
-              "top_secret=password1",
-              "db_password=dbpassword1");
 
   @BeforeClass
   public static void init() throws Exception {
     startCluster(ClusterFixture.builder(dirTestWatcher)
-        .configProperty(VaultCredentialsProvider.VAULT_ADDRESS, "http://" + vaultContainer.getHost() + ":" + vaultContainer.getFirstMappedPort())
-        .configProperty(VaultCredentialsProvider.VAULT_TOKEN, VAULT_TOKEN_VALUE));
+      // Bogus Vault server values are sufficient for the tests in this class.
+      .configProperty(VaultCredentialsProvider.VAULT_ADDRESS, "foo")
+      .configProperty(VaultCredentialsProvider.VAULT_APP_ROLE_ID, "foo")
+      .configProperty(VaultCredentialsProvider.VAULT_SECRET_ID, "foo")
+    );
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderSerDeTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/storage/CredentialsProviderSerDeTest.java
@@ -31,10 +31,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.vault.VaultContainer;
 
 import static org.junit.Assert.assertEquals;
 

--- a/exec/java-exec/src/test/resources/vault/read-vault-secrets.hcl
+++ b/exec/java-exec/src/test/resources/vault/read-vault-secrets.hcl
@@ -1,0 +1,4 @@
+path "secret/*"
+{
+  capabilities = ["read"]
+}

--- a/exec/java-exec/src/test/resources/vault/read-vault-secrets.hcl
+++ b/exec/java-exec/src/test/resources/vault/read-vault-secrets.hcl
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 path "secret/*"
 {
   capabilities = ["read"]

--- a/logical/src/main/java/org/apache/drill/common/logical/security/CredentialsProvider.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/security/CredentialsProvider.java
@@ -46,7 +46,7 @@ public interface CredentialsProvider {
    * @return A Map of the logged in user's credentials.
    */
   @JsonIgnore
-  default Map<String, String> getCredentials(String username) {
+  default Map<String, String> getUserCredentials(String username) {
     throw UserException.unsupportedError()
       .message("%s does not support per-user credentials.", getClass())
       .build(logger);

--- a/logical/src/main/java/org/apache/drill/common/logical/security/PlainCredentialsProvider.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/security/PlainCredentialsProvider.java
@@ -68,7 +68,8 @@ public class PlainCredentialsProvider implements CredentialsProvider {
 
   @Override
   @JsonIgnore(false)
-  @JsonProperty("credentials") public Map<String, String> getCredentials() {
+  @JsonProperty("credentials")
+  public Map<String, String> getCredentials() {
     return credentials;
   }
 
@@ -85,7 +86,7 @@ public class PlainCredentialsProvider implements CredentialsProvider {
    * @return A Map of the active user's credentials
    */
   @Override
-  public Map<String, String> getCredentials(String queryUser) {
+  public Map<String, String> getUserCredentials(String queryUser) {
     assert queryUser != null;
     logger.debug("Getting credentials for query user {}", queryUser);
 


### PR DESCRIPTION
# [DRILL-8232](https://issues.apache.org/jira/browse/DRILL-8232): Add support for user credentials to VaultCredentialsProvider

## Description

The VaultCredentialsProvider can join the PlainCredentialsProvider in supporting user credentials, credentials that stored for each each Drill query user and which are needed for the user_translation auth mode, by constructing a Vault secret path dynamically based on the name of the query user. A variable named `$user` in the VaultCredentialsProvider's `secretPath` is replaced with the query user's name at query time.

## Documentation
To be added once the new auth mode implementation has stabilised.

## Testing
CredentialsProviderImplementationsTest::testVaultUserCredentialsPresent
CredentialsProviderImplementationsTest::testVaultUserCredentialsAbsent
