### PR TITLE
DRILL-8251: Upgrade Hadoop 2 Due to CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4007,7 +4007,7 @@
         </property>
       </activation>
       <properties>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>2.10.2</hadoop.version>
       </properties>
       <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# [DRILL-8251](https://issues.apache.org/jira/browse/DRILL-8251): Upgrade hadoop 2 due to CVE

## Description

Relates to https://github.com/apache/drill/security/dependabot/21

## Documentation

Unknown

## Testing

CI build
