### PR TITLE
DRILL-8234: Register rules only from plugins used in the query

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -104,7 +104,7 @@ public class DynamicRootSchema extends DynamicSchema {
   private void loadSchemaFactory(String schemaName, boolean caseSensitive) {
     try {
       SchemaPlus schemaPlus = this.plus();
-      StoragePlugin plugin = storages.getPlugin(schemaName);
+      StoragePlugin plugin = getPlugin(schemaName);
       if (plugin != null) {
         plugin.registerSchemas(schemaConfig, schemaPlus);
         return;
@@ -113,7 +113,7 @@ public class DynamicRootSchema extends DynamicSchema {
       // Could not find the plugin of schemaName. The schemaName could be `dfs.tmp`, a 2nd level schema under 'dfs'
       List<String> paths = SchemaUtilites.getSchemaPathAsList(schemaName);
       if (paths.size() == 2) {
-        plugin = storages.getPlugin(paths.get(0));
+        plugin = getPlugin(paths.get(0));
         if (plugin == null) {
           return;
         }
@@ -155,9 +155,13 @@ public class DynamicRootSchema extends DynamicSchema {
     }
   }
 
+  public StoragePlugin getPlugin(String schemaName) throws PluginException {
+    return storages.getPlugin(schemaName);
+  }
+
   public static class RootSchema extends AbstractSchema {
 
-    private StoragePluginRegistry storages;
+    private final StoragePluginRegistry storages;
 
     public RootSchema(StoragePluginRegistry storages) {
       super(Collections.emptyList(), ROOT_SCHEMA_NAME);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.common.util.GuavaUtils;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 import org.apache.calcite.prepare.RelOptTableImpl;
@@ -252,7 +251,7 @@ public class FileSystemPartitionDescriptor extends AbstractPartitionDescriptor {
       DrillTranslatableTable newTable = new DrillTranslatableTable(dynamicDrillTable);
 
       RelOptTableImpl newOptTableImpl = RelOptTableImpl.create(relOptTable.getRelOptSchema(), relOptTable.getRowType(),
-          newTable, GuavaUtils.convertToUnshadedImmutableList(ImmutableList.of()));
+          newTable, GuavaUtils.convertToUnshadedImmutableList(relOptTable.getQualifiedName()));
 
       // return an DirPrunedTableScan with fileSelection being part of digest of TableScan node.
       return DirPrunedTableScan.create(scanRel.getCluster(), newOptTableImpl, newFileSelection.toString());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -364,7 +364,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
   protected RelNode transform(PlannerType plannerType, PlannerPhase phase, RelNode input, RelTraitSet targetTraits,
       boolean log) {
     final Stopwatch watch = Stopwatch.createStarted();
-    final RuleSet rules = config.getRules(phase);
+    final RuleSet rules = config.getRules(phase, input);
     final RelTraitSet toTraits = targetTraits.simplify();
 
     final RelNode output;


### PR DESCRIPTION
# [DRILL-8234](https://issues.apache.org/jira/browse/DRILL-8234): Register rules only from plugins used in the query

## Description
* Added visitor for collecting plugins used in the query
* Fixed passing table names into RelOptTable
* Added method for containing plugins from DynamicRootSchema

## Documentation
NA

## Testing
Unit tests pass
