### PR TITLE
DRILL-8248: Fix http_request for several rows

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -52,54 +52,56 @@ public class HttpHelperFunctions {
     OptionManager options;
 
     @Inject
-    ResultSetLoader loader;
+    ResultSetLoader rsLoader;
 
     @Workspace
-    org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder jsonLoaderBuilder;
+    org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl jsonLoader;
+
+    @Workspace
+    org.apache.drill.exec.store.easy.json.loader.SingleElementIterator<java.io.InputStream> stream;
 
     @Override
     public void setup() {
-      jsonLoaderBuilder = new org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder()
-        .resultSetLoader(loader)
-        .standardOptions(options);
+      stream = new org.apache.drill.exec.store.easy.json.loader.SingleElementIterator<>();
+      rsLoader.startBatch();
     }
 
     @Override
     public void eval() {
       // Get the URL
       String url = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
-
       // Process Positional Arguments
       java.util.List args = org.apache.drill.exec.store.http.util.SimpleHttp.buildParameterList(inputReaders);
       // If the arg list is null, indicating at least one null arg, return an empty map
       // as an approximation of null-if-null handling.
       if (args == null) {
-        // Return empty map
         return;
       }
-
       String finalUrl = org.apache.drill.exec.store.http.util.SimpleHttp.mapPositionalParameters(url, args);
-
       // Make the API call
       java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.getRequestAndStreamResponse(finalUrl);
-
       // If the result string is null or empty, return an empty map
       if (results == null) {
-        // Return empty map
         return;
       }
-
       try {
-        jsonLoaderBuilder.fromStream(results);
-        org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
-        loader.startBatch();
-        jsonLoader.readBatch();
+        stream.setValue(results);
+        if (jsonLoader == null) {
+          jsonLoader = org.apache.drill.exec.store.http.udfs.HttpUdfUtils.createJsonLoader(rsLoader, options, stream);
+        }
+        org.apache.drill.exec.physical.resultSet.RowSetLoader rowWriter = rsLoader.writer();
+        rowWriter.start();
+        if (jsonLoader.parser().next()) {
+          rowWriter.save();
+        }
       } catch (Exception e) {
-        throw new org.apache.drill.common.exceptions.DrillRuntimeException("Error while converting from JSON. ", e);
+        throw org.apache.drill.common.exceptions.UserException.dataReadError(e)
+          .message("Error while reading JSON. ")
+          .addContext(e.getMessage())
+          .build();
       }
     }
   }
