### PR TITLE
DRILL-8158: Remove non-reproducible build outputs

### DIFF
--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -246,6 +246,10 @@
       <outputDirectory />
     </file>
     <file>
+      <source>../git.properties</source>
+      <outputDirectory />
+    </file>
+    <file>
       <source>src/main/resources/runbit</source>
       <fileMode>0755</fileMode>
       <outputDirectory>bin</outputDirectory>

--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -246,10 +246,6 @@
       <outputDirectory />
     </file>
     <file>
-      <source>../git.properties</source>
-      <outputDirectory />
-    </file>
-    <file>
       <source>src/main/resources/runbit</source>
       <fileMode>0755</fileMode>
       <outputDirectory>bin</outputDirectory>

--- a/docs/dev/Release.md
+++ b/docs/dev/Release.md
@@ -27,9 +27,7 @@
 
         Example:
         ```
-        Note for the committers:
-        until the release is not over and Drill version is not changed to 1.17.0-SNAPSHOT, please do not push any
-        changes into Drill master.
+        Note for committers: until the release is over and Drill version is changed to 1.17.0-SNAPSHOT, please do not push any changes into Drill master.
         ```
 2. ## Setup environment:
     1. ### SVN
@@ -202,14 +200,9 @@
     The release script will push the maven artifacts to the Maven staging repo.
 
 5. ## Multiple builds
-    Currently, releasing multiple builds is done by performing consecutive releases.  E.g. to add
-    an Hadoop 2 build of Drill,  loop back to the top of the instructions now and start again with
-    a build profile of 'hadoop-2' and a release version of '1.17.0-hadoop2'.  Note that it is not
-    necessary to close the jar release in the Maven repo first since the artifacts from your next
-    release will cause no identifier collisions due to their different version suffix.  This means
-    that a single Maven repo can hold the artifacts for both 1.17.0 and 1.17.0-hadoop2.
+    For each additional build of Drill beyond the default, e.g. an Hadoop 2 build, create only the signed archives of the source and binaries and upload these to the Apache distribution network using svn. Do not run the full release process again using the Maven release plugin since that will result in the unwanted creation of a new Drill version number. This has the consequence that for additional builds we do not publish code artifacts to the Apache Maven repo. Users of these builds who require these artifacts must therefore build them by compiling Drill under the appropriate profile themselves.
 
