### PR TITLE
[MINOR UPDATE] Fix Port Clash Issue in HTTP Plugin Tests

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/DrillFileUtils.java
+++ b/common/src/main/java/org/apache/drill/common/util/DrillFileUtils.java
@@ -26,7 +26,7 @@ import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
 
 public class DrillFileUtils {
-  // These two seperators are intentionally used instead of Path.SEPERATPR or File.seperator
+  // These two separators are intentionally used instead of Path.SEPARATOR or File.separator
   // for loading classes since both alternatives return '\' on Windows. However, in the context
   // of classpath scanning and loading only '/' is valid.
   public static final char SEPARATOR_CHAR = '/';

--- a/contrib/native/client/src/include/drill/recordBatch.hpp
+++ b/contrib/native/client/src/include/drill/recordBatch.hpp
@@ -798,7 +798,7 @@ typedef NullableValueVectorTyped<int, ValueVectorBit > NullableValueVectorBit;
 // The definitions for decimal digits, width, max precision are defined in
 // /exec/java-exec/src/main/codegen/data/ValueVectorTypes.tdd
 //
-// Decimal9 and Decimal18 could be optimized, maybe write seperate classes?
+// Decimal9 and Decimal18 could be optimized, maybe write separate classes?
 typedef ValueVectorDecimalTrivial<int32_t> ValueVectorDecimal9;
 typedef ValueVectorDecimalTrivial<int64_t> ValueVectorDecimal18;
 typedef ValueVectorDecimal<3, 12, false, 28> ValueVectorDecimal28Dense;

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
@@ -59,7 +59,7 @@ import static org.junit.Assert.fail;
 public class TestOAuthProcess extends ClusterTest {
 
   private static final Logger logger = LoggerFactory.getLogger(TestOAuthProcess.class);
-  private static final int MOCK_SERVER_PORT = 47775;
+  private static final int MOCK_SERVER_PORT = 47779;
 
   private static final int TIMEOUT = 30;
   private static final String CONNECTION_NAME = "localOauth";

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestProvidedSchema.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestProvidedSchema.java
@@ -80,7 +80,7 @@ public class TestProvidedSchema extends ClusterTest {
       .build();
 
     HttpApiConfig basicJson = HttpApiConfig.builder()
-      .url("http://localhost:47777/json")
+      .url(makeUrl("http://localhost:%d/json"))
       .method("get")
       .jsonOptions(jsonOptions)
       .requireTail(false)
@@ -101,7 +101,7 @@ public class TestProvidedSchema extends ClusterTest {
       .build();
 
     HttpApiConfig schemaChange = HttpApiConfig.builder()
-      .url("http://localhost:47777/json")
+      .url(makeUrl("http://localhost:%d/json"))
       .method("get")
       .jsonOptions(jsonOptionsSchemaChange)
       .requireTail(false)
@@ -117,7 +117,7 @@ public class TestProvidedSchema extends ClusterTest {
 
 
     HttpApiConfig partialSchema = HttpApiConfig.builder()
-      .url("http://localhost:47777/json")
+      .url(makeUrl("http://localhost:%d/json"))
       .method("get")
       .jsonOptions(HttpJsonOptions.builder().schema(partialMapSchema).build())
       .requireTail(false)
@@ -138,7 +138,7 @@ public class TestProvidedSchema extends ClusterTest {
       .build();
 
     HttpApiConfig jsonModeConfig = HttpApiConfig.builder()
-      .url("http://localhost:47777/json")
+      .url(makeUrl("http://localhost:%d/json"))
       .method("get")
       .jsonOptions(jsonModeOptions)
       .requireTail(false)
@@ -146,7 +146,7 @@ public class TestProvidedSchema extends ClusterTest {
       .build();
 
     HttpApiConfig noSchema = HttpApiConfig.builder()
-      .url("http://localhost:47777/json")
+      .url(makeUrl("http://localhost:%d/json"))
       .method("get")
       .requireTail(false)
       .inputType("json")
@@ -316,9 +316,13 @@ public class TestProvidedSchema extends ClusterTest {
    * @return Started Mock server
    * @throws IOException If the server cannot start, throws IOException
    */
-  public MockWebServer startServer() throws IOException {
+  private MockWebServer startServer() throws IOException {
     MockWebServer server = new MockWebServer();
     server.start(MOCK_SERVER_PORT);
     return server;
+  }
+
+  private static String makeUrl(String url) {
+    return String.format(url, MOCK_SERVER_PORT);
   }
 }

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
@@ -18,11 +18,7 @@
 
 package org.apache.drill.exec.store.http;
 
-import okhttp3.Cookie;
-import okhttp3.CookieJar;
 import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -54,7 +50,6 @@ import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.QueryBuilder.QuerySummary;
 import org.apache.drill.test.rowSet.RowSetUtilities;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -63,11 +58,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
 import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
@@ -82,15 +74,7 @@ import static org.junit.Assert.fail;
 public class TestUserTranslationInHttpPlugin extends ClusterTest {
   private static final Logger logger = LoggerFactory.getLogger(TestUserTranslationInHttpPlugin.class);
 
-  private static final int MOCK_SERVER_PORT = 47775;
-  private static final int TIMEOUT = 30;
-  private final OkHttpClient httpClient = new OkHttpClient
-    .Builder()
-    .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
-    .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
-    .readTimeout(TIMEOUT, TimeUnit.SECONDS)
-    .cookieJar(new TestCookieJar())
-    .build();
+  private static final int MOCK_SERVER_PORT = 47778;
   private static String TEST_JSON_RESPONSE_WITH_DATATYPES;
   private static String ACCESS_TOKEN_RESPONSE;
   private static int portNumber;
@@ -298,13 +282,13 @@ public class TestUserTranslationInHttpPlugin extends ClusterTest {
    * @return Started Mock server
    * @throws IOException If the server cannot start, throws IOException
    */
-  public static MockWebServer startServer() throws IOException {
+  private static MockWebServer startServer() throws IOException {
     MockWebServer server = new MockWebServer();
     server.start(MOCK_SERVER_PORT);
     return server;
   }
 
-  public static String makeUrl(String url) {
+  private static String makeUrl(String url) {
     return String.format(url, MOCK_SERVER_PORT);
   }
 
@@ -312,22 +296,5 @@ public class TestUserTranslationInHttpPlugin extends ClusterTest {
     String pair = username + ":" + password;
     byte[] encodedBytes = Base64.encodeBase64(pair.getBytes());
     return "Basic " + new String(encodedBytes);
-  }
-
-  public static class TestCookieJar implements CookieJar {
-    private List<Cookie> cookies;
-
-    @Override
-    public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
-      this.cookies = cookies;
-    }
-
-    @Override
-    public List<Cookie> loadForRequest(@NotNull HttpUrl url) {
-      if (cookies != null) {
-        return cookies;
-      }
-      return new ArrayList<>();
-    }
   }
 }


### PR DESCRIPTION
Many build failures recently due to inability to start http servers - port already in use. 2 tests are using the same port.