### PR TITLE
DRILL-8242: Fix output for HttpHelperFunctions

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -75,9 +75,6 @@ public class HttpHelperFunctions {
       // as an approximation of null-if-null handling.
       if (args == null) {
         // Return empty map
-        org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter mapWriter = writer.rootAsMap();
-        mapWriter.start();
-        mapWriter.end();
         return;
       }
 
@@ -89,9 +86,6 @@ public class HttpHelperFunctions {
       // If the result string is null or empty, return an empty map
       if (results == null || results.length() == 0) {
         // Return empty map
-        org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter mapWriter = writer.rootAsMap();
-        mapWriter.start();
-        mapWriter.end();
         return;
       }
 
@@ -100,7 +94,6 @@ public class HttpHelperFunctions {
         org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
         loader.startBatch();
         jsonLoader.readBatch();
-        loader.close();
       } catch (Exception e) {
         throw new org.apache.drill.common.exceptions.DrillRuntimeException("Error while converting from JSON. ", e);
       }
@@ -174,9 +167,6 @@ public class HttpHelperFunctions {
       // as an approximation of null-if-null handling.
       if (args == null) {
         // Return empty map
-        org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter mapWriter = writer.rootAsMap();
-        mapWriter.start();
-        mapWriter.end();
         return;
       }
 
@@ -190,9 +180,6 @@ public class HttpHelperFunctions {
       // If the result string is null or empty, return an empty map
       if (results == null || results.length() == 0) {
         // Return empty map
-        org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter mapWriter = writer.rootAsMap();
-        mapWriter.start();
-        mapWriter.end();
         return;
       }
 
@@ -201,7 +188,6 @@ public class HttpHelperFunctions {
         org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
         loader.startBatch();
         jsonLoader.readBatch();
-        loader.close();
       } catch (Exception e) {
         throw new org.apache.drill.common.exceptions.DrillRuntimeException("Error while converting from JSON. ", e);
       }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -45,7 +45,7 @@ public class HttpHelperFunctions {
     @Param
     NullableVarCharHolder[] inputReaders;
 
-    @Output
+    @Output // todo: remove. Not used in this UDF
     ComplexWriter writer;
 
     @Inject
@@ -81,16 +81,16 @@ public class HttpHelperFunctions {
       String finalUrl = org.apache.drill.exec.store.http.util.SimpleHttp.mapPositionalParameters(url, args);
 
       // Make the API call
-      String results = org.apache.drill.exec.store.http.util.SimpleHttp.makeSimpleGetRequest(finalUrl);
+      java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.getRequestAndStreamResponse(finalUrl);
 
       // If the result string is null or empty, return an empty map
-      if (results == null || results.length() == 0) {
+      if (results == null) {
         // Return empty map
         return;
       }
 
       try {
-        jsonLoaderBuilder.fromString(results);
+        jsonLoaderBuilder.fromStream(results);
         org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
         loader.startBatch();
         jsonLoader.readBatch();
@@ -112,7 +112,7 @@ public class HttpHelperFunctions {
     @Param
     NullableVarCharHolder[] inputReaders;
 
-    @Output
+    @Output // todo: remove. Not used in this UDF
     ComplexWriter writer;
 
     @Inject
@@ -170,21 +170,21 @@ public class HttpHelperFunctions {
         return;
       }
 
-      String results = org.apache.drill.exec.store.http.util.SimpleHttp.makeAPICall(
+      java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.apiCall(
         plugin,
         endpointConfig,
         drillbitContext,
         args
-      );
+      ).getInputStream();
 
       // If the result string is null or empty, return an empty map
-      if (results == null || results.length() == 0) {
+      if (results == null) {
         // Return empty map
         return;
       }
 
       try {
-        jsonLoaderBuilder.fromString(results);
+        jsonLoaderBuilder.fromStream(results);
         org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
         loader.startBatch();
         jsonLoader.readBatch();

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -1127,7 +1127,8 @@ public class TestHttpPlugin extends ClusterTest {
         client.queryBuilder().sql(sql).rowSet();
         fail();
       } catch (Exception e) {
-         assertTrue("Not timeout exception, " + e, e.getMessage().contains("DATA_READ ERROR: timeout"));
+         assertTrue("Not timeout exception, " + e,
+           e.getMessage().contains("DATA_READ ERROR: timeout") || e.getMessage().contains("DATA_READ ERROR: Read timed out"));
       }
     }
   }

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
@@ -26,8 +26,10 @@ import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.util.DrillFileUtils;
+import org.apache.drill.exec.physical.impl.project.ProjectMemoryManager;
 import org.apache.drill.exec.physical.impl.project.ProjectRecordBatch;
 import org.apache.drill.exec.physical.impl.validate.IteratorValidatorBatchIterator;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
 import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -70,9 +72,11 @@ public class TestHttpUDFFunctions extends ClusterTest {
   public static void setup() throws Exception {
     logFixture = LogFixture.builder()
       .toConsole()
+      .logger(ProjectMemoryManager.class, CURRENT_LOG_LEVEL)
       .logger(ProjectRecordBatch.class, CURRENT_LOG_LEVEL)
       .logger(JsonLoaderImpl.class, CURRENT_LOG_LEVEL)
       .logger(IteratorValidatorBatchIterator.class, CURRENT_LOG_LEVEL)
+      .logger(ResultSetLoaderImpl.class, CURRENT_LOG_LEVEL)
       .build();
     startCluster(ClusterFixture.builder(dirTestWatcher));
     TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/simple.json"), Charsets.UTF_8).read();

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
@@ -24,10 +24,14 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.physical.impl.project.ProjectRecordBatch;
 import org.apache.drill.exec.physical.impl.validate.IteratorValidatorBatchIterator;
 import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
 import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
@@ -37,6 +41,7 @@ import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.LogFixture;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -47,6 +52,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -98,6 +105,33 @@ public class TestHttpUDFFunctions extends ClusterTest {
 
       RowSet results = client.queryBuilder().sql(sql).rowSet();
       assertEquals(1, results.rowCount());
+      TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("result")
+          .addMap("results")
+            .addNullable("sunrise", TypeProtos.MinorType.VARCHAR)
+            .addNullable("sunset", TypeProtos.MinorType.VARCHAR)
+            .addNullable("solar_noon", TypeProtos.MinorType.VARCHAR)
+            .addNullable("day_length", TypeProtos.MinorType.VARCHAR)
+            .addNullable("civil_twilight_begin", TypeProtos.MinorType.VARCHAR)
+            .addNullable("civil_twilight_end", TypeProtos.MinorType.VARCHAR)
+            .addNullable("nautical_twilight_begin", TypeProtos.MinorType.VARCHAR)
+            .addNullable("nautical_twilight_end", TypeProtos.MinorType.VARCHAR)
+            .addNullable("astronomical_twilight_begin", TypeProtos.MinorType.VARCHAR)
+            .addNullable("astronomical_twilight_end", TypeProtos.MinorType.VARCHAR)
+            .resumeMap()
+          .addNullable("status", TypeProtos.MinorType.VARCHAR)
+          .resumeSchema()
+        .build();
+
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+        .addRow(singleMap(
+                  mapValue(
+                    mapValue("6:13:58 AM", "5:59:55 PM", "12:06:56 PM", "11:45:57", "5:48:14 AM",
+          "6:25:38 PM", "5:18:16 AM", "6:55:36 PM", "4:48:07 AM", "7:25:45 PM"),
+                    "OK")))
+        .build();
+
+      RowSetUtilities.verify(expected, results);
       results.clear();
 
       RecordedRequest recordedRequest = server.takeRequest();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterFuncHolder.java
@@ -25,11 +25,13 @@ import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
 import org.apache.drill.exec.physical.impl.project.ProjectRecordBatch;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.record.VectorAccessibleComplexWriter;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JVar;
 
 import static org.apache.drill.shaded.guava.com.google.common.base.Preconditions.checkArgument;
@@ -56,25 +58,38 @@ public class DrillComplexWriterFuncHolder extends DrillSimpleFuncHolder {
     JBlock topSub = sub;
 
     JVar rsLoader = null;
+    JVar complexWriter = null;
+    JInvocation container = null;
 
     for (JVar workspaceJVar : workspaceJVars) {
       if ("ResultSetLoader".equals(workspaceJVar.type().name())) {
         rsLoader = workspaceJVar;
       }
     }
-    assert rsLoader != null : "Function should have ResultSetLoader variable";
+    if (rsLoader == null) {
+      complexWriter = classGenerator.declareClassField("complexWriter", classGenerator.getModel()._ref(ComplexWriter.class));
+
+
+      container = classGenerator.getMappingSet().getOutgoing().invoke("getOutgoingContainer");
+    }
     //Default name is "col", if not passed in a reference name for the output vector.
     String refName = fieldReference == null ? "col" : fieldReference.getRootSegment().getPath();
 
     JClass cwClass = classGenerator.getModel().ref(VectorAccessibleComplexWriter.class);
+    if (rsLoader == null) {
+      classGenerator.getSetupBlock().assign(complexWriter, cwClass.staticInvoke("getWriter").arg(refName).arg(container));
+    }
 
     JClass projBatchClass = classGenerator.getModel().ref(ProjectRecordBatch.class);
     JExpression projBatch = JExpr.cast(projBatchClass, classGenerator.getMappingSet().getOutgoing());
-
-    classGenerator.getSetupBlock().add(projBatch.invoke("addComplexWriter").arg(rsLoader));
-
-
-    sub.decl(classGenerator.getModel()._ref(ResultSetLoader.class), getReturnValue().getName(), rsLoader);
+    if (rsLoader == null) {
+      classGenerator.getSetupBlock().add(projBatch.invoke("addComplexWriter").arg(complexWriter));
+      classGenerator.getEvalBlock().add(complexWriter.invoke("setPosition").arg(classGenerator.getMappingSet().getValueWriteIndex()));
+      sub.decl(classGenerator.getModel()._ref(ComplexWriter.class), getReturnValue().getName(), complexWriter);
+    } else {
+      classGenerator.getSetupBlock().add(projBatch.invoke("addLoader").arg(rsLoader));
+      sub.decl(classGenerator.getModel()._ref(ResultSetLoader.class), getReturnValue().getName(), rsLoader);
+    }
 
     // add the subblock after the out declaration.
     classGenerator.getEvalBlock().add(topSub);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BufferManagerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BufferManagerImpl.java
@@ -34,12 +34,9 @@ public class BufferManagerImpl implements BufferManager {
 
   @Override
   public void close() {
-    managedBuffers.forEach(new LongObjectPredicate<DrillBuf>() {
-      @Override
-      public boolean apply(long key, DrillBuf value) {
-        value.release();
-        return true;
-      }
+    managedBuffers.forEach((LongObjectPredicate<DrillBuf>) (key, value) -> {
+      value.release();
+      return true;
     });
     managedBuffers.clear();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectBatchBuilder.java
@@ -95,7 +95,6 @@ public class ProjectBatchBuilder implements ProjectionMaterializer.BatchBuilder 
 
   @Override
   public void addComplexField(FieldReference ref) {
-    initComplexWriters();
     if (projectBatch.complexFieldReferencesList == null) {
       projectBatch.complexFieldReferencesList = Lists.newArrayList();
     } else {
@@ -109,15 +108,6 @@ public class ProjectBatchBuilder implements ProjectionMaterializer.BatchBuilder 
     // save the field reference for later for getting schema when input is empty
     projectBatch.complexFieldReferencesList.add(ref);
     projectBatch.memoryManager.addComplexField(null); // this will just add an estimate to the row width
-  }
-
-  private void initComplexWriters() {
-    // Lazy initialization of the list of complex writers, if not done yet.
-    if (projectBatch.complexWriters == null) {
-      projectBatch.complexWriters = new ArrayList<>();
-    } else {
-      projectBatch.complexWriters.clear();
-    }
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectBatchBuilder.java
@@ -95,6 +95,9 @@ public class ProjectBatchBuilder implements ProjectionMaterializer.BatchBuilder 
 
   @Override
   public void addComplexField(FieldReference ref) {
+    if (projectBatch.rsLoader == null) {
+      initComplexWriters();
+    }
     if (projectBatch.complexFieldReferencesList == null) {
       projectBatch.complexFieldReferencesList = Lists.newArrayList();
     } else {
@@ -108,6 +111,15 @@ public class ProjectBatchBuilder implements ProjectionMaterializer.BatchBuilder 
     // save the field reference for later for getting schema when input is empty
     projectBatch.complexFieldReferencesList.add(ref);
     projectBatch.memoryManager.addComplexField(null); // this will just add an estimate to the row width
+  }
+
+  private void initComplexWriters() {
+    // Lazy initialization of the list of complex writers, if not done yet.
+    if (projectBatch.complexWriters == null) {
+      projectBatch.complexWriters = new ArrayList<>();
+    } else {
+      projectBatch.complexWriters.clear();
+    }
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectMemoryManager.java
@@ -278,7 +278,7 @@ public class ProjectMemoryManager extends RecordBatchMemoryManager {
                 + ", total variable width {}, total complex width {}, batchSizer time {} ms, update time {}  ms"
                 + ", manager {}, incoming {}",outPutRowCount, batchSizer.rowCount(), incomingBatch.getRecordCount(),
                 rowWidth, totalFixedWidthColumnWidth, totalVariableColumnWidth, totalComplexColumnWidth,
-                (batchSizerEndTime - updateStartTime),(updateEndTime - updateStartTime), this, incomingBatch);
+                  (batchSizerEndTime - updateStartTime),(updateEndTime - updateStartTime), this, incomingBatch);
 
     RecordBatchStats.logRecordBatchStats(RecordBatchIOType.INPUT, getRecordBatchSizer(), outgoingBatch.getRecordBatchStatsContext());
     updateIncomingStats();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -19,21 +19,25 @@ package org.apache.drill.exec.physical.impl.project;
 
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.Project;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.record.AbstractSingleRecordBatch;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.SimpleRecordBatch;
 import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.util.record.RecordBatchStats;
 import org.apache.drill.exec.util.record.RecordBatchStats.RecordBatchIOType;
 import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
+import org.apache.drill.exec.vector.complex.MapVector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +50,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
   private static final Logger logger = LoggerFactory.getLogger(ProjectRecordBatch.class);
 
   protected List<ValueVector> allocationVectors;
-  protected List<ComplexWriter> complexWriters;
+  protected ResultSetLoader rsLoader;
   protected List<FieldReference> complexFieldReferencesList;
   protected ProjectMemoryManager memoryManager;
   private Projector projector;
@@ -103,7 +107,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     memoryManager.update();
 
     if (first && incomingRecordCount == 0) {
-      if (complexWriters != null) {
+      if (rsLoader != null) {
         IterOutcome next = null;
         while (incomingRecordCount == 0) {
           if (getLastKnownOutcome() == EMIT) {
@@ -138,7 +142,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
       }
     }
 
-    if (complexWriters != null && getLastKnownOutcome() == EMIT) {
+    if (rsLoader != null && getLastKnownOutcome() == EMIT) {
       throw UserException.unsupportedError()
           .message("Currently functions producing complex types as output are not " +
             "supported in project list for subquery between LATERAL and UNNEST. Please re-write the query using this " +
@@ -170,13 +174,18 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     }
     // In case of complex writer expression, vectors would be added to batch run-time.
     // We have to re-build the schema.
-    if (complexWriters != null) {
+    if (rsLoader != null && !rsLoader.isProjectionEmpty()) {
+      MapVector map = container.addOrGet(container.getLast().getField().getName(), Types.required(TypeProtos.MinorType.MAP), MapVector.class);
+      map.setMapValueCount(recordCount);
+      for (VectorWrapper<?> vectorWrapper : rsLoader.harvest()) {
+        ValueVector valueVector = vectorWrapper.getValueVector();
+        map.putChild(valueVector.getField().getName(), valueVector);
+      }
       container.buildSchema(SelectionVectorMode.NONE);
     }
 
     memoryManager.updateOutgoingStats(outputRecords);
     RecordBatchStats.logRecordBatchStats(RecordBatchIOType.OUTPUT, this, getRecordBatchStatsContext());
-
     // Get the final outcome based on hasRemainder since that will determine if all the incoming records were
     // consumed in current output batch or not
     return getFinalOutcome(hasRemainder);
@@ -210,7 +219,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     }
     // In case of complex writer expression, vectors would be added to batch run-time.
     // We have to re-build the schema.
-    if (complexWriters != null) {
+    if (rsLoader != null) {
       container.buildSchema(SelectionVectorMode.NONE);
     }
 
@@ -220,21 +229,14 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
 
   // Called from generated code.
 
-  public void addComplexWriter(ComplexWriter writer) {
-    complexWriters.add(writer);
+  public void addComplexWriter(ResultSetLoader loader) {
+    rsLoader = loader;
   }
 
   private void doAlloc(int recordCount) {
     // Allocate vv in the allocationVectors.
     for (ValueVector v : allocationVectors) {
       AllocationHelper.allocateNew(v, recordCount);
-    }
-
-    // Allocate vv for complexWriters.
-    if (complexWriters != null) {
-      for (ComplexWriter writer : complexWriters) {
-        writer.allocate();
-      }
     }
   }
 
@@ -251,13 +253,10 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     // the transfer pairs or vector copies.
     container.setRecordCount(count);
 
-    if (complexWriters == null) {
+    if (rsLoader == null) {
       return;
     }
-
-    for (ComplexWriter writer : complexWriters) {
-      writer.setValueCount(count);
-    }
+    rsLoader.setTargetRowCount(count);
   }
 
   @Override
@@ -276,8 +275,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     int configuredBatchSize = (int) context.getOptions().getOption(ExecConstants.OUTPUT_BATCH_SIZE_VALIDATOR);
     setupNewSchema(incomingBatch, configuredBatchSize);
 
-    ProjectBatchBuilder batchBuilder = new ProjectBatchBuilder(this,
-        container, callBack, incomingBatch);
+    ProjectBatchBuilder batchBuilder = new ProjectBatchBuilder(this, container, callBack, incomingBatch);
     ProjectionMaterializer em = new ProjectionMaterializer(context.getOptions(),
         incomingBatch, popConfig.getExprs(), context.getFunctionRegistry(),
         batchBuilder, unionTypeEnabled);
@@ -341,7 +339,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
   protected IterOutcome getFinalOutcome(boolean hasMoreRecordInBoundary) {
     // In a case of complex writers vectors are added at runtime, so the schema
     // may change (e.g. when a batch contains new column(s) not present in previous batches)
-    if (complexWriters != null) {
+    if (rsLoader != null) {
       return IterOutcome.OK_NEW_SCHEMA;
     }
     return super.getFinalOutcome(hasMoreRecordInBoundary);
@@ -357,8 +355,9 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     }
     allocationVectors = new ArrayList<>();
 
-    if (complexWriters != null) {
+    if (rsLoader != null) {
       container.clear();
+      rsLoader.close();
     } else {
       // Release the underlying DrillBufs and reset the ValueVectors to empty
       // Not clearing the container here is fine since Project output schema is

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectionMaterializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectionMaterializer.java
@@ -342,8 +342,7 @@ class ProjectionMaterializer {
     transferFieldIds.add(fid);
   }
 
-  private void setupFnCall(NamedExpression namedExpression,
-      LogicalExpression expr) {
+  private void setupFnCall(NamedExpression namedExpression, LogicalExpression expr) {
 
     // Need to process ComplexWriter function evaluation.
     // The reference name will be passed to ComplexWriter, used as the name of

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/Projector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/Projector.java
@@ -27,9 +27,9 @@ import java.util.List;
 
 public interface Projector {
 
-  public abstract void setup(FragmentContext context, RecordBatch incoming,  RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException;
-  public abstract int projectRecords(RecordBatch incomingBatch, int startIndex, int recordCount, int firstOutputIndex);
+  void setup(FragmentContext context, RecordBatch incoming,  RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException;
+  int projectRecords(RecordBatch incomingBatch, int startIndex, int recordCount, int firstOutputIndex);
 
-  public static TemplateClassDefinition<Projector> TEMPLATE_DEFINITION = new TemplateClassDefinition<Projector>(Projector.class, ProjectorTemplate.class);
+  TemplateClassDefinition<Projector> TEMPLATE_DEFINITION = new TemplateClassDefinition<Projector>(Projector.class, ProjectorTemplate.class);
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
@@ -88,8 +88,7 @@ public abstract class ProjectorTemplate implements Projector {
 
   @Override
   public final void setup(FragmentContext context, RecordBatch incoming,
-      RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException{
-
+      RecordBatch outgoing, List<TransferPair> transfers) throws SchemaChangeException {
     this.svMode = incoming.getSchema().getSelectionVectorMode();
     switch (svMode) {
     case FOUR_BYTE:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
@@ -253,8 +253,7 @@ public class ColumnBuilder {
       // have content that varies from batch to batch. Only the leaf
       // vectors can be cached.
       assert columnSchema.tupleSchema().isEmpty();
-      mapVector = new RepeatedMapVector(mapColSchema.schema(),
-          parent.loader().allocator(), null);
+      mapVector = new RepeatedMapVector(mapColSchema.schema(), parent.loader().allocator(), null);
       offsetVector = mapVector.getOffsetVector();
     } else {
       mapVector = null;
@@ -262,8 +261,7 @@ public class ColumnBuilder {
     }
 
     // Create the writer using the offset vector
-    final AbstractObjectWriter writer = MapWriter.buildMapArray(
-        columnSchema, mapVector, new ArrayList<>());
+    final AbstractObjectWriter writer = MapWriter.buildMapArray(columnSchema, mapVector, new ArrayList<>());
 
     // Wrap the offset vector in a vector state
     VectorState offsetVectorState;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
@@ -34,8 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implementation of the result set loader. Caches vectors
- * for a row or map.
+ * Implementation of the result set loader. Caches vectors for a row or map.
  *
  * @see {@link ResultSetLoader}
  */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -68,17 +68,8 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     this.batchStatsContext = new RecordBatchStatsContext(context, oContext);
     stats = oContext.getStats();
     container = new VectorContainer(this.oContext.getAllocator());
-    if (buildSchema) {
-      state = BatchState.BUILD_SCHEMA;
-    } else {
-      state = BatchState.FIRST;
-    }
-    OptionValue option = context.getOptions().getOption(ExecConstants.ENABLE_UNION_TYPE.getOptionName());
-    if (option != null) {
-      unionTypeEnabled = option.bool_val;
-    } else {
-      unionTypeEnabled = false;
-    }
+    state = buildSchema ? BatchState.BUILD_SCHEMA : BatchState.FIRST;
+    unionTypeEnabled = context.getOptions().getBoolean(ExecConstants.ENABLE_UNION_TYPE_KEY);
   }
 
   public enum BatchState {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -31,7 +31,6 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.impl.aggregate.SpilledRecordBatch;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
-import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.util.record.RecordBatchStats.RecordBatchStatsContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
@@ -247,8 +247,7 @@ public class BatchSchema implements Iterable<MaterializedField> {
         otherSchema.selectionVectorMode != SelectionVectorMode.NONE) {
       throw new IllegalArgumentException("Cannot merge schemas with selection vectors");
     }
-    List<MaterializedField> mergedFields =
-        new ArrayList<>(fields.size() + otherSchema.fields.size());
+    List<MaterializedField> mergedFields = new ArrayList<>(fields.size() + otherSchema.fields.size());
     mergedFields.addAll(this.fields);
     mergedFields.addAll(otherSchema.fields);
     return new BatchSchema(selectionVectorMode, mergedFields);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -20,12 +20,10 @@ package org.apache.drill.exec.store.easy.json.loader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.exceptions.UserException;
@@ -189,16 +187,6 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     public JsonLoaderBuilder fromStream(Iterable<InputStream> streams) {
       this.streams = streams;
       return this;
-    }
-
-    public JsonLoaderBuilder fromString(String jsonString) {
-      try (InputStream targetStream = IOUtils.toInputStream(jsonString, Charset.defaultCharset())) {
-        return fromStream(targetStream);
-      } catch (IOException e) {
-        throw UserException.dataReadError(e)
-          .message("Could not read JSON string: " + jsonString)
-          .build(logger);
-      }
     }
 
     public JsonLoaderBuilder fromReader(Reader reader) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/impl/VectorContainerWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/impl/VectorContainerWriter.java
@@ -26,6 +26,10 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.MapVector;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
+/**
+ * @see {@link org.apache.drill.exec.physical.resultSet.ResultSetLoader} - the replacement for this class
+ */
+@Deprecated
 public class VectorContainerWriter extends AbstractFieldWriter implements ComplexWriter {
   //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VectorContainerWriter.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.verify;
 /**
  * Test for validating {@link DrillSpnegoAuthenticator}
  */
+@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestDrillSpnegoAuthenticator extends BaseTest {
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/ComplexWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/ComplexWriterImpl.java
@@ -105,13 +105,13 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
   @Override
   public void setPosition(int index){
     super.setPosition(index);
-    switch(mode){
-    case MAP:
-      mapRoot.setPosition(index);
-      break;
-    case LIST:
-      listRoot.setPosition(index);
-      break;
+    switch (mode) {
+      case MAP:
+        mapRoot.setPosition(index);
+        break;
+      case LIST:
+        listRoot.setPosition(index);
+        break;
     }
   }
 


### PR DESCRIPTION
# [DRILL-8242](https://issues.apache.org/jira/browse/DRILL-8242): Fix output for HttpHelperFunctions

- add test to check the http_get function output
- replacing List<ComplexWriter> with ResultSetLoader

## Description

[DRILL-8236](https://issues.apache.org/jira/browse/DRILL-8236) changed `HttpHelperFunctions` to use EVF based JSON v2 reader. But function output left old

## Documentation
NA

## Testing
`TestHttpUDFFunctions#testHttpGetWithNoParams` test updated to check the function output
