### PR TITLE
DRILL-8249: Parquet decoding error reading nation.dict.parquet from test framework

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -306,9 +306,10 @@ public class SSLConfigServer extends SSLConfig {
 
   @Override
   public int getHandshakeTimeout() {
-    // TODO: (DRILL-8183) why do we hard code this when we provide
-    // {@link ExecConstants.SSL_HANDSHAKE_TIMEOUT}?
-    // A value of 0 is interpreted by Netty as "no timeout".
+    // A value of 0 is interpreted by Netty as "no timeout". This is hard coded
+    // here instead being read from {@link ExecConstants.SSL_HANDSHAKE_TIMEOUT}
+    // because the SSL handshake timeout is managed from the client end only
+    // (see {@link SSLConfigClient}).
     return 0;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
@@ -223,7 +223,7 @@ public abstract class ColumnReader<V extends ValueVector> {
   }
 
   protected boolean recordsRequireDecoding() {
-    return !Collections.disjoint(VALUE_ENCODINGS, columnChunkMetaData.getEncodings());
+    return usingDictionary || !Collections.disjoint(VALUE_ENCODINGS, columnChunkMetaData.getEncodings());
   }
 
   protected boolean processPageData(int recordsToReadInThisPass) throws IOException {


### PR DESCRIPTION
# [DRILL-8249](https://issues.apache.org/jira/browse/DRILL-8249): Parquet decoding error reading nation.dict.parquet from test framework.

## Description

Thank you to @ArtTrush for finding and partially debugging this regression. The Parquet test file attached to the Jira issue cannot be queried with Drill 1.20.1 because it decides from column chunk metadata that a chunk does not use dictionary encoding and ignores new information found by the Parquet page reader that indicates that dictionary encoding is used. This fix restores the consideration of the `usingDictionary` flag which is updated by the page reader.

## Documentation
N/A

## Testing
The Drill Test Framework contains a test query and file nation.dict.parquet that reveals this bug.
