### PR TITLE
DRILL-8199: Convert Excel EVF1 to EVF2

### DIFF
--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelFormatPlugin.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelFormatPlugin.java
@@ -18,42 +18,37 @@
 
 package org.apache.drill.exec.store.excel;
 
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
-import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReaderFactory;
-import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
-import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.v3.file.FileReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.v3.file.FileScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.file.FileSchemaNegotiator;
 
-import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
 import org.apache.drill.exec.server.DrillbitContext;
-import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.drill.exec.store.excel.ExcelBatchReader.ExcelReaderConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 public class ExcelFormatPlugin extends EasyFormatPlugin<ExcelFormatConfig> {
 
-  protected static final String DEFAULT_NAME = "excel";
-  private static final Logger logger = LoggerFactory.getLogger(ExcelFormatPlugin.class);
+  public static final String DEFAULT_NAME = "excel";
+  public static final String OPERATOR_TYPE = "EXCEL_SUB_SCAN";
 
   private static class ExcelReaderFactory extends FileReaderFactory {
     private final ExcelBatchReader.ExcelReaderConfig readerConfig;
-    private final int maxRecords;
+    private final EasySubScan scan;
 
-    public ExcelReaderFactory(ExcelReaderConfig config, int maxRecords) {
-      readerConfig = config;
-      this.maxRecords = maxRecords;
+    public ExcelReaderFactory(ExcelBatchReader.ExcelReaderConfig config, EasySubScan scan) {
+      this.readerConfig = config;
+      this.scan = scan;
     }
 
     @Override
-    public ManagedReader<? extends FileSchemaNegotiator> newReader() {
-      return new ExcelBatchReader(readerConfig, maxRecords);
+    public ManagedReader newReader(FileSchemaNegotiator negotiator) throws EarlyEofException {
+      return new ExcelBatchReader(readerConfig, scan, negotiator);
     }
   }
 
@@ -69,74 +64,19 @@ public class ExcelFormatPlugin extends EasyFormatPlugin<ExcelFormatConfig> {
         .writable(false)
         .blockSplittable(false)
         .compressible(true)
-        .supportsProjectPushdown(true)
         .extensions(pluginConfig.getExtensions())
         .fsConf(fsConf)
-        .defaultName(DEFAULT_NAME)
-        .scanVersion(ScanFrameworkVersion.EVF_V1)
+        .readerOperatorType(OPERATOR_TYPE)
+        .defaultName(ExcelFormatPlugin.DEFAULT_NAME)
+        .scanVersion(ScanFrameworkVersion.EVF_V2)
+        .supportsProjectPushdown(true)
         .supportsLimitPushdown(true)
         .build();
   }
 
   @Override
-  public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(
-    EasySubScan scan, OptionSet options) {
-    return new ExcelBatchReader(formatConfig.getReaderConfig(this), scan.getMaxRecords());
-  }
-
-  @Override
-  protected FileScanBuilder frameworkBuilder(EasySubScan scan, OptionSet options) {
-    FileScanBuilder builder = new FileScanBuilder();
-    ExcelReaderConfig readerConfig = new ExcelReaderConfig(this);
-
-    verifyConfigOptions(readerConfig);
-    builder.setReaderFactory(new ExcelReaderFactory(readerConfig, scan.getMaxRecords()));
-
-    initScanBuilder(builder, scan);
+  protected void configureScan(FileScanLifecycleBuilder builder, EasySubScan scan) {
     builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));
-    return builder;
-  }
-
-  /**
-   * This function verifies that the user entered valid user configuration options.  Specifically it verifies that:
-   * <ul>
-   * <li>the lastColumn is greater than the first column</li>
-   * <li>The lastColumn is not zero</li>
-   * <li>firstColumn is greater than zero</li>
-   * <li>lastColumn is greater than zero</li>
-   * <li>The headerRow index is less than the lastRow index</li>
-   * </ul>
-   *
-   * @param readerConfig The readerConfig object for which the function will verify the config options
-   */
-  private void verifyConfigOptions(ExcelReaderConfig readerConfig) {
-    // Validate the config variables
-    if ((readerConfig.lastColumn < readerConfig.firstColumn) && readerConfig.lastColumn != 0) {
-      throw UserException
-        .validationError()
-        .message("Invalid column configuration. The first column index is greater than the last column index.")
-        .build(logger);
-    }
-
-    if (readerConfig.firstColumn < 0) {
-      throw UserException
-        .validationError()
-        .message("Invalid value for first column. Index must be greater than zero.")
-        .build(logger);
-    }
-
-    if (readerConfig.lastColumn < 0) {
-      throw UserException
-        .validationError()
-        .message("Invalid value for last column. Index must be greater than zero.")
-        .build(logger);
-    }
-
-    if (readerConfig.headerRow > readerConfig.lastRow) {
-      throw UserException
-        .validationError()
-        .message("Invalid value for headerRow. Header row must be less than last row.")
-        .build(logger);
-    }
+    builder.readerFactory(new ExcelReaderFactory(formatConfig.getReaderConfig(this), scan));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/DynamicSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/schema/DynamicSchemaFilter.java
@@ -232,6 +232,9 @@ public abstract class DynamicSchemaFilter implements ProjectionFilter {
     @Override
     public ProjResult projection(ColumnMetadata col) {
       ColumnHandle handle = schema.find(col.name());
+      if (SchemaUtils.isExcludedFromWildcard(col) && handle == null) {
+        return NOT_PROJECTED;
+      }
       if (handle == null) {
         return newColumnProjection();
       }


### PR DESCRIPTION
# [DRILL-8199](https://issues.apache.org/jira/browse/DRILL-8199): Convert Excel EVF1 to EVF2

## Description

The Excel format plugin is upgraded to use the EVF 2 framework.

## Documentation
N/A

## Testing
Existing unit tests, manual testing.