### PR TITLE
DRILL-8236: Move HttpHelperFunctions to use JSON2 reader

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -18,7 +18,6 @@
 
 package org.apache.drill.exec.store.http.udfs;
 
-import io.netty.buffer.DrillBuf;
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.Output;
@@ -27,10 +26,8 @@ import org.apache.drill.exec.expr.annotations.Workspace;
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
-import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
 import javax.inject.Inject;
@@ -62,17 +59,9 @@ public class HttpHelperFunctions {
 
     @Override
     public void setup() {
-      org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions jsonLoaderOptions = new org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions();
-      jsonLoaderOptions.allTextMode = options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_ALL_TEXT_MODE);
-      jsonLoaderOptions.readNumbersAsDouble = options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE);
-      jsonLoaderOptions.allowNanInf = options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READER_NAN_INF_NUMBERS);
-      jsonLoaderOptions.skipMalformedRecords = options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG);
-      jsonLoaderOptions.unionEnabled = options.getBoolean(org.apache.drill.exec.ExecConstants.ENABLE_UNION_TYPE_KEY);
-      jsonLoaderOptions.enableEscapeAnyChar = options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READER_ESCAPE_ANY_CHAR);
-
       jsonLoaderBuilder = new org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder()
         .resultSetLoader(loader)
-        .options(jsonLoaderOptions);
+        .standardOptions(options);
     }
 
     @Override
@@ -111,6 +100,7 @@ public class HttpHelperFunctions {
         org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
         loader.startBatch();
         jsonLoader.readBatch();
+        loader.close();
       } catch (Exception e) {
         throw new org.apache.drill.common.exceptions.DrillRuntimeException("Error while converting from JSON. ", e);
       }
