### PR TITLE
DRILL-8268: Fix Hadoop 2 and Netty lib exclusions, REST mem limiter disabled by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       matrix:
         # Java versions to run unit tests
         java: [ '8', '11', '17' ]
+        profile: ['default-hadoop']
+        include:
+          - java: '8'
+            profile: 'hadoop-2'
       fail-fast: false
     steps:
       - name: Checkout
@@ -51,16 +55,19 @@ jobs:
         run: |
           MAVEN_OPTS="-XX:+UseG1GC"
           sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
-          mvn install --batch-mode --no-transfer-progress \
+          mvn -P${MAVEN_PROFILE} install --batch-mode --no-transfer-progress \
           -DexcludedGroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        env:
+          MAVEN_PROFILE: ${{ matrix.profile }}
       - name: Test Specific Categories # EasyOutOfMemory
         run: |
           sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
-          mvn test -pl org.apache.drill.exec:drill-java-exec \
+          mvn -P${MAVEN_PROFILE} test -pl org.apache.drill.exec:drill-java-exec \
           -Dgroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-
+        env:
+          MAVEN_PROFILE: ${{ matrix.profile }}
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,19 +55,15 @@ jobs:
         run: |
           MAVEN_OPTS="-XX:+UseG1GC"
           sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
-          mvn -P${MAVEN_PROFILE} install --batch-mode --no-transfer-progress \
+          mvn -P${{ matrix.profile }} install --batch-mode --no-transfer-progress \
           -DexcludedGroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        env:
-          MAVEN_PROFILE: ${{ matrix.profile }}
       - name: Test Specific Categories # EasyOutOfMemory
         run: |
           sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
-          mvn -P${MAVEN_PROFILE} test -pl org.apache.drill.exec:drill-java-exec \
+          mvn -P${{ matrix.profile }} test -pl org.apache.drill.exec:drill-java-exec \
           -Dgroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        env:
-          MAVEN_PROFILE: ${{ matrix.profile }}
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs
     runs-on: ubuntu-latest

--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
     </dependencies>
@@ -150,6 +154,10 @@
         <exclusion>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-jaxrs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -219,6 +219,10 @@
               <groupId>org.codehaus.jackson</groupId>
               <artifactId>jackson-xc</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>io.netty</groupId>
+              <artifactId>netty</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
         <dependency>

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -223,6 +223,10 @@
               <groupId>io.netty</groupId>
               <artifactId>netty</artifactId>
             </exclusion>
+              <exclusion>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP-java7</artifactId>
+              </exclusion>
           </exclusions>
         </dependency>
         <dependency>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -261,6 +261,10 @@
           <artifactId>netty</artifactId>
           <groupId>io.netty</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -164,6 +164,10 @@
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>reload4j</artifactId>
+          <groupId>ch.qos.reload4j</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Used by complex types tests for loading nested data -->
@@ -212,6 +216,10 @@
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>reload4j</artifactId>
+          <groupId>ch.qos.reload4j</groupId>
         </exclusion>
         <exclusion>
           <groupId>org.mortbay.jetty</groupId>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -245,6 +245,14 @@
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-xc</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>netty-all</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -284,6 +284,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -98,6 +98,16 @@
       <version>6.0.0-drill-r1</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-xc</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -270,6 +270,10 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -173,6 +173,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>log4j-over-slf4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/docs/dev/Release.md
+++ b/docs/dev/Release.md
@@ -200,8 +200,20 @@
     The release script will push the maven artifacts to the Maven staging repo.
 
 5. ## Multiple builds
-    For each additional build of Drill beyond the default, e.g. an Hadoop 2 build, create only the signed archives of the source and binaries and upload these to the Apache distribution network using svn. Do not run the full release process again using the Maven release plugin since that will result in the unwanted creation of a new Drill version number. This has the consequence that for additional builds we do not publish code artifacts to the Apache Maven repo. Users of these builds who require these artifacts must therefore build them by compiling Drill under the appropriate profile themselves.
+    For each additional build of Drill beyond the default create only the signed binary archives and upload these to the Apache distribution network using svn. Do not run the full release process again using the Maven release plugin since that will result in the unwanted creation of a new Drill version number. This has the consequence that for additional builds we do not publish code artifacts to the Apache Maven repo. Users of these builds who require these artifacts must therefore build them by compiling Drill under the appropriate profile themselves.
 
