### PR TITLE
DRILL-8263: upgrade libpam4j due to CVE

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -29,7 +29,7 @@
   <name>Drill : Exec : Java Execution Engine</name>
 
   <properties>
-    <libpam4j.version>1.8-rev2</libpam4j.version>
+    <libpam4j.version>1.11</libpam4j.version>
     <aether.version>1.1.0</aether.version>
     <wagon.version>3.3.4</wagon.version>
     <okhttp.version>4.9.3</okhttp.version>


### PR DESCRIPTION
## Description

CVE in libpam4j

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
