### PR TITLE
[BACKPORT-TO-STABLE] Bugfix Release 1.20.2 

### DIFF
--- a/contrib/format-httpd/src/test/java/org/apache/drill/exec/store/httpd/TestHTTPDLogReader.java
+++ b/contrib/format-httpd/src/test/java/org/apache/drill/exec/store/httpd/TestHTTPDLogReader.java
@@ -118,6 +118,12 @@ public class TestHTTPDLogReader extends ClusterTest {
       "\\\"%{User-agent}i\\\"', " +
       "flattenWildcards => true)) WHERE `request_firstline_original_uri_query_came__from` IS NOT NULL";
 
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("columns=\\[`request_firstline_original_uri_query_came__from`\\]")
+      .match();
+
     RowSet results = client.queryBuilder().sql(sql).rowSet();
 
     TupleMetadata expectedSchema = new SchemaBuilder()

--- a/contrib/format-httpd/src/test/java/org/apache/drill/exec/store/httpd/TestHTTPDLogReaderUserAgent.java
+++ b/contrib/format-httpd/src/test/java/org/apache/drill/exec/store/httpd/TestHTTPDLogReaderUserAgent.java
@@ -199,8 +199,6 @@ public class TestHTTPDLogReaderUserAgent extends ClusterTest {
 
     RowSet results = client.queryBuilder().sql(sql).rowSet();
 
-    results.print();
-
     TupleMetadata expectedSchema = new SchemaBuilder()
             .addNullable("request_receive_time_epoch",                          MinorType.TIMESTAMP)
             .addNullable("request_user-agent",                                  MinorType.VARCHAR)
@@ -255,8 +253,4 @@ public class TestHTTPDLogReaderUserAgent extends ClusterTest {
     RowSetUtilities.verify(expected, results);
   }
 
-
-
 }
-
-

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMSSQL.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMSSQL.java
@@ -31,7 +31,6 @@ import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.MSSQLServerContainer;
@@ -48,7 +47,7 @@ import static org.junit.Assert.assertEquals;
 @Category(JdbcStorageTest.class)
 public class TestJdbcPluginWithMSSQL extends ClusterTest {
 
-  private static MSSQLServerContainer jdbcContainer;
+  private static MSSQLServerContainer<?> jdbcContainer;
 
   @BeforeClass
   public static void initMSSQL() throws Exception {
@@ -313,8 +312,6 @@ public class TestJdbcPluginWithMSSQL extends ClusterTest {
   }
 
   @Test
-  @Ignore
-  // TODO: Enable once the push down logic has been clarified.
   public void testLimitPushDownWithOffset() throws Exception {
     String query = "select person_id, first_name from mssql.dbo.person limit 100 offset 10";
     queryBuilder()

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMSSQL.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMSSQL.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.store.jdbc;
 
 import org.apache.drill.categories.JdbcStorageTest;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
-import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.DirectRowSet;
 import org.apache.drill.exec.physical.rowSet.RowSet;
@@ -85,7 +84,6 @@ public class TestJdbcPluginWithMSSQL extends ClusterTest {
       false,
       sourceParms,
       credentialsProvider,
-      AuthMode.SHARED_USER.name(),
       100000
     );
     jdbcStorageConfig.setEnabled(true);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -322,7 +322,8 @@ public enum PlannerPhase {
       /*
        Filter push-down related rules
        */
-      DrillPushFilterPastProjectRule.INSTANCE,
+      DrillPushFilterPastProjectRule.LOGICAL,
+      DrillPushFilterPastProjectRule.DRILL_INSTANCE,
       // Due to infinite loop in planning (DRILL-3257/CALCITE-1271), temporarily use this rule in Hep planner
       // RuleInstance.FILTER_SET_OP_TRANSPOSE_RULE,
       DrillFilterAggregateTransposeRule.INSTANCE,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushFilterPastProjectRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushFilterPastProjectRule.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner.logical;
 
+import org.apache.drill.exec.planner.common.DrillProjectRelBase;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -39,7 +40,10 @@ import java.util.List;
 
 public class DrillPushFilterPastProjectRule extends RelOptRule {
 
-  public final static RelOptRule INSTANCE = new DrillPushFilterPastProjectRule(DrillRelFactories.LOGICAL_BUILDER);
+  public final static RelOptRule LOGICAL = new DrillPushFilterPastProjectRule(
+    LogicalFilter.class, LogicalProject.class, DrillRelFactories.LOGICAL_BUILDER, "DrillPushFilterPastProjectRule:logical");
+  public final static RelOptRule DRILL_INSTANCE = new DrillPushFilterPastProjectRule(
+    DrillFilterRel.class, DrillProjectRelBase.class, DrillRelFactories.LOGICAL_BUILDER, "DrillPushFilterPastProjectRule:drill_logical");
 
   private static final Collection<String> BANNED_OPERATORS;
 
@@ -49,8 +53,9 @@ public class DrillPushFilterPastProjectRule extends RelOptRule {
     BANNED_OPERATORS.add("item");
   }
 
-  private DrillPushFilterPastProjectRule(RelBuilderFactory relBuilderFactory) {
-    super(operand(LogicalFilter.class, operand(LogicalProject.class, any())), relBuilderFactory,null);
+  private DrillPushFilterPastProjectRule(Class<? extends Filter> filter,
+    Class<? extends Project> project, RelBuilderFactory relBuilderFactory, String description) {
+    super(operand(filter, operand(project, any())), relBuilderFactory,description);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/SpnegoConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/SpnegoConfig.java
@@ -26,12 +26,12 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 public class SpnegoConfig {
 
+  // Standard Object Identifier for the SPNEGO GSS-API mechanism.
+  public static final String GSS_SPNEGO_MECH_OID = "1.3.6.1.5.5.2";
+
   private UserGroupInformation loggedInUgi;
-
   private final String principal;
-
   private final String keytab;
-
   // Optional parameter
   private final String clientNameMapping;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcSort.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/plan/DrillJdbcSort.java
@@ -42,7 +42,8 @@ public class DrillJdbcSort extends JdbcRules.JdbcSort {
       double numRows = mq.getRowCount(this);
       double cpuCost = DrillCostBase.COMPARE_CPU_COST * numRows;
       DrillCostBase.DrillCostFactory costFactory = (DrillCostBase.DrillCostFactory) planner.getCostFactory();
-      return costFactory.makeCost(numRows, cpuCost, 0, 0);
+      // adjust cost to handle the case when the original limit was split
+      return costFactory.makeCost(numRows, cpuCost, 0, 0).multiplyBy(0.1);
     }
     return super.computeSelfCost(planner, mq);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
@@ -117,7 +117,10 @@ public class TestBitBitKerberos extends BaseTestQuery {
     // initialization which causes the tests to fail. So the following two changes are required.
 
     // (1) Refresh Kerberos config.
-    sun.security.krb5.Config.refresh();
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
+
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
     defaultRealm.setAccessible(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberos.java
@@ -18,19 +18,19 @@
 package org.apache.drill.exec.rpc.user.security;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import com.typesafe.config.ConfigValueFactory;
 import org.apache.drill.categories.SecurityTest;
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.rpc.RpcMetrics;
 import org.apache.drill.exec.rpc.control.ControlRpcMetrics;
 import org.apache.drill.exec.rpc.data.DataRpcMetrics;
 import org.apache.drill.exec.rpc.security.KerberosHelper;
 import org.apache.drill.exec.rpc.user.UserRpcMetrics;
 import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.hadoop.security.authentication.util.KerberosName;
-import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -39,175 +39,171 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import javax.security.auth.Subject;
-import java.lang.reflect.Field;
 import java.security.PrivilegedExceptionAction;
-import java.util.Properties;
 
-import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertEquals;
 
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
-public class TestUserBitKerberos extends BaseTestQuery {
-  //private static final org.slf4j.Logger logger =org.slf4j.LoggerFactory.getLogger(TestUserBitKerberos.class);
+public class TestUserBitKerberos extends ClusterTest {
 
   private static KerberosHelper krbHelper;
 
   @BeforeClass
   public static void setupTest() throws Exception {
-
     krbHelper = new KerberosHelper(TestUserBitKerberos.class.getSimpleName(), null);
     krbHelper.setupKdc(dirTestWatcher.getTmpDir());
+    cluster = defaultClusterConfig().build();
+  }
 
-    // Create a new DrillConfig which has user authentication enabled and authenticator set to
-    // UserAuthenticatorTestImpl.
-    final DrillConfig newConfig = new DrillConfig(DrillConfig.create(cloneDefaultTestConfigProperties())
-      .withValue(ExecConstants.USER_AUTHENTICATION_ENABLED,
-        ConfigValueFactory.fromAnyRef(true))
-      .withValue(ExecConstants.USER_AUTHENTICATOR_IMPL,
-        ConfigValueFactory.fromAnyRef(UserAuthenticatorTestImpl.TYPE))
-      .withValue(ExecConstants.SERVICE_PRINCIPAL,
-        ConfigValueFactory.fromAnyRef(krbHelper.SERVER_PRINCIPAL))
-      .withValue(ExecConstants.SERVICE_KEYTAB_LOCATION,
-        ConfigValueFactory.fromAnyRef(krbHelper.serverKeytab.toString()))
-      .withValue(ExecConstants.AUTHENTICATION_MECHANISMS,
-        ConfigValueFactory.fromIterable(Lists.newArrayList("plain", "kerberos"))));
-
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.USER, "anonymous");
-    connectionProps.setProperty(DrillProperties.PASSWORD, "anything works!");
-
-    // Ignore the compile time warning caused by the code below.
-
-    // Config is statically initialized at this point. But the above configuration results in a different
-    // initialization which causes the tests to fail. So the following two changes are required.
-
-    // (1) Refresh Kerberos config.
-    sun.security.krb5.Config.refresh();
-    // (2) Reset the default realm.
-    final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
-    defaultRealm.setAccessible(true);
-    defaultRealm.set(null, KerberosUtil.getDefaultRealm());
-
-    updateTestCluster(1, newConfig, connectionProps);
+  private static ClusterFixtureBuilder defaultClusterConfig() {
+    return ClusterFixture.bareBuilder(dirTestWatcher)
+      .clusterSize(1)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .configProperty(ExecConstants.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+      .configProperty(ExecConstants.SERVICE_KEYTAB_LOCATION, krbHelper.serverKeytab.toString())
+      .configNonStringProperty(ExecConstants.AUTHENTICATION_MECHANISMS, Lists.newArrayList("plain", "kerberos"));
   }
 
   @Test
   public void successKeytab() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.USER, krbHelper.CLIENT_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KEYTAB, krbHelper.clientKeytab.getAbsolutePath());
-    updateClient(connectionProps);
+    try (
+      ClientFixture client = cluster.clientBuilder()
+      .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+      .property(DrillProperties.USER, krbHelper.CLIENT_PRINCIPAL)
+      .property(DrillProperties.KEYTAB, krbHelper.clientKeytab.getAbsolutePath())
+      .build()
+    ) {
 
-    // Run few queries using the new client
-    testBuilder()
+      // Run few queries using the new client
+      client.testBuilder()
         .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
         .unOrdered()
         .baselineColumns("session_user")
         .baselineValues(krbHelper.CLIENT_SHORT_NAME)
         .go();
-    test("SHOW SCHEMAS");
-    test("USE INFORMATION_SCHEMA");
-    test("SHOW TABLES");
-    test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
-    test("SELECT * FROM cp.`region.json` LIMIT 5");
+
+      client.runSqlSilently("SHOW SCHEMAS");
+      client.runSqlSilently("USE INFORMATION_SCHEMA");
+      client.runSqlSilently("SHOW TABLES");
+      client.runSqlSilently("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
+      client.runSqlSilently("SELECT * FROM cp.`region.json` LIMIT 5");
+    }
   }
 
   @Test
   public void successTicket() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KERBEROS_FROM_SUBJECT, "true");
-    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(krbHelper.CLIENT_PRINCIPAL,
-      krbHelper.clientKeytab.getAbsoluteFile());
+    Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
+      krbHelper.CLIENT_PRINCIPAL,
+      krbHelper.clientKeytab.getAbsoluteFile()
+    );
 
-    Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        updateClient(connectionProps);
-        return null;
-      }
-    });
+    try (
+      ClientFixture client = Subject.doAs(
+        clientSubject,
+        (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
+          .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+          .property(DrillProperties.KERBEROS_FROM_SUBJECT, "true")
+          .build()
+      )
+    ) {
 
     // Run few queries using the new client
-    testBuilder()
-        .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
-        .unOrdered()
-        .baselineColumns("session_user")
-        .baselineValues(krbHelper.CLIENT_SHORT_NAME)
-        .go();
-    test("SHOW SCHEMAS");
-    test("USE INFORMATION_SCHEMA");
-    test("SHOW TABLES");
-    test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
-    test("SELECT * FROM cp.`region.json` LIMIT 5");
+    client.testBuilder()
+      .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
+      .unOrdered()
+      .baselineColumns("session_user")
+      .baselineValues(krbHelper.CLIENT_SHORT_NAME)
+      .go();
+
+    client.runSqlSilently("SHOW SCHEMAS");
+    client.runSqlSilently("USE INFORMATION_SCHEMA");
+    client.runSqlSilently("SHOW TABLES");
+    client.runSqlSilently("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE 'COLUMNS'");
+    client.runSqlSilently("SELECT * FROM cp.`region.json` LIMIT 5");
+    }
+   }
+
+  @Test
+  @Ignore("See DRILL-5387. This test works in isolation but not when sharing counters with other tests")
+  public void testUnencryptedConnectionCounter() throws Exception {
+    Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
+      krbHelper.CLIENT_PRINCIPAL,
+      krbHelper.clientKeytab.getAbsoluteFile()
+    );
+
+    try (
+      // Use a dedicated cluster fixture so that the tested RPC counters have a clean start.
+      ClusterFixture cluster = defaultClusterConfig().build();
+      ClientFixture client = Subject.doAs(
+        clientSubject,
+        (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
+          .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+          .property(DrillProperties.KERBEROS_FROM_SUBJECT, "true")
+          .build()
+      )
+    ) {
+      client.testBuilder()
+          .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
+          .unOrdered()
+          .baselineColumns("session_user")
+          .baselineValues(krbHelper.CLIENT_SHORT_NAME)
+          .go();
+
+      RpcMetrics userMetrics = UserRpcMetrics.getInstance(),
+        ctrlMetrics = ControlRpcMetrics.getInstance(),
+        dataMetrics = DataRpcMetrics.getInstance();
+
+      // Check encrypted counters value
+      assertEquals(0, userMetrics.getEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getEncryptedConnectionCount());
+      assertEquals(0, dataMetrics.getEncryptedConnectionCount());
+
+      // Check unencrypted counters value
+      assertEquals(1, userMetrics.getUnEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getUnEncryptedConnectionCount());
+      assertEquals(0, dataMetrics.getUnEncryptedConnectionCount());
+    }
   }
 
   @Test
-  public void testUnecryptedConnectionCounter() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KERBEROS_FROM_SUBJECT, "true");
-    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(krbHelper.CLIENT_PRINCIPAL,
-        krbHelper.clientKeytab.getAbsoluteFile());
+  @Ignore("See DRILL-5387. This test works in isolation but not when sharing counters with other tests")
+  public void testUnencryptedConnectionCounter_LocalControlMessage() throws Exception {
+    Subject clientSubject = JaasKrbUtil.loginUsingKeytab(
+      krbHelper.CLIENT_PRINCIPAL,
+      krbHelper.clientKeytab.getAbsoluteFile()
+    );
 
-    Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        updateClient(connectionProps);
-        return null;
-      }
-    });
+    try (
+      // Use a dedicated cluster fixture so that the tested RPC counters have a clean start.
+      ClusterFixture cluster = defaultClusterConfig().build();
+      ClientFixture client = Subject.doAs(
+        clientSubject,
+        (PrivilegedExceptionAction<ClientFixture>) () -> cluster.clientBuilder()
+          .property(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL)
+          .property(DrillProperties.KERBEROS_FROM_SUBJECT, "true")
+          .build()
+      )
+     ) {
+      // Run query on memory system table this sends remote fragments to all Drillbit and Drillbits then send data
+      // using data channel. In this test we have only 1 Drillbit so there should not be any control connection but a
+      // local data connections
+      client.runSqlSilently("SELECT * FROM sys.memory");
 
-    // Run few queries using the new client
-    testBuilder()
-        .sqlQuery("SELECT session_user FROM (SELECT * FROM sys.drillbits LIMIT 1)")
-        .unOrdered()
-        .baselineColumns("session_user")
-        .baselineValues(krbHelper.CLIENT_SHORT_NAME)
-        .go();
+      RpcMetrics userMetrics = UserRpcMetrics.getInstance(),
+        ctrlMetrics = ControlRpcMetrics.getInstance(),
+        dataMetrics = DataRpcMetrics.getInstance();
 
-    // Check encrypted counters value
-    assertTrue(0 == UserRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == DataRpcMetrics.getInstance().getEncryptedConnectionCount());
+      // Check encrypted counters value
+      assertEquals(0, userMetrics.getEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getEncryptedConnectionCount());
+      assertEquals(0, dataMetrics.getEncryptedConnectionCount());
 
-    // Check unencrypted counters value
-    assertTrue(1 == UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(0 == DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-  }
-
-  @Test
-  public void testUnecryptedConnectionCounter_LocalControlMessage() throws Exception {
-    final Properties connectionProps = new Properties();
-    connectionProps.setProperty(DrillProperties.SERVICE_PRINCIPAL, krbHelper.SERVER_PRINCIPAL);
-    connectionProps.setProperty(DrillProperties.KERBEROS_FROM_SUBJECT, "true");
-    final Subject clientSubject = JaasKrbUtil.loginUsingKeytab(krbHelper.CLIENT_PRINCIPAL,
-      krbHelper.clientKeytab.getAbsoluteFile());
-
-    Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-        updateClient(connectionProps);
-        return null;
-      }
-    });
-
-    // Run query on memory system table this sends remote fragments to all Drillbit and Drillbits then send data
-    // using data channel. In this test we have only 1 Drillbit so there should not be any control connection but a
-    // local data connections
-    testSql("SELECT * FROM sys.memory");
-
-    // Check encrypted counters value
-    assertTrue(0 == UserRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getEncryptedConnectionCount());
-    assertTrue(0 == DataRpcMetrics.getInstance().getEncryptedConnectionCount());
-
-    // Check unencrypted counters value
-    assertTrue(1 == UserRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(0 == ControlRpcMetrics.getInstance().getUnEncryptedConnectionCount());
-    assertTrue(2 == DataRpcMetrics.getInstance().getUnEncryptedConnectionCount());
+      // Check unencrypted counters value
+      assertEquals(1, userMetrics.getUnEncryptedConnectionCount());
+      assertEquals(0, ctrlMetrics.getUnEncryptedConnectionCount());
+      assertEquals(2, dataMetrics.getUnEncryptedConnectionCount());
+    }
   }
 
   @AfterClass

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -29,6 +29,7 @@ import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.WebServerConstants;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoAuthenticator;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoLoginService;
+import org.apache.drill.exec.server.rest.auth.SpnegoConfig;
 import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.security.authentication.util.KerberosName;
@@ -50,7 +51,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import sun.security.jgss.GSSUtil;
 
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
@@ -67,7 +67,6 @@ import static org.mockito.Mockito.verify;
 /**
  * Test for validating {@link DrillSpnegoAuthenticator}
  */
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestDrillSpnegoAuthenticator extends BaseTest {
 
@@ -84,8 +83,10 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
     spnegoHelper = new KerberosHelper(TestSpnegoAuthentication.class.getSimpleName(), primaryName);
     spnegoHelper.setupKdc(dirTestWatcher.getTmpDir());
 
-
-    sun.security.krb5.Config.refresh();
+    // (1) Refresh Kerberos config.
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
 
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");
@@ -203,6 +204,7 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
    * {@link DrillSpnegoAuthenticator#validateRequest(javax.servlet.ServletRequest, javax.servlet.ServletResponse, boolean)}
    */
   @Test
+  @Ignore("See DRILL-5387")
   public void testAuthClientRequestForLogOut() throws Exception {
     final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -242,7 +244,7 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
       final GSSManager gssManager = GSSManager.getInstance();
       GSSContext gssContext = null;
       try {
-        final Oid oid = GSSUtil.GSS_SPNEGO_MECH_OID;
+        final Oid oid = new Oid(SpnegoConfig.GSS_SPNEGO_MECH_OID);
         final GSSName serviceName = gssManager.createName(spnegoHelper.SERVER_PRINCIPAL, GSSName.NT_USER_NAME, oid);
 
         gssContext = gssManager.createContext(serviceName, oid, null, GSSContext.DEFAULT_LIFETIME);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoConfig.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -46,11 +45,8 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for validating {@link SpnegoConfig}
  */
-@Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
 public class TestSpnegoConfig extends BaseTest {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSpnegoConfig.class);
-
   private static KerberosHelper spnegoHelper;
 
   private static final String primaryName = "HTTP";
@@ -62,8 +58,10 @@ public class TestSpnegoConfig extends BaseTest {
     spnegoHelper = new KerberosHelper(TestSpnegoAuthentication.class.getSimpleName(), primaryName);
     spnegoHelper.setupKdc(dirTestWatcher.getTmpDir());
 
-
-    sun.security.krb5.Config.refresh();
+    // (1) Refresh Kerberos config.
+    // This disabled call to an unsupported internal API does not appear to be
+    // required and it prevents compiling with a target of JDK 8 on newer JDKs.
+    // sun.security.krb5.Config.refresh();
 
     // (2) Reset the default realm.
     final Field defaultRealm = KerberosName.class.getDeclaredField("defaultRealm");

--- a/pom.xml
+++ b/pom.xml
@@ -4004,7 +4004,7 @@
         </property>
       </activation>
       <properties>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>2.10.2</hadoop.version>
       </properties>
       <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3985,6 +3985,7 @@
         <jdk>[9,)</jdk>
       </activation>
       <properties>
+        <maven.compiler.release>8</maven.compiler.release>
         <junit.args>
           --add-opens=java.base/java.lang=ALL-UNNAMED
           --add-opens java.base/java.net=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
     <univocity-parsers.version>2.8.3</univocity-parsers.version>
     <mongo.version>4.3.3</mongo.version>
     <junit.args />
+    <log4j.version>2.17.2</log4j.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
# [BACKPORT-TO-STABLE] Bugfix Release 1.20.2 

## Description

Merged several backport-to-stable commits for new bugfix release 1.20.2, which includes:

* https://github.com/apache/drill/pull/2577
* https://github.com/apache/drill/pull/2572
* https://github.com/apache/drill/pull/2565
* https://github.com/apache/drill/pull/2564

Commit with backport-to-stable tag https://github.com/apache/drill/pull/2575, bases on commit https://github.com/apache/drill/pull/2516, which is a new feature after release 1.20. So excluded from this PR.

## Documentation
None.

## Testing
UT