+    An example command sequence for RC0 of the Hadoop 2 build follows.
+    ```sh
+    git checkout drill-1.17.0 # check out the tag created for this release
+    git status # ensure that you working copy is completely clean
+    mvn -T1C -Phadoop-2 install -DskipTests # build Drill for Hadoop 2
+    cp distribution/target/apache-drill-1.17.0.tar.gz ~/src/release/drill-dist-dev/1.17.0-rc0/apache-drill-1.17.0-hadoop2.tar.gz
+    cd ~/src/release/drill-dist-dev
+    gpg --clearsign --output apache-drill-1.17.0-hadoop2.tar.gz.asc --detach-sign apache-drill-1.17.0-hadoop2.tar.gz
+    sha512sum apache-drill-1.17.0-hadoop2.tar.gz > apache-drill-1.17.0-hadoop2.tar.gz.sha512
+    svn add apache-drill-*-hadoop2.*
+    svn commit
+    ```
 6. ## Publish release candidate and vote
     1. Go to the [Apache Maven staging repo](https://repository.apache.org/) and close the new jar release.
         This step is done in the Maven GUI. For detailed instructions on sonatype GUI please refer to
@@ -214,13 +226,13 @@
 
         Subject:
         ```
-        [VOTE] Release Apache Drill 1.12.0 - RC0
+        [VOTE] Release Apache Drill 1.17.0 - RC0
         ```
         Body:
         ```
         Hi all,
 
-        I'd like to propose the first release candidate (RC0) of Apache Drill, version 1.12.0.
+        I'd like to propose the first release candidate (RC0) of Apache Drill, version 1.17.0.
 
         The release candidate covers a total of 100500 resolved JIRAs [1]. Thanks to everyone who contributed to this release.
 
@@ -276,7 +288,7 @@
 
             Subject:
             ```
-            [RESULT] [VOTE] Release Apache Drill 1.12.0 RC1
+            [RESULT] [VOTE] Release Apache Drill 1.17.0 RC1
             ```
             Body:
             ```

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -651,6 +651,28 @@
       </dependencies>
     </profile>
     <profile>
+      <id>hadoop-2</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <excludes>
+                  <!-- The following tests are flaky when run in the full Hadoop 2 CI. -->
+                  <exclude>**/TestBitBitKerberos.java</exclude>
+                  <exclude>**/TestUserBitKerberos.java</exclude>
+                  <exclude>**/TestUserBitKerberosEncryption.java</exclude>
+                  <exclude>**/TestDrillSpnegoAuthenticator.java</exclude>
+                  <exclude>**/TestSpnegoAuthentication.java</exclude>
+                  <exclude>**/TestSpnegoConfig.java</exclude>
+                </excludes>
+              </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>mapr</id>
       <build>
         <plugins>

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -190,7 +190,9 @@ drill.exec: {
             maximum: 9223372036854775807
         }
     },
