### PR TITLE
DRILL-7960: Column metadata DECIMAL precision can exceed max supported value

### DIFF
--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -807,44 +807,44 @@ public class Types {
    * @return type builder
    */
   public static MajorType.Builder calculateTypePrecisionAndScale(MajorType leftType, MajorType rightType, MajorType.Builder typeBuilder) {
-    MinorType minorType = leftType.getMinorType();
-
-    if (minorType.equals(rightType.getMinorType())) {
-      boolean isScalarString = Types.isScalarStringType(leftType) && Types.isScalarStringType(rightType);
-      boolean isDecimal = isDecimalType(leftType);
-
-      if (isScalarString && leftType.hasPrecision() && rightType.hasPrecision()) {
-        typeBuilder.setPrecision(Math.max(leftType.getPrecision(), rightType.getPrecision()));
-      }
-
-      if (isDecimal) {
-        int scale = Math.max(leftType.getScale(), rightType.getScale());
-        // resulting precision should take into account resulting scale value and be calculated as
-        // sum of two components:
-        // - max integer digits number (precision - scale) for left and right;
-        // - resulting scale.
-        // So for the case of cast(9999 as decimal(4,0)) and cast(1.23 as decimal(3,2))
-        // resulting scale would be Max(0, 2) = 2 and resulting precision
-        // would be Max(4 - 0, 3 - 2) + 2 = 6.
-        // In this case, both values would fit into decimal(6, 2): 9999.00, 1.23
-        int leftNumberOfDigits = leftType.getPrecision() - leftType.getScale();
-        int rightNumberOfDigits = rightType.getPrecision() - rightType.getScale();
-        int precision = Math.max(leftNumberOfDigits, rightNumberOfDigits) + scale;
-        int maxPrecision = maxPrecision(minorType);
-
-        if (precision > maxPrecision) {
-          logger.warn(
-            "Possible loss of precision: wanted {}({}, {}) but limited to {}({}, {})",
-            minorType, precision, scale,
-            minorType, maxPrecision, scale
-          );
-          precision = maxPrecision;
-        }
-
-        typeBuilder.setPrecision(precision);
-        typeBuilder.setScale(scale);
-      }
+    if (!leftType.getMinorType().equals(rightType.getMinorType())) {
+      return typeBuilder;
     }
+
+    if (Types.isScalarStringType(leftType) && leftType.hasPrecision() && rightType.hasPrecision()) {
+      return typeBuilder.setPrecision(Math.max(leftType.getPrecision(), rightType.getPrecision()));
+    }
+
+    MinorType minorType = leftType.getMinorType();
+    if (isDecimalType(leftType)) {
+      int scale = Math.max(leftType.getScale(), rightType.getScale());
+      // resulting precision should take into account resulting scale value and be calculated as
+      // sum of two components:
+      // - max integer digits number (precision - scale) for left and right;
+      // - resulting scale.
+      // So for the case of cast(9999 as decimal(4,0)) and cast(1.23 as decimal(3,2))
+      // resulting scale would be Max(0, 2) = 2 and resulting precision
+      // would be Max(4 - 0, 3 - 2) + 2 = 6.
+      // In this case, both values would fit into decimal(6, 2): 9999.00, 1.23
+      int leftNumberOfDigits = leftType.getPrecision() - leftType.getScale();
+      int rightNumberOfDigits = rightType.getPrecision() - rightType.getScale();
+      int precision = Math.max(leftNumberOfDigits, rightNumberOfDigits) + scale;
+      int maxPrecision = maxPrecision(minorType);
+
+      if (precision > maxPrecision) {
+        logger.warn(
+          "Possible loss of precision: wanted {}({}, {}) but limited to {}({}, {})",
+          minorType, precision, scale,
+          minorType, maxPrecision, scale
+        );
+        precision = maxPrecision;
+      }
+
+      typeBuilder.setPrecision(precision);
+      typeBuilder.setScale(scale);
+      return typeBuilder;
+    }
+
     return typeBuilder;
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestVarlenDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestVarlenDecimal.java
@@ -191,4 +191,31 @@ public class TestVarlenDecimal extends ClusterTest {
       run("drop table if exists dfs.tmp.t");
     }
   }
+
+  @Test // DRILL-7960
+  public void testWideningLimit() throws Exception {
+    // A union of VARDECIMALs that requires a widening to an unsupported
+    // DECIMAL(40, 6). The resulting column should be limited DECIMAL(38, 6)
+    // and a precision loss warning logged.
+    String query = "SELECT CAST(10 AS DECIMAL(38, 4)) AS `Col1` " +
+      "UNION ALL " +
+      "SELECT CAST(22 AS DECIMAL(29, 6)) AS `Col1`";
+
+    testBuilder().sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("Col1")
+      .baselineValues(new BigDecimal("10.000000"))
+      .baselineValues(new BigDecimal("22.000000"))
+      .go();
+
+    List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Collections.singletonList(Pair.of(
+        SchemaPath.getSimplePath("Col1"),
+        Types.withPrecisionAndScale(MinorType.VARDECIMAL, DataMode.REQUIRED, 38, 6)
+    ));
+
+    testBuilder()
+        .sqlQuery(query)
+        .schemaBaseLine(expectedSchema)
+        .go();
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MetadataUtils.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MetadataUtils.java
@@ -28,6 +28,9 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.vector.complex.DictVector;
 
+/**
+ * A collection of utility methods for working with column and tuple metadata.
+ */
 public class MetadataUtils {
 
   public static TupleSchema fromFields(Iterable<MaterializedField> fields) {


### PR DESCRIPTION
# [DRILL-7960](https://issues.apache.org/jira/browse/DRILL-7960): Column metadata DECIMAL precision can exceed max supported value.

## Description
The calculation of the decimal precision needed to encompass two input decimal precisions and scales can produce precisions greater than the maximums supported by Drill. While this does not affect the output vector itself, it does cause the error reported in the associated Jira if column metadata to be included with the result data is built using org.apache.drill.exec.record.metadata.MetadataUtils, as is done for queries sent over the REST interface. This PR limits the calculated precision to the maximum supported value when this happens and log a precision loss warning.

## Documentation
N/A

## Testing
Manually run the repro query provided in the Jira.
New unit test TestTupleSchema:testDecimalWidening()