### PR TITLE
DRILL-8237: Limit is not pushed down to scan for MSSQL

### DIFF
--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMSSQL.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMSSQL.java
@@ -32,7 +32,6 @@ import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.MSSQLServerContainer;
@@ -50,7 +49,7 @@ import static org.junit.Assert.assertEquals;
 @Category(JdbcStorageTest.class)
 public class TestJdbcPluginWithMSSQL extends ClusterTest {
 
-  private static MSSQLServerContainer jdbcContainer;
+  private static MSSQLServerContainer<?> jdbcContainer;
 
   @BeforeClass
   public static void initMSSQL() throws Exception {
@@ -317,8 +316,6 @@ public class TestJdbcPluginWithMSSQL extends ClusterTest {
   }
 
   @Test
-  @Ignore
-  // TODO: Enable once the push down logic has been clarified.
   public void testLimitPushDownWithOffset() throws Exception {
     String query = "select person_id, first_name from mssql.dbo.person limit 100 offset 10";
     queryBuilder()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcSort.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcSort.java
@@ -42,7 +42,8 @@ public class DrillJdbcSort extends JdbcRules.JdbcSort {
       double numRows = mq.getRowCount(this);
       double cpuCost = DrillCostBase.COMPARE_CPU_COST * numRows;
       DrillCostBase.DrillCostFactory costFactory = (DrillCostBase.DrillCostFactory) planner.getCostFactory();
-      return costFactory.makeCost(numRows, cpuCost, 0, 0);
+      // adjust cost to handle the case when the original limit was split
+      return costFactory.makeCost(numRows, cpuCost, 0, 0).multiplyBy(0.1);
     }
     return super.computeSelfCost(planner, mq);
   }


### PR DESCRIPTION
# [DRILL-8237](https://issues.apache.org/jira/browse/DRILL-8237): Limit is not pushed down to scan for MSSQL

## Description
Adjusted the cost of `DrillJdbcSort` to handle the case when the original limit was split

## Documentation
NA

## Testing
All unit tests passed, enabled disabled test which is fixed with these changes.
