### PR TITLE
DRILL-8223: Change JDK 17 Docker base image from Oracle Linux to Debian.

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -32,6 +32,6 @@ docker build \
 
 docker build \
 	--build-arg BUILD_BASE_IMAGE=maven:3-openjdk-17 \
-	--build-arg BASE_IMAGE=openjdk:17 \
+	--build-arg BASE_IMAGE=openjdk:17-slim-bullseye \
 	-t apache/drill:$DOCKER_TAG-openjdk-17 \
 	.


### PR DESCRIPTION
# [DRILL-8223](https://issues.apache.org/jira/browse/DRILL-8223): Change JDK 17 Docker base image from Oracle Linux to Debian.

## Description0

The change is made in order to remain consistent with the OS in Drill's base images for JDK 8 and 11 since users may have derived from the Drill Dockerfile or written other scripts that assume a Debian-like OS inside the Docker image.

## Documentation
No changes.

## Testing
Build a Docker image using the new base image in this PR, then start it and run some queries.  
