### PR TITLE
DRILL-8113: Support building with a JDK 8 target using newer JDKs

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/SpnegoConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/SpnegoConfig.java
@@ -26,12 +26,12 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 public class SpnegoConfig {
 
+  // Standard Object Identifier for the SPNEGO GSS-API mechanism.
+  public static final String GSS_SPNEGO_MECH_OID = "1.3.6.1.5.5.2";
+
   private UserGroupInformation loggedInUgi;
-
   private final String principal;
-
   private final String keytab;
-
   // Optional parameter
   private final String clientNameMapping;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
@@ -117,7 +117,10 @@ public class TestBitBitKerberos extends BaseTestQuery {
     // initialization which causes the tests to fail. So the following two changes are required.
 
     // (1) Refresh Kerberos config.
-    sun.security.krb5.Config.refresh();
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
+
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
     defaultRealm.setAccessible(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
@@ -34,6 +34,7 @@ import org.apache.drill.test.ClusterTest;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -124,6 +125,7 @@ public class TestUserBitKerberos extends ClusterTest {
    }
 
   @Test
+  @Ignore("See DRILL-5387. This test works in isolation but not when sharing counters with other tests")
   public void testUnencryptedConnectionCounter() throws Exception {
     Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
       krbHelper.CLIENT_PRINCIPAL,
@@ -165,6 +167,7 @@ public class TestUserBitKerberos extends ClusterTest {
   }
 
   @Test
+  @Ignore("See DRILL-5387. This test works in isolation but not when sharing counters with other tests")
   public void testUnencryptedConnectionCounter_LocalControlMessage() throws Exception {
     Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
       krbHelper.CLIENT_PRINCIPAL,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
@@ -21,6 +21,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.categories.SecurityTest;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.rpc.RpcMetrics;
 import org.apache.drill.exec.rpc.control.ControlRpcMetrics;
 import org.apache.drill.exec.rpc.data.DataRpcMetrics;
 import org.apache.drill.exec.rpc.security.KerberosHelper;
@@ -28,6 +29,7 @@ import org.apache.drill.exec.rpc.user.UserRpcMetrics;
 import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
@@ -47,20 +49,19 @@ public class TestUserBitKerberos extends ClusterTest {
 
   @BeforeClass
   public static void setupTest() throws Exception {
-
     krbHelper = new KerberosHelper(TestUserBitKerberos.class.getSimpleName(), null);
     krbHelper.setupKdc(dirTestWatcher.getTmpDir());
+    cluster = defaultClusterConfig().build();
+  }
 
-    // Create a new DrillConfig which has user authentication enabled and authenticator set to
-    // UserAuthenticatorTestImpl.
-    cluster = ClusterFixture.bareBuilder(dirTestWatcher)
+  private static ClusterFixtureBuilder defaultClusterConfig() {
+    return ClusterFixture.bareBuilder(dirTestWatcher)
       .clusterSize(1)
       .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
       .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
       .configProperty(ExecConstants.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
       .configProperty(ExecConstants.SERVICE_KEYTAB_LOCATION, krbHelper.serverKeytab.toString())
-      .configNonStringProperty(ExecConstants.AUTHENTICATION_MECHANISMS, Lists.newArrayList("plain", "kerberos"))
-      .build();
+      .configNonStringProperty(ExecConstants.AUTHENTICATION_MECHANISMS, Lists.newArrayList("plain", "kerberos"));
   }
 
   @Test
@@ -130,6 +131,8 @@ public class TestUserBitKerberos extends ClusterTest {
     );
 
     try (
+      // Use a dedicated cluster fixture so that the tested RPC counters have a clean start.
+      ClusterFixture cluster = defaultClusterConfig().build();
       ClientFixture client = Subject.doAs(
         clientSubject,
         (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
@@ -145,15 +148,19 @@ public class TestUserBitKerberos extends ClusterTest {
           .baselineValues(krbHelper.CLIENT_SHORT_NAME)
           .go();
 
+      RpcMetrics userMetrics = UserRpcMetrics.getInstance(),
+        ctrlMetrics = ControlRpcMetrics.getInstance(),
+        dataMetrics = DataRpcMetrics.getInstance();
+
       // Check encrypted counters value
-      assertEquals(0, UserRpcMetrics.getInstance().getEncryptedConnectionCount());
-      assertEquals(0, ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
-      assertEquals(0, DataRpcMetrics.getInstance().getEncryptedConnectionCount());
+      assertEquals(0, userMetrics.getEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getEncryptedConnectionCount());
+      assertEquals(0, dataMetrics.getEncryptedConnectionCount());
 
       // Check unencrypted counters value
-      assertEquals(1, UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-      assertEquals(0, ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-      assertEquals(2, DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      assertEquals(1, userMetrics.getUnEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getUnEncryptedConnectionCount());
+      assertEquals(0, dataMetrics.getUnEncryptedConnectionCount());
     }
   }
 
@@ -165,6 +172,8 @@ public class TestUserBitKerberos extends ClusterTest {
     );
 
     try (
+      // Use a dedicated cluster fixture so that the tested RPC counters have a clean start.
+      ClusterFixture cluster = defaultClusterConfig().build();
       ClientFixture client = Subject.doAs(
         clientSubject,
         (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
@@ -178,15 +187,19 @@ public class TestUserBitKerberos extends ClusterTest {
       // local data connections
       client.runSqlSilently("SELECT * FROM sys.memory");
 
+      RpcMetrics userMetrics = UserRpcMetrics.getInstance(),
+        ctrlMetrics = ControlRpcMetrics.getInstance(),
+        dataMetrics = DataRpcMetrics.getInstance();
+
       // Check encrypted counters value
-      assertEquals(0, UserRpcMetrics.getInstance().getEncryptedConnectionCount());
-      assertEquals(0, ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
-      assertEquals(0, DataRpcMetrics.getInstance().getEncryptedConnectionCount());
+      assertEquals(0, userMetrics.getEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getEncryptedConnectionCount());
+      assertEquals(0, dataMetrics.getEncryptedConnectionCount());
 
       // Check unencrypted counters value
-      assertEquals(1, UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-      assertEquals(0, ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-      assertEquals(2, DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      assertEquals(1, userMetrics.getUnEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getUnEncryptedConnectionCount());
+      assertEquals(2, dataMetrics.getUnEncryptedConnectionCount());
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
@@ -18,9 +18,7 @@
 package org.apache.drill.exec.rpc.user.security;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import com.typesafe.config.ConfigValueFactory;
 import org.apache.drill.categories.SecurityTest;
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.rpc.control.ControlRpcMetrics;
@@ -28,9 +26,9 @@ import org.apache.drill.exec.rpc.data.DataRpcMetrics;
 import org.apache.drill.exec.rpc.security.KerberosHelper;
 import org.apache.drill.exec.rpc.user.UserRpcMetrics;
 import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.hadoop.security.authentication.util.KerberosName;
-import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -38,15 +36,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import javax.security.auth.Subject;
-import java.lang.reflect.Field;
 import java.security.PrivilegedExceptionAction;
-import java.util.Properties;
 
-import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertEquals;
 
 @Category(SecurityTest.class)
-public class TestUserBitKerberos extends BaseTestQuery {
-  //private static final org.slf4j.Logger logger =org.slf4j.LoggerFactory.getLogger(TestUserBitKerberos.class);
+public class TestUserBitKerberos extends ClusterTest {
 
   private static KerberosHelper krbHelper;
 
@@ -58,157 +53,141 @@ public class TestUserBitKerberos extends BaseTestQuery {
 
     // Create a new DrillConfig which has user authentication enabled and authenticator set to
     // UserAuthenticatorTestImpl.
-    final DrillConfig newConfig = new DrillConfig(DrillConfig.create(cloneDefaultTestConfigProperties())
-      .withValue(ExecConstants.USER_AUTHENTICATION_ENABLED,
-        ConfigValueFactory.fromAnyRef(true))
-      .withValue(ExecConstants.USER_AUTHENTICATOR_IMPL,
-        ConfigValueFactory.fromAnyRef(UserAuthenticatorTestImpl.TYPE))
-      .withValue(ExecConstants.SERVICE_PRINCIPAL,
-        ConfigValueFactory.fromAnyRef(krbHelper.SERVER_PRINCIPAL))
-      .withValue(ExecConstants.SERVICE_KEYTAB_LOCATION,
-        ConfigValueFactory.fromAnyRef(krbHelper.serverKeytab.toString()))
-      .withValue(ExecConstants.AUTHENTICATION_MECHANISMS,
-        ConfigValueFactory.fromIterable(Lists.newArrayList("plain", "kerberos"))));
-
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.USER, "anonymous");
-    connectionProps.setProperty(DrillProperties.PASSWORD, "anything works!");
-
-    // Ignore the compile time warning caused by the code below.
-
-    // Config is statically initialized at this point. But the above configuration results in a different
-    // initialization which causes the tests to fail. So the following two changes are required.
-
-    // (1) Refresh Kerberos config.
-    // This disabled call to an unsupported internal API does not appear to be
-    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
-    // sun.security.krb5.Config.refresh();
-
-    // (2) Reset the default realm.
-    final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
-    defaultRealm.setAccessible(true);
-    defaultRealm.set(null, KerberosUtil.getDefaultRealm());
-
-    updateTestCluster(1, newConfig, connectionProps);
+    cluster = ClusterFixture.bareBuilder(dirTestWatcher)
+      .clusterSize(1)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .configProperty(ExecConstants.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+      .configProperty(ExecConstants.SERVICE_KEYTAB_LOCATION, krbHelper.serverKeytab.toString())
+      .configNonStringProperty(ExecConstants.AUTHENTICATION_MECHANISMS, Lists.newArrayList("plain", "kerberos"))
+      .build();
   }
 
   @Test
   public void successKeytab() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.USER, krbHelper.CLIENT_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KEYTAB, krbHelper.clientKeytab.getAbsolutePath());
-    updateClient(connectionProps);
+    try (
+      ClientFixture client = cluster.clientBuilder()
+      .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+      .property(DrillProperties.USER, krbHelper.CLIENT_PRINCIPAL)
+      .property(DrillProperties.KEYTAB, krbHelper.clientKeytab.getAbsolutePath())
+      .build()
+    ) {
 
-    // Run few queries using the new client
-    testBuilder()
+      // Run few queries using the new client
+      client.testBuilder()
         .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
         .unOrdered()
         .baselineColumns("session_user")
         .baselineValues(krbHelper.CLIENT_SHORT_NAME)
         .go();
-    test("SHOW SCHEMAS");
-    test("USE INFORMATION_SCHEMA");
-    test("SHOW TABLES");
-    test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
-    test("SELECT * FROM cp.`region.json` LIMIT 5");
+
+      client.runSqlSilently("SHOW SCHEMAS");
+      client.runSqlSilently("USE INFORMATION_SCHEMA");
+      client.runSqlSilently("SHOW TABLES");
+      client.runSqlSilently("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
+      client.runSqlSilently("SELECT * FROM cp.`region.json` LIMIT 5");
+    }
   }
 
   @Test
   public void successTicket() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KERBEROS_FROM_SUBJECT, "true");
-    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(krbHelper.CLIENT_PRINCIPAL,
-      krbHelper.clientKeytab.getAbsoluteFile());
+    Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
+      krbHelper.CLIENT_PRINCIPAL,
+      krbHelper.clientKeytab.getAbsoluteFile()
+    );
 
-    Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        updateClient(connectionProps);
-        return null;
-      }
-    });
+    try (
+      ClientFixture client = Subject.doAs(
+        clientSubject,
+        (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
+          .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+          .property(DrillProperties.KERBEROS_FROM_SUBJECT, "true")
+          .build()
+      )
+    ) {
 
     // Run few queries using the new client
-    testBuilder()
-        .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
-        .unOrdered()
-        .baselineColumns("session_user")
-        .baselineValues(krbHelper.CLIENT_SHORT_NAME)
-        .go();
-    test("SHOW SCHEMAS");
-    test("USE INFORMATION_SCHEMA");
-    test("SHOW TABLES");
-    test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
-    test("SELECT * FROM cp.`region.json` LIMIT 5");
+    client.testBuilder()
+      .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
+      .unOrdered()
+      .baselineColumns("session_user")
+      .baselineValues(krbHelper.CLIENT_SHORT_NAME)
+      .go();
+
+    client.runSqlSilently("SHOW SCHEMAS");
+    client.runSqlSilently("USE INFORMATION_SCHEMA");
+    client.runSqlSilently("SHOW TABLES");
+    client.runSqlSilently("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
+    client.runSqlSilently("SELECT * FROM cp.`region.json` LIMIT 5");
+    }
+   }
+
+  @Test
+  public void testUnencryptedConnectionCounter() throws Exception {
+    Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
+      krbHelper.CLIENT_PRINCIPAL,
+      krbHelper.clientKeytab.getAbsoluteFile()
+    );
+
+    try (
+      ClientFixture client = Subject.doAs(
+        clientSubject,
+        (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
+          .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+          .property(DrillProperties.KERBEROS_FROM_SUBJECT, "true")
+          .build()
+      )
+    ) {
+      client.testBuilder()
+          .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
+          .unOrdered()
+          .baselineColumns("session_user")
+          .baselineValues(krbHelper.CLIENT_SHORT_NAME)
+          .go();
+
+      // Check encrypted counters value
+      assertEquals(0, UserRpcMetrics.getInstance().getEncryptedConnectionCount());
+      assertEquals(0, ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
+      assertEquals(0, DataRpcMetrics.getInstance().getEncryptedConnectionCount());
+
+      // Check unencrypted counters value
+      assertEquals(1, UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      assertEquals(0, ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      assertEquals(2, DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+    }
   }
 
   @Test
-  public void testUnecryptedConnectionCounter() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KERBEROS_FROM_SUBJECT, "true");
-    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(krbHelper.CLIENT_PRINCIPAL,
-        krbHelper.clientKeytab.getAbsoluteFile());
+  public void testUnencryptedConnectionCounter_LocalControlMessage() throws Exception {
+    Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
+      krbHelper.CLIENT_PRINCIPAL,
+      krbHelper.clientKeytab.getAbsoluteFile()
+    );
 
-    Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        updateClient(connectionProps);
-        return null;
-      }
-    });
+    try (
+      ClientFixture client = Subject.doAs(
+        clientSubject,
+        (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
+          .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+          .property(DrillProperties.KERBEROS_FROM_SUBJECT, "true")
+          .build()
+      )
+     ) {
+      // Run query on memory system table this sends remote fragments to all Drillbit and Drillbits then send data
+      // using data channel. In this test we have only 1 Drillbit so there should not be any control connection but a
+      // local data connections
+      client.runSqlSilently("SELECT * FROM sys.memory");
 
-    // Run few queries using the new client
-    testBuilder()
-        .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
-        .unOrdered()
-        .baselineColumns("session_user")
-        .baselineValues(krbHelper.CLIENT_SHORT_NAME)
-        .go();
+      // Check encrypted counters value
+      assertEquals(0, UserRpcMetrics.getInstance().getEncryptedConnectionCount());
+      assertEquals(0, ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
+      assertEquals(0, DataRpcMetrics.getInstance().getEncryptedConnectionCount());
 
-    // Check encrypted counters value
-    assertTrue(0 == UserRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == DataRpcMetrics.getInstance().getEncryptedConnectionCount());
-
-    // Check unencrypted counters value
-    assertTrue(1 == UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(0 == DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-  }
-
-  @Test
-  public void testUnecryptedConnectionCounter_LocalControlMessage() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KERBEROS_FROM_SUBJECT, "true");
-    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(krbHelper.CLIENT_PRINCIPAL,
-      krbHelper.clientKeytab.getAbsoluteFile());
-
-    Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        updateClient(connectionProps);
-        return null;
-      }
-    });
-
-    // Run query on memory system table this sends remote fragments to all Drillbit and Drillbits then send data
-    // using data channel. In this test we have only 1 Drillbit so there should not be any control connection but a
-    // local data connections
-    testSql("SELECT * FROM sys.memory");
-
-    // Check encrypted counters value
-    assertTrue(0 == UserRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == DataRpcMetrics.getInstance().getEncryptedConnectionCount());
-
-    // Check unencrypted counters value
-    assertTrue(1 == UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(2 == DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      // Check unencrypted counters value
+      assertEquals(1, UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      assertEquals(0, ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      assertEquals(2, DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+    }
   }
 
   @AfterClass

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -45,7 +44,6 @@ import java.util.Properties;
 
 import static junit.framework.TestCase.assertTrue;
 
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestUserBitKerberos extends BaseTestQuery {
   //private static final org.slf4j.Logger logger =org.slf4j.LoggerFactory.getLogger(TestUserBitKerberos.class);
@@ -82,7 +80,10 @@ public class TestUserBitKerberos extends BaseTestQuery {
     // initialization which causes the tests to fail. So the following two changes are required.
 
     // (1) Refresh Kerberos config.
-    sun.security.krb5.Config.refresh();
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
+
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
     defaultRealm.setAccessible(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberosEncryption.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberosEncryption.java
@@ -36,6 +36,7 @@ import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -113,6 +114,7 @@ public class TestUserBitKerberosEncryption extends ClusterTest {
    * @throws Exception
    */
   @Test
+  @Ignore("See DRILL-5387. This test works in isolation but not when sharing counters with other tests")
   public void testConnectionCounters() throws Exception {
     try (
       // Use a dedicated cluster fixture so that the tested RPC counters have a clean start.
@@ -315,6 +317,7 @@ public class TestUserBitKerberosEncryption extends ClusterTest {
    */
 
   @Test
+  @Ignore("See DRILL-5387. This test works in isolation but not when sharing counters with other tests")
   public void testEncryptedConnectionCountersAllChannel() throws Exception {
     try (
       // Use a dedicated cluster fixture so that the tested RPC counters have a clean start.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberosEncryption.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberosEncryption.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,7 +47,6 @@ import java.util.Properties;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestUserBitKerberosEncryption extends BaseTestQuery {
   private static final org.slf4j.Logger logger =
@@ -89,7 +87,10 @@ public class TestUserBitKerberosEncryption extends BaseTestQuery {
     // initialization which causes the tests to fail. So the following two changes are required.
 
     // (1) Refresh Kerberos config.
-    sun.security.krb5.Config.refresh();
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
+
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
     defaultRealm.setAccessible(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -29,6 +29,7 @@ import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.WebServerConstants;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoAuthenticator;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoLoginService;
+import org.apache.drill.exec.server.rest.auth.SpnegoConfig;
 import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.security.authentication.util.KerberosName;
@@ -50,7 +51,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import sun.security.jgss.GSSUtil;
 
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
@@ -83,8 +83,10 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
     spnegoHelper = new KerberosHelper(TestSpnegoAuthentication.class.getSimpleName(), primaryName);
     spnegoHelper.setupKdc(dirTestWatcher.getTmpDir());
 
-
-    sun.security.krb5.Config.refresh();
+    // (1) Refresh Kerberos config.
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
 
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
@@ -242,7 +244,7 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
       final GSSManager gssManager = GSSManager.getInstance();
       GSSContext gssContext = null;
       try {
-        final Oid oid = GSSUtil.GSS_SPNEGO_MECH_OID;
+        final Oid oid = new Oid(SpnegoConfig.GSS_SPNEGO_MECH_OID);
         final GSSName serviceName = gssManager.createName(spnegoHelper.SERVER_PRINCIPAL, GSSName.NT_USER_NAME, oid);
 
         gssContext = gssManager.createContext(serviceName, oid, null, GSSContext.DEFAULT_LIFETIME);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -67,7 +67,6 @@ import static org.mockito.Mockito.verify;
 /**
  * Test for validating {@link DrillSpnegoAuthenticator}
  */
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestDrillSpnegoAuthenticator extends BaseTest {
 
@@ -203,6 +202,7 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
    * {@link DrillSpnegoAuthenticator#validateRequest(javax.servlet.ServletRequest, javax.servlet.ServletResponse, boolean)}
    */
   @Test
+  @Ignore("See DRILL-5387")
   public void testAuthClientRequestForLogOut() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
@@ -64,7 +64,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for validating {@link DrillSpnegoLoginService}
  */
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestSpnegoAuthentication extends BaseTest {
 
@@ -246,6 +245,7 @@ public class TestSpnegoAuthentication extends BaseTest {
    * when provided with client token for a configured service principal.
    */
   @Test
+  @Ignore("See DRILL-5387")
   public void testDrillSpnegoLoginService() throws Exception {
 
     // Create client subject using it's principal and keytab

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.auth.DrillHttpSecurityHandlerProvider;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoLoginService;
+import org.apache.drill.exec.server.rest.auth.SpnegoConfig;
 import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.security.authentication.util.KerberosName;
@@ -50,7 +51,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import sun.security.jgss.GSSUtil;
 
 import javax.security.auth.Subject;
 import java.lang.reflect.Field;
@@ -78,8 +78,10 @@ public class TestSpnegoAuthentication extends BaseTest {
     spnegoHelper = new KerberosHelper(TestSpnegoAuthentication.class.getSimpleName(), primaryName);
     spnegoHelper.setupKdc(dirTestWatcher.getTmpDir());
 
-
-    sun.security.krb5.Config.refresh();
+    // (1) Refresh Kerberos config.
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
 
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
@@ -260,7 +262,7 @@ public class TestSpnegoAuthentication extends BaseTest {
         final GSSManager gssManager = GSSManager.getInstance();
         GSSContext gssContext = null;
         try {
-          final Oid oid = GSSUtil.GSS_SPNEGO_MECH_OID;
+          final Oid oid = new Oid(SpnegoConfig.GSS_SPNEGO_MECH_OID);
           final GSSName serviceName = gssManager.createName(spnegoHelper.SERVER_PRINCIPAL, GSSName.NT_USER_NAME, oid);
 
           gssContext = gssManager.createContext(serviceName, oid, null, GSSContext.DEFAULT_LIFETIME);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoConfig.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -46,11 +45,8 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for validating {@link SpnegoConfig}
  */
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestSpnegoConfig extends BaseTest {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSpnegoConfig.class);
-
   private static KerberosHelper spnegoHelper;
 
   private static final String primaryName = "HTTP";
@@ -62,8 +58,10 @@ public class TestSpnegoConfig extends BaseTest {
     spnegoHelper = new KerberosHelper(TestSpnegoAuthentication.class.getSimpleName(), primaryName);
     spnegoHelper.setupKdc(dirTestWatcher.getTmpDir());
 
-
-    sun.security.krb5.Config.refresh();
+    // (1) Refresh Kerberos config.
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
 
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");

--- a/pom.xml
+++ b/pom.xml
@@ -3988,13 +3988,13 @@
         <jdk>[9,)</jdk>
       </activation>
       <properties>
+        <maven.compiler.release>8</maven.compiler.release>
         <junit.args>
           --add-opens=java.base/java.lang=ALL-UNNAMED
           --add-opens java.base/java.net=ALL-UNNAMED
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens=java.base/java.util=ALL-UNNAMED
           --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-          --add-opens java.security.jgss/sun.security.krb5=ALL-UNNAMED
         </junit.args>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -3995,6 +3995,7 @@
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens=java.base/java.util=ALL-UNNAMED
           --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+          --add-opens java.security.jgss/sun.security.krb5=ALL-UNNAMED
         </junit.args>
       </properties>
     </profile>


### PR DESCRIPTION
# [DRILL-8113](https://issues.apache.org/jira/browse/DRILL-8113): Support building with a JDK 8 target using newer JDKs

## Description

- Add the `maven.compiler.release` property to the jdk9+ profile, solving API errors like the missing `ByteBuffer` methods which are not covered by `maven.compiler.source` and `maven.compiler.target`.
- Remove calls to unsupported internal sun.security.* APIs that were blocking the use of `maven.compiler.release` for JDK 9+.
- Enable some Kerberos tests that were disabled but do work (partially resolves [DRILL-8036](https://issues.apache.org/jira/browse/DRILL-8036)).

## Documentation
N/A

## Testing
Test building in JDK 8 and running in 8.
Test building in JDK 8 and running in 11.
Test building in JDK 11 and running in 8.
Test building in JDK 11 and running in 11.
