### PR TITLE
DRILL-8262: Remove Xalan Dependency

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -140,10 +140,6 @@
       <artifactId>xercesImpl</artifactId>
     </dependency>
     <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.codemodel</groupId>
       <artifactId>codemodel</artifactId>
       <version>${codemodel.version}</version>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -72,14 +72,10 @@
       <artifactId>sqlline</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Specify xalan and xerces versions to avoid setXIncludeAware error. -->
+    <!-- Specify xerces versions to avoid setXIncludeAware error. -->
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
     <testcontainers.version>1.16.3</testcontainers.version>
     <typesafe.config.version>1.0.0</typesafe.config.version>
     <commons.codec.version>1.14</commons.codec.version>
-    <xalan.version>2.7.2</xalan.version>
     <xerces.version>2.12.2</xerces.version>
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
@@ -1986,11 +1985,6 @@
         <version>${xerces.version}</version>
       </dependency>
       <dependency>
-        <groupId>xalan</groupId>
-        <artifactId>xalan</artifactId>
-        <version>${xalan.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
         <version>${commons.configuration.version}</version>
@@ -2774,11 +2768,6 @@
             <version>${xerces.version}</version>
           </dependency>
           <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>${xalan.version}</version>
-          </dependency>
-          <dependency>
             <groupId>net.sf.jpam</groupId>
             <artifactId>jpam</artifactId>
             <version>1.1</version>
@@ -3145,11 +3134,6 @@
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>${xerces.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>${xalan.version}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.parquet</groupId>
@@ -4041,11 +4025,6 @@
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>${xerces.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>${xalan.version}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
## Description

https://issues.apache.org/jira/browse/DRILL-8262

The mapr contrib component still pulls xalan transitively via https://mvnrepository.com/artifact/com.mapr.hadoop/maprfs/6.1.0-mapr

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
