### PR TITLE
DRILL-8253: Support Limit Results in Kafka Scan

### DIFF
--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
@@ -62,6 +62,7 @@ public class KafkaRecordReader implements ManagedReader<SchemaNegotiator> {
       }
     };
     negotiator.setErrorContext(errorContext);
+    negotiator.limit(maxRecords);
 
     messageReader = MessageReaderFactory.getMessageReader(readOptions.getMessageReader());
     messageReader.init(negotiator, readOptions, plugin);
@@ -86,10 +87,6 @@ public class KafkaRecordReader implements ManagedReader<SchemaNegotiator> {
   }
 
   private boolean nextLine(RowSetLoader rowWriter) {
-    if (rowWriter.limitReached(maxRecords)) {
-      return false;
-    }
-
     if (currentOffset >= subScanSpec.getEndOffset() || !msgItr.hasNext()) {
       return false;
     }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaScanBatchCreator.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaScanBatchCreator.java
@@ -61,7 +61,7 @@ public class KafkaScanBatchCreator implements BatchCreator<KafkaSubScan> {
     builder.setUserName(subScan.getUserName());
 
     List<ManagedReader<SchemaNegotiator>> readers = subScan.getPartitionSubScanSpecList().stream()
-        .map(scanSpec -> new KafkaRecordReader(scanSpec, options, subScan.getKafkaStoragePlugin(), -1))
+        .map(scanSpec -> new KafkaRecordReader(scanSpec, options, subScan.getKafkaStoragePlugin(), subScan.getRecords()))
         .collect(Collectors.toList());
     ManagedScanFramework.ReaderFactory readerFactory = new BasicScanFactory(readers.iterator());
     builder.setReaderFactory(readerFactory);

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaStoragePlugin.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaStoragePlugin.java
@@ -76,7 +76,7 @@ public class KafkaStoragePlugin extends AbstractStoragePlugin {
     KafkaScanSpec kafkaScanSpec = selection.getListWith(new ObjectMapper(),
         new TypeReference<KafkaScanSpec>() {
         });
-    return new KafkaGroupScan(this, kafkaScanSpec, null);
+    return new KafkaGroupScan(this, kafkaScanSpec, null, -1);
   }
 
   public void registerToClose(AutoCloseable autoCloseable) {

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaSubScan.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaSubScan.java
@@ -44,6 +44,7 @@ public class KafkaSubScan extends AbstractBase implements SubScan {
 
   private final KafkaStoragePlugin kafkaStoragePlugin;
   private final List<SchemaPath> columns;
+  private final int records;
   private final List<KafkaPartitionScanSpec> partitionSubScanSpecList;
 
   @JsonCreator
@@ -51,21 +52,25 @@ public class KafkaSubScan extends AbstractBase implements SubScan {
                       @JsonProperty("userName") String userName,
                       @JsonProperty("kafkaStoragePluginConfig") KafkaStoragePluginConfig kafkaStoragePluginConfig,
                       @JsonProperty("columns") List<SchemaPath> columns,
+                      @JsonProperty("records") int records,
                       @JsonProperty("partitionSubScanSpecList") LinkedList<KafkaPartitionScanSpec> partitionSubScanSpecList)
       throws ExecutionSetupException {
     this(userName,
         registry.resolve(kafkaStoragePluginConfig, KafkaStoragePlugin.class),
         columns,
+        records,
         partitionSubScanSpecList);
   }
 
   public KafkaSubScan(String userName,
                       KafkaStoragePlugin kafkaStoragePlugin,
                       List<SchemaPath> columns,
+                      int records,
                       List<KafkaPartitionScanSpec> partitionSubScanSpecList) {
     super(userName);
     this.kafkaStoragePlugin = kafkaStoragePlugin;
     this.columns = columns;
+    this.records = records;
     this.partitionSubScanSpecList = partitionSubScanSpecList;
   }
 
@@ -77,7 +82,7 @@ public class KafkaSubScan extends AbstractBase implements SubScan {
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
     Preconditions.checkArgument(children.isEmpty());
-    return new KafkaSubScan(getUserName(), kafkaStoragePlugin, columns, partitionSubScanSpecList);
+    return new KafkaSubScan(getUserName(), kafkaStoragePlugin, columns, records, partitionSubScanSpecList);
   }
 
   @Override
@@ -93,6 +98,11 @@ public class KafkaSubScan extends AbstractBase implements SubScan {
   @JsonProperty
   public List<SchemaPath> getColumns() {
     return columns;
+  }
+
+  @JsonProperty
+  public int getRecords() {
+    return records;
   }
 
   @JsonProperty

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
@@ -64,6 +64,16 @@ public class KafkaQueriesTest extends KafkaTestBase {
   }
 
   @Test
+  public void testResultLimit() throws Exception {
+    String queryString = String.format(TestQueryConstants.MSG_LIMIT_QUERY, TestQueryConstants.JSON_TOPIC);
+    queryBuilder()
+      .sql(queryString)
+      .planMatcher()
+      .include("Scan", "records=3")
+      .match();
+  }
+
+  @Test
   public void testResultCount() {
     String queryString = String.format(TestQueryConstants.MSG_SELECT_QUERY, TestQueryConstants.JSON_TOPIC);
     runKafkaSQLVerifyCount(queryString, TestKafkaSuit.NUM_JSON_MSG);

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestQueryConstants.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestQueryConstants.java
@@ -40,6 +40,7 @@ public interface TestQueryConstants {
   // Queries
   String MSG_COUNT_QUERY = "select count(*) from kafka.`%s`";
   String MSG_SELECT_QUERY = "select * from kafka.`%s`";
+  String MSG_LIMIT_QUERY = "select * from kafka.`%s` limit 3";
   String MIN_OFFSET_QUERY = "select MIN(kafkaMsgOffset) as minOffset from kafka.`%s`";
   String MAX_OFFSET_QUERY = "select MAX(kafkaMsgOffset) as maxOffset from kafka.`%s`";
 


### PR DESCRIPTION
# [DRILL-8253](https://issues.apache.org/jira/browse/DRILL-8253): Support the limit results in kafka scan

## Description
In the current implementation of the kafka storage, although we use the limit detection method in the result loader, but the actual `maxRecords` is always -1.

The mechanism for this revision is to get limit (SQL parsing from the execution plan stage) from the group scan, then pass it to the sub-scan, and finally process it in the result loader.

## Documentation
N/A

## Testing
Added the unit test. KafkaQueriesTest#testResultLimit()