-5. ## Publish release candidate and vote
+6. ## Publish release candidate and vote
     1. Go to the [Apache Maven staging repo](https://repository.apache.org/) and close the new jar release.
         This step is done in the Maven GUI. For detailed instructions on sonatype GUI please refer to
         https://central.sonatype.org/pages/releasing-the-deployment.html#locate-and-examine-your-staging-repository.

--- a/docs/dev/Release.md
+++ b/docs/dev/Release.md
@@ -88,7 +88,7 @@
             1. run `mvn --encrypt-master-password` and add an encrypted master password to `security-settings.xml` file;
             2. run `mvn --encrypt-password` and add an encrypted Apache LDAP password to `settings.xml` file.
     5. Check that `NOTICE` file in sources has the current copyright year.
-    6. Make sure you are using JDK 8.
+    6. ~~Make sure you are using JDK 8~~. Since the completion of DRILL-8113 it is now possible to build Drill using newer JDKs while continuing to target JDK 8. Nevertheless, always test Drill under JDK 8 after building it.
 3. ## Manual Release process (this section is more for information how release process is performed, release manager should use `automated release process` described later).
     1. Setup GPG Password env variable:
         ```

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/VersionIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/VersionIterator.java
@@ -35,7 +35,9 @@ public class VersionIterator implements Iterator<Object>{
     public String commit_id = "Unknown";
     public String commit_message = "";
     public String commit_time = "";
+    /** @deprecated No longer populated in order to achieve reproducible builds */
     public String build_email = "Unknown";
+    /** @deprecated No longer populated in order to achieve reproducible builds */
     public String build_time = "";
 
     public VersionInfo(){

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,7 @@
             </manifest>
             <manifestEntries>
               <Extension-Name>org.apache.drill</Extension-Name>
+              <Built-By>${user.name}</Built-By>
               <url>https://drill.apache.org/</url>
             </manifestEntries>
           </archive>
@@ -545,6 +546,77 @@
             </goals>
             <configuration>
               <skipIfEmpty>true</skipIfEmpty>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>4.0.0</version>
+        <executions>
+          <execution>
+            <id>for-source-tarball</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <inherited>false</inherited>
+            <configuration>
+              <generateGitPropertiesFilename>./git.properties</generateGitPropertiesFilename>
+            </configuration>
+          </execution>
+        </executions>
+
+        <configuration>
+          <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
+          <verbose>false</verbose>
+          <skipPoms>false</skipPoms>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <gitDescribe>
+            <skip>false</skip>
+            <always>false</always>
+            <abbrev>7</abbrev>
+            <dirty>-dirty</dirty>
+            <forceLongFormat>true</forceLongFormat>
+          </gitDescribe>
+          <includeOnlyProperties>
+            <!-- Only include properties that are compatible with reproducible builds -->
+            <includeOnlyProperty>^git\.branch$</includeOnlyProperty>
+            <includeOnlyProperty>^git\.build\.version$</includeOnlyProperty>
+            <includeOnlyProperty>^git\.closest\.tag\..*$</includeOnlyProperty>
+            <includeOnlyProperty>^git\.commit\..*$</includeOnlyProperty>
+            <includeOnlyProperty>^git\.dirty$</includeOnlyProperty>
+            <includeOnlyProperty>^git\.tags$</includeOnlyProperty>
+            <includeOnlyProperty>^git\.total\.commit\.count$</includeOnlyProperty>
+          </includeOnlyProperties>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <encoding>UTF-8</encoding>
+        </configuration>
+        <executions>
+          <execution>
+            <!-- copy root git.properties file to target/classes folder for every module
+                to ensure that it will be placed into jar -->
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <!--suppress UnresolvedMavenProperty -->
+                  <directory>${maven.multiModuleProjectDirectory}</directory>
+                  <includes>
+                    <include>git.properties</include>
+                  </includes>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <sourceReleaseAssemblyDescriptor>source-release-zip-tar</sourceReleaseAssemblyDescriptor>
-    <project.build.outputTimestamp>1</project.build.outputTimestamp>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
     <target.gen.source.path>${project.basedir}/target/generated-sources</target.gen.source.path>
     <proto.cas.path>${project.basedir}/src/main/protobuf/</proto.cas.path>
     <junit.version>5.7.2</junit.version>
@@ -534,7 +534,6 @@
             </manifest>
             <manifestEntries>
               <Extension-Name>org.apache.drill</Extension-Name>
-              <Built-By>${user.name}</Built-By>
               <url>https://drill.apache.org/</url>
             </manifestEntries>
           </archive>
@@ -546,67 +545,6 @@
             </goals>
             <configuration>
               <skipIfEmpty>true</skipIfEmpty>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.0.0</version>
-        <executions>
-          <execution>
-            <id>for-source-tarball</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <inherited>false</inherited>
-            <configuration>
-              <generateGitPropertiesFilename>./git.properties</generateGitPropertiesFilename>
-            </configuration>
-          </execution>
-        </executions>
-
-        <configuration>
-          <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-          <verbose>false</verbose>
-          <skipPoms>false</skipPoms>
-          <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          <gitDescribe>
-            <skip>false</skip>
-            <always>false</always>
-            <abbrev>7</abbrev>
-            <dirty>-dirty</dirty>
-            <forceLongFormat>true</forceLongFormat>
-          </gitDescribe>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
-        <executions>
-          <execution>
-            <!-- copy root git.properties file to target/classes folder for every module
-                to ensure that it will be placed into jar -->
-            <phase>initialize</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <resources>
-                <resource>
-                  <!--suppress UnresolvedMavenProperty -->
-                  <directory>${maven.multiModuleProjectDirectory}</directory>
-                  <includes>
-                    <include>git.properties</include>
-                  </includes>
-                </resource>
-              </resources>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
# [DRILL-8158](https://issues.apache.org/jira/browse/DRILL-8158): Remove non-reproducible build outputs

## Description

For context see [1] and [2]. The git-commit-id plugin includes information like build host, email and time which is not compatible with a reproducible build. Drill's built in sys.version table will return the build email and time if they are present in the build's git.properties file so these columns must be deprecated. Other useful Git-related information is retained.

In accompanying commits, ~~some Kerberos unit test fixes are applied, and the tests reenabled,~~ and some updates to Release.md are included.

[1] https://maven.apache.org/guides/mini/guide-reproducible-builds.html

[2] https://github.com/jvm-repo-rebuild/reproducible-central#org.apache.drill:drill-root

## Documentation
Update the Query System Tables doc page.

## Testing
Run `select * from sys.version`. Manually inspect git.properties file.
