### PR TITLE
DRILL-8254: upgrade mysql-connectors-java to 8.0.28 due to CVE-2022-21363

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Storage : JDBC</name>
 
   <properties>
-    <mysql.connector.version>8.0.25</mysql.connector.version>
+    <mysql.connector.version>8.0.28</mysql.connector.version>
     <clickhouse.jdbc.version>0.3.1</clickhouse.jdbc.version>
     <h2.version>2.1.210</h2.version>
     <postgresql.version>42.3.3</postgresql.version>


### PR DESCRIPTION
# [DRILL-8254](https://issues.apache.org/jira/browse/DRILL-8254): upgrade mysql-connectors-java to 8.0.28 due to CVE-2022-21363

## Description
Upgrade mysql-connectors-java to 8.0.28 due to CVE-2022-21363

## Documentation
Please refer to https://github.com/advisories/GHSA-g76j-4cxx-23h9

## Testing
UT test