@@ -139,10 +129,10 @@ public class HttpHelperFunctions {
     DrillbitContext drillbitContext;
 
     @Inject
-    DrillBuf buffer;
+    ResultSetLoader loader;
 
     @Workspace
-    org.apache.drill.exec.vector.complex.fn.JsonReader jsonReader;
+    org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder jsonLoaderBuilder;
 
     @Workspace
     org.apache.drill.exec.store.http.HttpStoragePlugin plugin;
@@ -152,15 +142,9 @@ public class HttpHelperFunctions {
 
     @Override
     public void setup() {
-      jsonReader = new org.apache.drill.exec.vector.complex.fn.JsonReader.Builder(buffer)
-        .defaultSchemaPathColumns()
-        .readNumbersAsDouble(options.getOption(org.apache.drill.exec.ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE).bool_val)
-        .allTextMode(options.getOption(org.apache.drill.exec.ExecConstants.JSON_ALL_TEXT_MODE).bool_val)
-        .enableNanInf(options.getOption(org.apache.drill.exec.ExecConstants.JSON_READER_NAN_INF_NUMBERS).bool_val)
-        .build();
-
-      jsonReader.setIgnoreJSONParseErrors(
-        options.getBoolean(org.apache.drill.exec.ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG));
+      jsonLoaderBuilder = new org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder()
+        .resultSetLoader(loader)
+        .standardOptions(options);
 
       String schemaPath = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
       // Get the plugin name and endpoint name
@@ -213,10 +197,11 @@ public class HttpHelperFunctions {
       }
 
       try {
-        jsonReader.setSource(results);
-        jsonReader.setIgnoreJSONParseErrors(true);  // Reduce number of errors
-        jsonReader.write(writer);
-        buffer = jsonReader.getWorkBuf();
+        jsonLoaderBuilder.fromString(results);
+        org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
+        loader.startBatch();
+        jsonLoader.readBatch();
+        loader.close();
       } catch (Exception e) {
         throw new org.apache.drill.common.exceptions.DrillRuntimeException("Error while converting from JSON. ", e);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BufferManagerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BufferManagerImpl.java
@@ -44,6 +44,10 @@ public class BufferManagerImpl implements BufferManager {
     managedBuffers.clear();
   }
 
+  public BufferAllocator getAllocator() {
+    return allocator;
+  }
+
   @Override
   public DrillBuf replace(DrillBuf old, int newSize) {
     if (managedBuffers.remove(old.memoryAddress()) == null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -47,6 +47,9 @@ import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.QueryContext.SqlStatementType;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.impl.OperatorCreatorRegistry;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl.ResultSetOptions;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.BitControl.PlanFragment;
@@ -345,6 +348,11 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   @Override
   public DrillbitContext getDrillbitContext() {
     return context;
+  }
+
+  @Override
+  public ResultSetLoader getResultSetLoader() {
+    return new ResultSetLoaderImpl(bufferManager.getAllocator(), new ResultSetOptions());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -32,6 +32,9 @@ import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.expr.fn.registry.RemoteFunctionRegistry;
 import org.apache.drill.exec.expr.holders.ValueHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl.ResultSetOptions;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.planner.sql.DrillOperatorTable;
 import org.apache.drill.exec.proto.BitControl.QueryContextInformation;
@@ -319,6 +322,11 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   @Override
   public DrillbitContext getDrillbitContext() {
     return drillbitContext;
+  }
+
+  @Override
+  public ResultSetLoader getResultSetLoader() {
+    return new ResultSetLoaderImpl(allocator, new ResultSetOptions());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/UdfUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/UdfUtilities.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.ops;
 import io.netty.buffer.DrillBuf;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.expr.holders.ValueHolder;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.PartitionExplorer;
@@ -44,6 +45,7 @@ public interface UdfUtilities {
           .put(OptionManager.class, "getOptions")
           .put(BufferManager.class, "getManagedBufferManager")
           .put(DrillbitContext.class, "getDrillbitContext")
+          .put(ResultSetLoader.class, "getResultSetLoader")
           .build();
 
 
@@ -97,6 +99,8 @@ public interface UdfUtilities {
    * @return - an object for accessing drillbit information such as storage configs.
    */
   DrillbitContext getDrillbitContext();
+
+  ResultSetLoader getResultSetLoader();
 
   /**
    * Works with value holders cache which holds constant value and its wrapper by type.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/ReaderState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/ReaderState.java
@@ -344,29 +344,26 @@ class ReaderState {
    */
   protected boolean next() {
     switch (state) {
-    case LOOK_AHEAD:
-    case LOOK_AHEAD_WITH_EOF:
-      // Use batch previously read.
-      assert lookahead != null;
-      lookahead.exchange(scanOp.containerAccessor.container());
-      assert lookahead.getRecordCount() == 0;
-      lookahead = null;
-      if (state == State.LOOK_AHEAD_WITH_EOF) {
-        state = State.EOF;
-      } else {
-        state = State.ACTIVE;
+      case LOOK_AHEAD:
+      case LOOK_AHEAD_WITH_EOF:
+        // Use batch previously read.
+        assert lookahead != null;
+        lookahead.exchange(scanOp.containerAccessor.container());
+        assert lookahead.getRecordCount() == 0;
+        lookahead = null;
+        if (state == State.LOOK_AHEAD_WITH_EOF) {
+          state = State.EOF;
+        } else {
+          state = State.ACTIVE;
+        }
+        return true;
+      case ACTIVE:
+        return readBatch();
+      case EOF:
+        return false;
+      default:
+        throw new IllegalStateException("Unexpected state: " + state);
       }
-      return true;
-
-    case ACTIVE:
-      return readBatch();
-
-    case EOF:
-      return false;
-
-    default:
-      throw new IllegalStateException("Unexpected state: " + state);
-    }
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -20,10 +20,12 @@ package org.apache.drill.exec.store.easy.json.loader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.exceptions.UserException;
@@ -187,6 +189,16 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     public JsonLoaderBuilder fromStream(Iterable<InputStream> streams) {
       this.streams = streams;
       return this;
+    }
+
+    public JsonLoaderBuilder fromString(String jsonString) {
+      try (InputStream targetStream = IOUtils.toInputStream(jsonString, Charset.defaultCharset())) {
+        return fromStream(targetStream);
+      } catch (IOException e) {
+        throw UserException.dataReadError(e)
+          .message("Could not read JSON string: " + jsonString)
+          .build(logger);
+      }
     }
 
     public JsonLoaderBuilder fromReader(Reader reader) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -18,6 +18,9 @@
 package org.apache.drill.test;
 
 import org.apache.drill.exec.alias.AliasRegistryProvider;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl.ResultSetOptions;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.metastore.MetastoreRegistry;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
@@ -242,6 +245,11 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     @Override
     public DrillbitContext getDrillbitContext() {
       return null;
+    }
+
+    @Override
+    public ResultSetLoader getResultSetLoader() {
+      return new ResultSetLoaderImpl(allocator, new ResultSetOptions());
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBatchIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBatchIterator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.test;
 
+import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.physical.resultSet.impl.PullResultSetReaderImpl.UpstreamSource;
@@ -156,6 +157,8 @@ public class QueryBatchIterator implements UpstreamSource, AutoCloseable {
       QueryEvent event = listener.get();
       if (event.type == QueryEvent.Type.EOF) {
         state = State.EOF;
+      } else if (event.type == QueryEvent.Type.ERROR) {
+        throw DrillRuntimeException.create("Closed with outstanding buffers allocated");
       }
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -694,21 +694,21 @@ public class QueryBuilder {
       QueryEvent event = listener.get();
       switch (event.type)
       {
-      case BATCH:
-        batchCount++;
-        recordCount += event.batch.getHeader().getRowCount();
-        event.batch.release();
-        break;
-      case EOF:
-        state = event.state;
-        break loop;
-      case ERROR:
-        throw event.error;
-      case QUERY_ID:
-        queryId = event.queryId;
-        break;
-      default:
-        throw new IllegalStateException("Unexpected event: " + event.type);
+        case BATCH:
+          batchCount++;
+          recordCount += event.batch.getHeader().getRowCount();
+          event.batch.release();
+          break;
+        case EOF:
+          state = event.state;
+          break loop;
+        case ERROR:
+          throw event.error;
+        case QUERY_ID:
+          queryId = event.queryId;
+          break;
+        default:
+          throw new IllegalStateException("Unexpected event: " + event.type);
       }
     }
     long end = System.currentTimeMillis();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryResultSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryResultSet.java
@@ -58,32 +58,27 @@ public class QueryResultSet {
     }
     while (true) {
       QueryEvent event = listener.get();
-      switch (event.type)
-      {
-      case BATCH:
-        batchCount++;
-        recordCount += event.batch.getHeader().getRowCount();
-        loader.load(event.batch.getHeader().getDef(), event.batch.getData());
-        event.batch.release();
-        return DirectRowSet.fromVectorAccessible(loader.allocator(), loader);
-
-      case EOF:
-        state = event.state;
-        eof = true;
-        return null;
-
-      case ERROR:
-        state = event.state;
-        eof = true;
-        throw event.error;
-
-      case QUERY_ID:
-        queryId = event.queryId;
-        continue;
-
-      default:
-        throw new IllegalStateException("Unexpected event: " + event.type);
-      }
+      switch (event.type) {
+        case BATCH:
+          batchCount++;
+          recordCount += event.batch.getHeader().getRowCount();
+          loader.load(event.batch.getHeader().getDef(), event.batch.getData());
+          event.batch.release();
+          return DirectRowSet.fromVectorAccessible(loader.allocator(), loader);
+        case EOF:
+          state = event.state;
+          eof = true;
+          return null;
+        case ERROR:
+          state = event.state;
+          eof = true;
+          throw event.error;
+        case QUERY_ID:
+          queryId = event.queryId;
+          continue;
+        default:
+          throw new IllegalStateException("Unexpected event: " + event.type);
+        }
     }
   }
 

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -57,7 +57,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
    * because the buffer is used multiple times by an operator.
    */
 
-  private static final int IO_BUFFER_SIZE = 32*1024;
+  private static final int IO_BUFFER_SIZE = 32 * 1024;
   private final Object DEBUG_LOCK = DEBUG ? new Object() : null;
 
   private final BaseAllocator parentAllocator;
@@ -500,13 +500,13 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         if (allocatedCount > 0) {
           throw new IllegalStateException(
               String.format("Allocator[%s] closed with outstanding buffers allocated (%d).\n%s",
-                  name, allocatedCount, toString()));
+                  name, allocatedCount, this));
         }
 
         if (reservations.size() != 0) {
           throw new IllegalStateException(
               String.format("Allocator[%s] closed with outstanding reservations (%d).\n%s", name, reservations.size(),
-                  toString()));
+                this));
         }
 
       }
@@ -535,8 +535,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   @Override
   public String toString() {
-    final Verbosity verbosity = logger.isTraceEnabled() ? Verbosity.LOG_WITH_STACKTRACE
-        : Verbosity.BASIC;
+    final Verbosity verbosity = logger.isTraceEnabled() ? Verbosity.LOG_WITH_STACKTRACE : Verbosity.BASIC;
     final StringBuilder sb = new StringBuilder();
     print(sb, 0, verbosity);
     return sb.toString();
@@ -562,8 +561,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   /**
    * Rounds up the provided value to the nearest power of two.
    *
-   * @param val
-   *          An integer value.
+   * @param val An integer value.
    * @return The closest power of two of that value.
    */
   public static int nextPowerOfTwo(int val) {
@@ -578,8 +576,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   /**
    * Rounds up the provided value to the nearest power of two.
    *
-   * @param val
-   *          An integer long value.
+   * @param val An integer long value.
    * @return The closest power of two of that value.
    */
   public static long longNextPowerOfTwo(long val) {
@@ -622,7 +619,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     synchronized (DEBUG_LOCK) {
-
       final long allocated = getAllocatedMemory();
 
       // verify my direct descendants
@@ -689,9 +685,9 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         sb.append("allocator[");
         sb.append(name);
         sb.append("]\nallocated: ");
-        sb.append(Long.toString(allocated));
+        sb.append(allocated);
         sb.append(" allocated - (bufferTotal + reservedTotal + childTotal): ");
-        sb.append(Long.toString(allocated - (bufferTotal + reservedTotal + childTotal)));
+        sb.append(allocated - (bufferTotal + reservedTotal + childTotal));
         sb.append('\n');
 
         if (bufferTotal != 0) {
@@ -703,14 +699,14 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
         if (childTotal != 0) {
           sb.append("child total: ");
-          sb.append(Long.toString(childTotal));
+          sb.append(childTotal);
           sb.append('\n');
 
           for (final BaseAllocator childAllocator : childSet) {
             sb.append("child allocator[");
             sb.append(childAllocator.name);
             sb.append("] owned ");
-            sb.append(Long.toString(childAllocator.getAllocatedMemory()));
+            sb.append(childAllocator.getAllocatedMemory());
             sb.append('\n');
           }
         }

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/ops/BufferManager.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/ops/BufferManager.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.ops;
 
 import io.netty.buffer.DrillBuf;
+import org.apache.drill.exec.memory.BufferAllocator;
 
 /**
  * Manages a list of {@link DrillBuf}s that can be reallocated as needed. Upon
@@ -61,6 +62,8 @@ public interface BufferManager extends AutoCloseable {
    * @return A buffer
    */
   public DrillBuf getManagedBuffer(int size);
+
+  BufferAllocator getAllocator();
 
   public void close();
 }


### PR DESCRIPTION
# [DRILL-8236](https://issues.apache.org/jira/browse/DRILL-8236): Move HttpHelperFunctions to use JSON2 reader

## Description

* It updates HttpHelperFunctions to leverage JSON v2.
* Fixed possibility of memory leak for tests in `org.apache.drill.test.QueryBatchIterator`.

## Documentation
NA

## Testing
TestHttpUDFFunctions still pass