-
 
   @FunctionTemplate(names = {"http_request", "httpRequest"},
     scope = FunctionTemplate.FunctionScope.SIMPLE,
@@ -122,16 +124,19 @@ public class HttpHelperFunctions {
     DrillbitContext drillbitContext;
 
     @Inject
-    ResultSetLoader loader;
+    ResultSetLoader rsLoader;
 
     @Workspace
-    org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder jsonLoaderBuilder;
+    org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl jsonLoader;
 
     @Workspace
     org.apache.drill.exec.store.http.HttpStoragePlugin plugin;
 
     @Workspace
     org.apache.drill.exec.store.http.HttpApiConfig endpointConfig;
+
+    @Workspace
+    org.apache.drill.exec.store.easy.json.loader.SingleElementIterator<java.io.InputStream> stream;
 
     @Override
     public void setup() {
@@ -154,15 +159,43 @@ public class HttpHelperFunctions {
         endpointName,
         plugin.getConfig()
       );
-
+      stream = new org.apache.drill.exec.store.easy.json.loader.SingleElementIterator<>();
       // Add JSON configuration from Storage plugin, if present.
-      jsonLoaderBuilder = org.apache.drill.exec.store.http.udfs.HttpUdfUtils.setupJsonBuilder(endpointConfig, loader, options);
-
+      rsLoader.startBatch();
     }
 
     @Override
     public void eval() {
-      org.apache.drill.exec.store.http.udfs.HttpUdfUtils.processResults(inputReaders, plugin, endpointConfig, drillbitContext, jsonLoaderBuilder, loader);
+      // Process Positional Arguments
+      java.util.List args = org.apache.drill.exec.store.http.util.SimpleHttp.buildParameterList(inputReaders);
+      // If the arg list is null, indicating at least one null arg, return an empty map
+      // as an approximation of null-if-null handling.
+      if (args == null) {
+        return;
+      }
+      java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.apiCall(plugin, endpointConfig, drillbitContext, args)
+        .getInputStream();
+      // If the result string is null or empty, return an empty map
+      if (results == null) {
+        return;
+      }
+      try {
+        stream.setValue(results);
+        if (jsonLoader == null) {
+          // Add JSON configuration from Storage plugin, if present.
+          jsonLoader = org.apache.drill.exec.store.http.udfs.HttpUdfUtils.createJsonLoader(endpointConfig, rsLoader, options, stream);
+        }
+        org.apache.drill.exec.physical.resultSet.RowSetLoader rowWriter = rsLoader.writer();
+        rowWriter.start();
+        if (jsonLoader.parser().next()) {
+          rowWriter.save();
+        }
+      } catch (Exception e) {
+        throw org.apache.drill.common.exceptions.UserException.dataReadError(e)
+          .message("Error while reading JSON. ")
+          .addContext(e.getMessage())
+          .build();
+      }
     }
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -162,36 +162,7 @@ public class HttpHelperFunctions {
 
     @Override
     public void eval() {
-      // Process Positional Arguments
-      java.util.List args = org.apache.drill.exec.store.http.util.SimpleHttp.buildParameterList(inputReaders);
-      // If the arg list is null, indicating at least one null arg, return an empty map
-      // as an approximation of null-if-null handling.
-      if (args == null) {
-        // Return empty map
-        return;
-      }
-
-      java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.apiCall(
-        plugin,
-        endpointConfig,
-        drillbitContext,
-        args
-      ).getInputStream();
-
-      // If the result string is null or empty, return an empty map
-      if (results == null) {
-        // Return empty map
-        return;
-      }
-
-      try {
-        jsonLoaderBuilder.fromStream(results);
-        org.apache.drill.exec.store.easy.json.loader.JsonLoader jsonLoader = jsonLoaderBuilder.build();
-        loader.startBatch();
-        jsonLoader.readBatch();
-      } catch (Exception e) {
-        throw new org.apache.drill.common.exceptions.DrillRuntimeException("Error while converting from JSON. ", e);
-      }
+      org.apache.drill.exec.store.http.udfs.HttpUdfUtils.processResults(inputReaders, plugin, endpointConfig, drillbitContext, jsonLoaderBuilder, loader);
     }
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpUdfUtils.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpUdfUtils.java
@@ -19,113 +19,52 @@
 package org.apache.drill.exec.store.http.udfs;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
-import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
-import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
-import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
+import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.loader.SingleElementIterator;
 import org.apache.drill.exec.store.http.HttpApiConfig;
-import org.apache.drill.exec.store.http.HttpJsonOptions;
-import org.apache.drill.exec.store.http.HttpStoragePlugin;
-import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class HttpUdfUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(HttpUdfUtils.class);
 
-  public static JsonLoaderBuilder setupJsonBuilder(HttpApiConfig endpointConfig, ResultSetLoader loader, OptionManager options) {
-    loader.setTargetRowCount(1);
+  public static JsonLoaderImpl createJsonLoader(ResultSetLoader rsLoader,
+                                                OptionManager options,
+                                                SingleElementIterator<InputStream> stream) {
+    return createJsonLoader(null, rsLoader, options, stream);
+  }
+  public static JsonLoaderImpl createJsonLoader(HttpApiConfig endpointConfig, ResultSetLoader rsLoader,
+                                                OptionManager options, SingleElementIterator<InputStream> stream) {
     // Add JSON configuration from Storage plugin, if present.
-    JsonLoaderBuilder jsonLoaderBuilder = new JsonLoaderBuilder()
-      .resultSetLoader(loader)
-      .maxRows(1)
-      .standardOptions(options);
-
+    org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder jsonLoaderBuilder =
+      new org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder()
+      .resultSetLoader(rsLoader)
+      .standardOptions(options)
+      .fromStream(() -> stream);
     // Add data path if present
-    if (StringUtils.isNotEmpty(endpointConfig.dataPath())) {
-      jsonLoaderBuilder.dataPath(endpointConfig.dataPath());
-    }
+    if (endpointConfig != null) {
+      if (StringUtils.isNotEmpty(endpointConfig.dataPath())) {
+        jsonLoaderBuilder.dataPath(endpointConfig.dataPath());
+      }
+      // Add JSON configuration from Storage plugin, if present.
+      org.apache.drill.exec.store.http.HttpJsonOptions jsonOptions = endpointConfig.jsonOptions();
+      if (jsonOptions != null) {
+        // Add options from endpoint configuration to jsonLoader
+        org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions jsonLoaderOptions = jsonOptions.getJsonOptions(options);
+        jsonLoaderBuilder.options(jsonLoaderOptions);
 
-    // Add JSON configuration from Storage plugin, if present.
-    HttpJsonOptions jsonOptions = endpointConfig.jsonOptions();
-    if (jsonOptions != null) {
-      // Add options from endpoint configuration to jsonLoader
-      JsonLoaderOptions jsonLoaderOptions = jsonOptions.getJsonOptions(options);
-      jsonLoaderBuilder.options(jsonLoaderOptions);
-
-      // Add provided schema if present
-      if (jsonOptions.schema() != null) {
-        logger.debug("Found schema: {}", jsonOptions.schema());
-        jsonLoaderBuilder.providedSchema(jsonOptions.schema());
+        // Add provided schema if present
+        if (jsonOptions.schema() != null) {
+          logger.debug("Found schema: {}", jsonOptions.schema());
+          jsonLoaderBuilder.providedSchema(jsonOptions.schema());
+        }
       }
     }
-    loader.startBatch();
-    return jsonLoaderBuilder;
-  }
-
-  public static void processResults(NullableVarCharHolder[] inputReaders,
-                                    HttpStoragePlugin plugin,
-                                    HttpApiConfig endpointConfig,
-                                    DrillbitContext drillbitContext,
-                                    JsonLoaderBuilder jsonLoaderBuilder,
-                                    ResultSetLoader loader) {
-    // Process Positional Arguments
-    List args = SimpleHttp.buildParameterList(inputReaders);
-
-    // If the arg list is null, indicating at least one null arg, return an empty map
-    // as an approximation of null-if-null handling.
-    if (args == null) {
-      // Return empty map
-      return;
-    }
-
-    InputStream results = SimpleHttp.apiCall(plugin, endpointConfig, drillbitContext, args)
-      .getInputStream();
-
-    // If the result string is null or empty, return an empty map
-    if (results == null) {
-      // Return empty map
-      return;
-    }
-
-    try {
-      String jsonInput = getStringFromInputStream(results);
-      jsonLoaderBuilder.fromString(jsonInput);
-      System.out.println("Batch size: {} " +  loader.maxBatchSize());
-      JsonLoader jsonLoader = jsonLoaderBuilder.build();
-      jsonLoader.readBatch();
-      jsonLoader.close();
-      loader.setTargetRowCount(loader.targetRowCount() + 1);
-
-    } catch (Exception e) {
-      throw UserException.dataReadError(e)
-        .message("Error while reading JSON. ")
-        .addContext(e.getMessage())
-        .build(logger);
-    }
-  }
-
-  /**
-   * Reads an {@link InputStream} and returns the contents as a {@link String}.
-   * @param in An {@link InputStream}
-   * @return A {@link String} of the InputStream's contents
-   */
-  public static String getStringFromInputStream(InputStream in) {
-    return new BufferedReader(
-      new InputStreamReader(in, StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining("\n"));
+    return (org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl) jsonLoaderBuilder.build();
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpUdfUtils.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpUdfUtils.java
@@ -19,14 +19,27 @@
 package org.apache.drill.exec.store.http.udfs;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
 import org.apache.drill.exec.store.http.HttpApiConfig;
 import org.apache.drill.exec.store.http.HttpJsonOptions;
+import org.apache.drill.exec.store.http.HttpStoragePlugin;
+import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class HttpUdfUtils {
 
@@ -35,7 +48,6 @@ public class HttpUdfUtils {
   public static JsonLoaderBuilder setupJsonBuilder(HttpApiConfig endpointConfig, ResultSetLoader loader, OptionManager options) {
     loader.setTargetRowCount(1);
     // Add JSON configuration from Storage plugin, if present.
-    HttpJsonOptions jsonOptions = endpointConfig.jsonOptions();
     JsonLoaderBuilder jsonLoaderBuilder = new JsonLoaderBuilder()
       .resultSetLoader(loader)
       .maxRows(1)
@@ -46,6 +58,8 @@ public class HttpUdfUtils {
       jsonLoaderBuilder.dataPath(endpointConfig.dataPath());
     }
 
+    // Add JSON configuration from Storage plugin, if present.
+    HttpJsonOptions jsonOptions = endpointConfig.jsonOptions();
     if (jsonOptions != null) {
       // Add options from endpoint configuration to jsonLoader
       JsonLoaderOptions jsonLoaderOptions = jsonOptions.getJsonOptions(options);
@@ -57,6 +71,61 @@ public class HttpUdfUtils {
         jsonLoaderBuilder.providedSchema(jsonOptions.schema());
       }
     }
+    loader.startBatch();
     return jsonLoaderBuilder;
+  }
+
+  public static void processResults(NullableVarCharHolder[] inputReaders,
+                                    HttpStoragePlugin plugin,
+                                    HttpApiConfig endpointConfig,
+                                    DrillbitContext drillbitContext,
+                                    JsonLoaderBuilder jsonLoaderBuilder,
+                                    ResultSetLoader loader) {
+    // Process Positional Arguments
+    List args = SimpleHttp.buildParameterList(inputReaders);
+
+    // If the arg list is null, indicating at least one null arg, return an empty map
+    // as an approximation of null-if-null handling.
+    if (args == null) {
+      // Return empty map
+      return;
+    }
+
+    InputStream results = SimpleHttp.apiCall(plugin, endpointConfig, drillbitContext, args)
+      .getInputStream();
+
+    // If the result string is null or empty, return an empty map
+    if (results == null) {
+      // Return empty map
+      return;
+    }
+
+    try {
+      String jsonInput = getStringFromInputStream(results);
+      jsonLoaderBuilder.fromString(jsonInput);
+      System.out.println("Batch size: {} " +  loader.maxBatchSize());
+      JsonLoader jsonLoader = jsonLoaderBuilder.build();
+      jsonLoader.readBatch();
+      jsonLoader.close();
+      loader.setTargetRowCount(loader.targetRowCount() + 1);
+
+    } catch (Exception e) {
+      throw UserException.dataReadError(e)
+        .message("Error while reading JSON. ")
+        .addContext(e.getMessage())
+        .build(logger);
+    }
+  }
+
+  /**
+   * Reads an {@link InputStream} and returns the contents as a {@link String}.
+   * @param in An {@link InputStream}
+   * @return A {@link String} of the InputStream's contents
+   */
+  public static String getStringFromInputStream(InputStream in) {
+    return new BufferedReader(
+      new InputStreamReader(in, StandardCharsets.UTF_8))
+      .lines()
+      .collect(Collectors.joining("\n"));
   }
 }

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
@@ -36,6 +36,7 @@ import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
+import org.apache.drill.exec.store.http.udfs.HttpUdfUtils;
 import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
@@ -68,7 +69,7 @@ public class TestHttpUDFFunctions extends ClusterTest {
   private static String TEST_JSON_PAGE1;
   private static String DUMMY_URL = "http://localhost:" + MOCK_SERVER_PORT;
   protected static LogFixture logFixture;
-  private final static Level CURRENT_LOG_LEVEL = Level.INFO;
+  private final static Level CURRENT_LOG_LEVEL = Level.DEBUG;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -79,6 +80,7 @@ public class TestHttpUDFFunctions extends ClusterTest {
       .logger(JsonLoaderImpl.class, CURRENT_LOG_LEVEL)
       .logger(IteratorValidatorBatchIterator.class, CURRENT_LOG_LEVEL)
       .logger(ResultSetLoaderImpl.class, CURRENT_LOG_LEVEL)
+      .logger(HttpUdfUtils.class, CURRENT_LOG_LEVEL)
       .build();
     startCluster(ClusterFixture.builder(dirTestWatcher));
     TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/simple.json"), Charsets.UTF_8).read();

--- a/contrib/storage-http/src/test/resources/data/p4.json
+++ b/contrib/storage-http/src/test/resources/data/p4.json
@@ -1,0 +1,2 @@
+{"col1": "apache"}
+{"col1": "ddr"}

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
@@ -26,6 +26,7 @@ import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
+import org.apache.drill.exec.store.easy.json.loader.SingleElementIterator;
 import org.apache.drill.exec.store.easy.json.parser.TokenIterator;
 import org.apache.drill.exec.store.kafka.KafkaStoragePlugin;
 import org.apache.drill.exec.store.kafka.MetaDataField;
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.Properties;
 import java.util.StringJoiner;
 
@@ -155,25 +155,5 @@ public class JsonMessageReader implements MessageReader {
         .add("kafkaJsonLoader=" + kafkaJsonLoader)
         .add("resultSetLoader=" + resultSetLoader)
         .toString();
-  }
-
-  public static class SingleElementIterator<T> implements Iterator<T> {
-    private T value;
-
-    @Override
-    public boolean hasNext() {
-      return value != null;
-    }
-
-    @Override
-    public T next() {
-      T value = this.value;
-      this.value = null;
-      return value;
-    }
-
-    public void setValue(T value) {
-      this.value = value;
-    }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.project;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.types.TypeProtos;
@@ -110,7 +111,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     memoryManager.update();
 
     if (first && incomingRecordCount == 0) {
-      if ((complexWriters != null && !complexWriters.isEmpty()) || rsLoader != null ) {
+      if (!CollectionUtils.isEmpty(complexWriters) || rsLoader != null ) {
         IterOutcome next = null;
         while (incomingRecordCount == 0) {
           if (getLastKnownOutcome() == EMIT) {
@@ -145,7 +146,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
       }
     }
 
-    if (((complexWriters != null && !complexWriters.isEmpty()) || rsLoader != null) && getLastKnownOutcome() == EMIT) {
+    if ((!CollectionUtils.isEmpty(complexWriters) || rsLoader != null) && getLastKnownOutcome() == EMIT) {
       throw UserException.unsupportedError()
           .message("Currently functions producing complex types as output are not " +
             "supported in project list for subquery between LATERAL and UNNEST. Please re-write the query using this " +
@@ -185,7 +186,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
         map.putChild(valueVector.getField().getName(), valueVector);
       }
       container.buildSchema(SelectionVectorMode.NONE);
-    } else if (complexWriters != null && !complexWriters.isEmpty()) {
+    } else if (!CollectionUtils.isEmpty(complexWriters)) {
       container.buildSchema(SelectionVectorMode.NONE);
     }
 
@@ -224,7 +225,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     }
     // In case of complex writer expression, vectors would be added to batch run-time.
     // We have to re-build the schema.
-    if ((complexWriters != null && !complexWriters.isEmpty()) || rsLoader != null) {
+    if (!CollectionUtils.isEmpty(complexWriters) || rsLoader != null) {
       container.buildSchema(SelectionVectorMode.NONE);
     }
 
@@ -358,7 +359,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
   protected IterOutcome getFinalOutcome(boolean hasMoreRecordInBoundary) {
     // In a case of complex writers vectors are added at runtime, so the schema
     // may change (e.g. when a batch contains new column(s) not present in previous batches)
-    if ((complexWriters != null && !complexWriters.isEmpty()) || rsLoader != null) {
+    if (!CollectionUtils.isEmpty(complexWriters) || rsLoader != null) {
       return IterOutcome.OK_NEW_SCHEMA;
     }
     return super.getFinalOutcome(hasMoreRecordInBoundary);
@@ -377,7 +378,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     if (rsLoader != null) {
       container.clear();
       rsLoader.close();
-    } else if (complexWriters != null && !complexWriters.isEmpty()) {
+    } else if (!CollectionUtils.isEmpty(complexWriters)) {
       container.clear();
     } else {
       // Release the underlying DrillBufs and reset the ValueVectors to empty

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
@@ -434,8 +434,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
         throw new IllegalStateException("Unexpected state: " + state);
     }
 
-    // Update the visible schema with any pending overflow batch
-    // updates
+    // Update the visible schema with any pending overflow batch updates
     harvestSchemaVersion = activeSchemaVersion;
     pendingRowCount = 0;
     batchSizeLimit = (int) Math.min(targetRowCount, options.scanLimit - totalRowCount());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -20,10 +20,14 @@ package org.apache.drill.exec.store.easy.json.loader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import io.netty.buffer.DrillBuf;
+import org.apache.commons.io.IOUtils;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.exceptions.UserException;
@@ -43,6 +47,7 @@ import org.apache.drill.exec.store.easy.json.parser.TokenIterator.RecoverableJso
 import org.apache.drill.exec.store.easy.json.parser.ValueDef;
 import org.apache.drill.exec.store.easy.json.parser.ValueDef.JsonType;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
+import org.apache.drill.exec.vector.complex.fn.DrillBufInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,6 +191,16 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
 
     public JsonLoaderBuilder fromStream(Iterable<InputStream> streams) {
       this.streams = streams;
+      return this;
+    }
+
+    public JsonLoaderBuilder fromStream(int start, int end, DrillBuf buf) {
+      this.streams = Collections.singletonList(DrillBufInputStream.getStream(start, end, buf));
+      return this;
+    }
+
+    public JsonLoaderBuilder fromString(String jsonString) {
+      this.streams = Collections.singletonList(IOUtils.toInputStream(jsonString, Charset.defaultCharset()));
       return this;
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/SingleElementIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/SingleElementIterator.java
@@ -20,7 +20,7 @@ package org.apache.drill.exec.store.easy.json.loader;
 import java.util.Iterator;
 
 /**
- * It allows setting current value in the iterator and cane be used once after {@link #next} call
+ * It allows setting the current value in the iterator and can be used once after {@link #next} call
  *
  * @param <T> type of the value
  */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/SingleElementIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/SingleElementIterator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.loader;
+
+import java.util.Iterator;
+
+/**
+ * It allows setting current value in the iterator and cane be used once after {@link #next} call
+ *
+ * @param <T> type of the value
+ */
+public class SingleElementIterator<T> implements Iterator<T> {
+    private T value;
+
+    @Override
+    public boolean hasNext() {
+      return value != null;
+    }
+
+    @Override
+    public T next() {
+      T value = this.value;
+      this.value = null;
+      return value;
+    }
+
+    public void setValue(T value) {
+      this.value = value;
+    }
+  }


### PR DESCRIPTION
# [DRILL-8248](https://issues.apache.org/jira/browse/DRILL-8248): Fix http_request for several rows

## Description

Fixes the limiting of the `http_request` to 1 row. The main issue is in creating `jsonLoader` for every row.

## Documentation
NA

## Testing
Unit test added. And tested manually with Drill Remote debug tool.