-    memory.heap.failure.threshold: 0.85,
+    # Default to failing queries only at 100% heap usage, i.e. the heap usage
+    # limiting logic in the REST API is disabled by default.
+    memory.heap.failure.threshold: 1.0,
     web.client.resultset: {
         autolimit {
             checked: false,

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -34,7 +34,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>44100000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>45550000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>
@@ -256,10 +256,6 @@
         <exclusion>
           <groupId>com.yahoo.datasketches</groupId>
           <artifactId>sketches-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.htrace</groupId>
-          <artifactId>htrace-core4</artifactId>
         </exclusion>
         <exclusion>
           <groupId>${calcite.groupId}</groupId>
@@ -1290,7 +1286,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>47150000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>48650000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -34,7 +34,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>44000000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>44100000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>
@@ -59,6 +59,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
 
@@ -263,6 +269,10 @@
           <groupId>${calcite.groupId}</groupId>
           <artifactId>calcite-linq4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>net.sf.jpam</groupId>
+          <artifactId>jpam</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -400,7 +410,6 @@
               <exclude>com.github.stefanbirkner</exclude>
               <exclude>org.ow2.asm:*</exclude>
               <exclude>com.univocity:*</exclude>
-              <exclude>net.sf.jpam:*</exclude>
               <exclude>com.twitter:*</exclude>
               <exclude>org.apache.parquet:*</exclude>
               <exclude>javax.inject:*</exclude>
@@ -1281,7 +1290,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>47110000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>47150000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -34,7 +34,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>45550000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>46000000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>
@@ -62,6 +62,10 @@
       <version>${slf4j.version}</version>
     </dependency>
 
+    <!--
+      The JDBC driver uses a very lightweight logger backend that can only
+      log to stderr.
+    -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
@@ -366,6 +370,8 @@
             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             <app.class.path>${app.class.path}</app.class.path>
             <project.version>${project.version}</project.version>
+            <!-- Suppress noisy log messages that would hit stderr because of SimpleLogger -->
+            <org.slf4j.simpleLogger.defaultLogLevel>error</org.slf4j.simpleLogger.defaultLogLevel>
           </systemPropertyVariables>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -1286,7 +1292,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>48650000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>49000000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -62,16 +62,6 @@
       <version>${slf4j.version}</version>
     </dependency>
 
-    <!--
-      The JDBC driver uses a very lightweight logger backend that can only
-      log to stderr.
-    -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.drill</groupId>
       <artifactId>drill-common</artifactId>
@@ -370,8 +360,6 @@
             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             <app.class.path>${app.class.path}</app.class.path>
             <project.version>${project.version}</project.version>
-            <!-- Suppress noisy log messages that would hit stderr because of SimpleLogger -->
-            <org.slf4j.simpleLogger.defaultLogLevel>error</org.slf4j.simpleLogger.defaultLogLevel>
           </systemPropertyVariables>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -1230,7 +1230,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>50400000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>52800000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -34,10 +34,27 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>50000000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>44000000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>
+    <!--
+      Notes for excluding unwanted code from the JDBC driver to keep its
+      size down.
+
+      First use conventional Maven exclusions, most commonly required under
+      drill-java-exec, to try to exclude the dependency. If you cannot see
+      the code you want exclude in this module's mvn:dependency-tree under
+      a dependency where you could add an exclusion then you will need to
+      use exclusion rules in the maven-shade-plugin instead.
+
+      Once you've excluded something that was previously present in the JDBC
+      driver you need to test it. Note that neither the JDBC unit tests nor
+      drill-embedded exercise the JDBC driver JAR produced by *this module*,
+      even though they both connect to Drill using JDBC. So to test you need
+      to launch a JDBC client like DBeaver or a short Java CLI program that
+      loads the driver JAR created by this module.
+    -->
 
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -53,6 +70,10 @@
         <exclusion>
           <artifactId>javassist</artifactId>
           <groupId>javassist</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.dropwizard.metrics</groupId>
+          <artifactId>metrics-servlets</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -131,6 +152,10 @@
           <groupId>org.apache.parquet</groupId>
         </exclusion>
         <exclusion>
+          <artifactId>parquet-common</artifactId>
+          <groupId>org.apache.parquet</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>infinispan-core</artifactId>
           <groupId>org.infinispan</groupId>
         </exclusion>
@@ -196,7 +221,7 @@
         </exclusion>
         <exclusion>
           <groupId>io.airlift</groupId>
-          <artifactId>aircompresssor</artifactId>
+          <artifactId>aircompressor</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.swagger.core.v3</groupId>
@@ -205,6 +230,38 @@
         <exclusion>
           <groupId>io.swagger.core.v3</groupId>
           <artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.tdunning</groupId>
+          <artifactId>t-digest</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.bettercloud</groupId>
+          <artifactId>vault-java-driver</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.esri.geometry</groupId>
+          <artifactId>esri-geometry-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.yahoo.datasketches</groupId>
+          <artifactId>sketches-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.htrace</groupId>
+          <artifactId>htrace-core4</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>${calcite.groupId}</groupId>
+          <artifactId>calcite-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>${calcite.groupId}</groupId>
+          <artifactId>calcite-linq4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -329,8 +386,6 @@
             </includes>
             <excludes>
               <exclude>io.protostuff:*</exclude>
-              <exclude>${calcite.groupId}:calcite-core</exclude>
-              <exclude>${calcite.groupId}:calcite-linq4j</exclude>
               <exclude>org.pentaho:*</exclude>
               <exclude>org.msgpack:*</exclude>
               <exclude>xerces:*</exclude>
@@ -358,7 +413,6 @@
               <exclude>net.hydromatic:linq4j</exclude>
               <exclude>org.mortbay.jetty:*</exclude>
               <exclude>org.slf4j:jul-to-slf4j</exclude>
-              <exclude>org.slf4j:log4j-over-slf4j</exclude>
               <exclude>org.hamcrest:hamcrest-core</exclude>
               <exclude>org.mockito:mockito-core</exclude>
               <exclude>org.objenesis:objenesis</exclude>
@@ -372,14 +426,11 @@
               <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
               <exclude>com.google.code.findbugs:jsr305:*</exclude>
-              <exclude>com.esri.geometry:esri-geometry-api:*</exclude>
               <exclude>dnsjava:dnsjava:jar:*</exclude>
               <exclude>io.netty:netty-tcnative:jar:*</exclude>
               <exclude>io.netty:netty-tcnative-classes:jar:*</exclude>
-              <exclude>com.bettercloud:vault-java-driver:jar:*</exclude>
-              <exclude>com.tdunning:t-digest:jar:*</exclude>
-              <exclude>io.airlift:aircompressor:jar:*</exclude>
-              <exclude>com.rdblue:brotli-codec:jar:*</exclude>
+              <exclude>com.nimbusds:*</exclude>
+              <exclude>org.apache.yetus:*</exclude>
             </excludes>
           </artifactSet>
           <relocations>
@@ -1230,7 +1281,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>52800000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>47110000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -2175,6 +2175,10 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-jaxrs</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -2242,101 +2246,6 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <exclusions>
-              <exclusion>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>servlet-api</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>servlet-api-2.5</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>servlet-api-2.5</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-yarn-api</artifactId>
-              </exclusion>
-              <exclusion>
-                <artifactId>jets3t</artifactId>
-                <groupId>net.java.dev.jets3t</groupId>
-              </exclusion>
-              <exclusion>
-                <artifactId>log4j</artifactId>
-                <groupId>log4j</groupId>
-              </exclusion>
-              <exclusion>
-                <artifactId>slf4j-log4j12</artifactId>
-                <groupId>org.slf4j</groupId>
-              </exclusion>
-              <exclusion>
-                <artifactId>mockito-all</artifactId>
-                <groupId>org.mockito</groupId>
-              </exclusion>
-              <exclusion>
-                <artifactId>commons-logging-api</artifactId>
-                <groupId>commons-logging</groupId>
-              </exclusion>
-              <exclusion>
-                <artifactId>commons-logging</artifactId>
-                <groupId>commons-logging</groupId>
-              </exclusion>
-              <exclusion>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-core</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-server</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-json</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-client</artifactId>
-              </exclusion>
-              <exclusion>
-                <artifactId>core</artifactId>
-                <groupId>org.eclipse.jdt</groupId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-asl</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-xc</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-jaxrs</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-              </exclusion>
-            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2249,6 +2249,103 @@
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+            <exclusions>
+              <exclusion>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>servlet-api-2.5</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>servlet-api-2.5</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <artifactId>jets3t</artifactId>
+                <groupId>net.java.dev.jets3t</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>log4j</artifactId>
+                <groupId>log4j</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>slf4j-log4j12</artifactId>
+                <groupId>org.slf4j</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>mockito-all</artifactId>
+                <groupId>org.mockito</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>commons-logging-api</artifactId>
+                <groupId>commons-logging</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>commons-logging</artifactId>
+                <groupId>commons-logging</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-core</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-server</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-json</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <artifactId>core</artifactId>
+                <groupId>org.eclipse.jdt</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-xc</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-jaxrs</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
@@ -2281,35 +2378,6 @@
 
           <!-- Hadoop Test Dependencies -->
 
-          <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-            <exclusions>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-xc</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-jaxrs</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-              </exclusion>
-              <exclusion>
-                <artifactId>slf4j-log4j12</artifactId>
-                <groupId>org.slf4j</groupId>
-              </exclusion>
-              <exclusion>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-              </exclusion>
-            </exclusions>
-          </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
@@ -4192,6 +4260,10 @@
                 <groupId>org.slf4j</groupId>
               </exclusion>
               <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+              </exclusion>
+              <exclusion>
                 <artifactId>log4j</artifactId>
                 <groupId>log4j</groupId>
               </exclusion>
@@ -4316,8 +4388,8 @@
                 <groupId>org.slf4j</groupId>
               </exclusion>
               <exclusion>
-                <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
+                <groupId>org.slf4j</groupId>
               </exclusion>
               <exclusion>
                 <artifactId>asm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2200,11 +2200,23 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -2235,8 +2247,6 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
-            <scope>test</scope>
-            <classifier>tests</classifier>
             <exclusions>
               <exclusion>
                 <groupId>org.mortbay.jetty</groupId>
@@ -2332,7 +2342,6 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
-            <scope>test</scope>
             <exclusions>
               <exclusion>
                 <groupId>commons-logging</groupId>
@@ -2349,6 +2358,14 @@
               <exclusion>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -2389,6 +2406,14 @@
               <exclusion>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3967,6 +3992,58 @@
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+              <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-auth</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-common</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+              <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-client</artifactId>
             <version>${hadoop.version}</version>
             <scope>compile</scope>
@@ -4063,6 +4140,22 @@
               <exclusion>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
             </exclusions>
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2374,6 +2374,27 @@
 
           <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+            <exclusions>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-xc</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-jaxrs</artifactId>
+              </exclusion>
+              <exclusion>
+                <artifactId>slf4j-log4j12</artifactId>
+                <groupId>org.slf4j</groupId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
@@ -3882,6 +3903,14 @@
                 <groupId>org.slf4j</groupId>
               </exclusion>
               <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>slf4j-reload4j</artifactId>
+                <groupId>org.slf4j</groupId>
+              </exclusion>
+              <exclusion>
                 <artifactId>mockito-all</artifactId>
                 <groupId>org.mockito</groupId>
               </exclusion>
@@ -3938,6 +3967,10 @@
               </exclusion>
               <exclusion>
                 <artifactId>slf4j-log4j12</artifactId>
+                <groupId>org.slf4j</groupId>
+              </exclusion>
+              <exclusion>
+                <artifactId>slf4j-reload4j</artifactId>
                 <groupId>org.slf4j</groupId>
               </exclusion>
               <exclusion>
@@ -4096,6 +4129,10 @@
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
               </exclusion>
+              <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -4115,6 +4152,31 @@
             </exclusions>
           </dependency>
           <!-- Test Dependencies -->
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+              </exclusion>
+              <exclusion>
+                <artifactId>reload4j</artifactId>
+                <groupId>ch.qos.reload4j</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
@@ -4280,6 +4342,10 @@
                 <groupId>org.slf4j</groupId>
               </exclusion>
               <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+              </exclusion>
+              <exclusion>
                 <artifactId>log4j</artifactId>
                 <groupId>log4j</groupId>
               </exclusion>
@@ -4323,6 +4389,10 @@
               <exclusion>
                 <artifactId>slf4j-log4j12</artifactId>
                 <groupId>org.slf4j</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
               </exclusion>
               <exclusion>
                 <artifactId>asm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2388,8 +2388,16 @@
                 <artifactId>jackson-jaxrs</artifactId>
               </exclusion>
               <exclusion>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+              </exclusion>
+              <exclusion>
                 <artifactId>slf4j-log4j12</artifactId>
                 <groupId>org.slf4j</groupId>
+              </exclusion>
+              <exclusion>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
               </exclusion>
             </exclusions>
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2441,6 +2441,10 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-jaxrs</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP-java7</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -3937,6 +3941,10 @@
               <exclusion>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-core</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP-java7</artifactId>
               </exclusion>
             </exclusions>
           </dependency>

--- a/tools/release-scripts/release.sh
+++ b/tools/release-scripts/release.sh
@@ -77,9 +77,7 @@ function readInputAndSetup(){
     read -p "Drill Working Directory : " WORK_DIR
     createDirectoryIfAbsent "${WORK_DIR}"
 
-    read -p "Build profile (e.g. hadoop-2, blank for default) : " BUILD_PROFILE
-
-    read -p "Drill Release Version (e.g. 1.4.0, 1.20.0-hadoop2) : " DRILL_RELEASE_VERSION
+    read -p "Drill Release Version (e.g. 1.4.0) : " DRILL_RELEASE_VERSION
 
     read -p "Drill Development Version (e.g. 1.5.0-SNAPSHOT) : " DRILL_DEV_VERSION
 
@@ -100,14 +98,12 @@ function readInputAndSetup(){
 
     DRILL_RELEASE_OUTFILE="${DRILL_RELEASE_OUTDIR}/drill_release.out.txt"
     DRILL_SRC=${WORK_DIR}/drill-release
-    [ -z "$BUILD_PROFILE" ] || BUILD_PROFILE="-P$BUILD_PROFILE"
 
     echo ""
     echo "-----------------"
     echo "JAVA_HOME : " ${JAVA_HOME}
     echo "Drill Working Directory : " ${WORK_DIR}
     echo "Drill Src Directory : " ${DRILL_SRC}
-    echo "Build profile mvn arg: " ${BUILD_PROFILE}
     echo "Drill Release Version : " ${DRILL_RELEASE_VERSION}
     echo "Drill Development Version : " ${DRILL_DEV_VERSION}
     echo "Release Commit SHA : " ${RELEASE_COMMIT_SHA}
@@ -163,14 +159,14 @@ runCmd "Preparing the release " mvn -X release:prepare \
   -DdevelopmentVersion=${DRILL_DEV_VERSION} \
   -DreleaseVersion=${DRILL_RELEASE_VERSION} \
   -Dtag=drill-${DRILL_RELEASE_VERSION} \
-  -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE} -DskipTests -Dmaven.javadoc.skip=false ${BUILD_PROFILE}"
+  -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE} -DskipTests -Dmaven.javadoc.skip=false"
 
 runCmd "Pushing to private repo ${MY_REPO}" git push ${MY_REPO} drill-${DRILL_RELEASE_VERSION}
 
 runCmd "Performing the release to ${MY_REPO}" mvn release:perform \
   -DconnectionUrl=scm:git:${MY_REPO} \
   -DlocalCheckout=true \
-  -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE} -DskipTests ${BUILD_PROFILE}"
+  -Darguments="-Dgpg.passphrase=${GPG_PASSPHRASE} -DskipTests"
 
 runCmd "Checking out release commit" git checkout drill-${DRILL_RELEASE_VERSION}
 


### PR DESCRIPTION
# [DRILL-8268](https://issues.apache.org/jira/browse/DRILL-8268): Fix Hadoop 2 and Netty lib exclusions, REST mem limiter disabled by default

## Description

1. New exclusions of reload4j, slf4j-reload4j are required in the Hadoop 2 profile, probably due to the upgrade of Hadoop from 2.10.1 to 2.10.2.
2. We remove the netty-all metapackage which entered the dependency tree with the change introducing the Netty bom bringing many uneeded libs with it.
3. The heap memory usage limiting logic in the REST server becomes disabled by default since REST query results are streamed these days. This change aims to let the Java GC now do its job without interference and if that results in OOM under a constant load then there is good evidence for a heap leak which must be tracked and completely resolved anyway, not mitigated or "swept under a rug".

## Documentation
N/A

## Testing
Lib exclusions: successful build and launch under the Hadoop 2 profile, check for the presence of Netty and log library jars.
Heap memory usage: I probably recommend a new (or existing) performance test in the drill-test-framework over unit test but I'm open to ideas.
