### PR TITLE
DRILL-8269: Classified metrics for easier maintenance

### DIFF
--- a/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
@@ -20,17 +20,20 @@ package org.apache.drill.exec.metrics;
 import java.lang.management.ManagementFactory;
 import java.util.concurrent.TimeUnit;
 
-import com.codahale.metrics.jmx.JmxReporter;
+import org.apache.drill.exec.util.SystemPropertyUtil;
+
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
+import com.codahale.metrics.jmx.JmxReporter;
 import com.codahale.metrics.jvm.BufferPoolMetricSet;
+import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
+import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-import org.apache.drill.exec.util.SystemPropertyUtil;
 
 public final class DrillMetrics {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillMetrics.class);
@@ -45,21 +48,21 @@ public final class DrillMetrics {
   private static class RegistryHolder {
 
     private static final MetricRegistry REGISTRY;
-    private static final JmxReporter JMX_REPORTER;
-    private static final Slf4jReporter LOG_REPORTER;
 
     static {
       REGISTRY = new MetricRegistry();
       registerSystemMetrics();
-      JMX_REPORTER = getJmxReporter();
-      LOG_REPORTER = getLogReporter();
+      getJmxReporter();
+      getLogReporter();
     }
 
     private static void registerSystemMetrics() {
       REGISTRY.registerAll(new GarbageCollectorMetricSet());
-      REGISTRY.registerAll(new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
-      REGISTRY.registerAll(new MemoryUsageGaugeSet());
-      REGISTRY.registerAll(new ThreadStatesGaugeSet());
+      REGISTRY.registerAll(MetricsCategory.BUFFERPOOL_PREFIX, new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+      REGISTRY.registerAll(MetricsCategory.MEMORY_PREFIX, new MemoryUsageGaugeSet());
+      REGISTRY.registerAll(MetricsCategory.THREADS_PREFIX, new ThreadStatesGaugeSet());
+      REGISTRY.registerAll(MetricsCategory.CACHED_THREADS_PREFIX, new CachedThreadStatesGaugeSet(1, TimeUnit.MINUTES));
+      REGISTRY.registerAll(MetricsCategory.CLASS_PREFIX, new ClassLoadingGaugeSet());
       REGISTRY.registerAll(new CpuGaugeSet());
       register("fd.usage", new FileDescriptorRatioGauge());
     }

--- a/common/src/main/java/org/apache/drill/exec/metrics/MetricsCategory.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/MetricsCategory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metrics;
+
+public class MetricsCategory {
+
+  public static final String DRILL_PREFIX = "drill";
+  public static final String BUFFERPOOL_PREFIX = "jvm";
+  public static final String MEMORY_PREFIX = "memory";
+  public static final String THREADS_PREFIX = "threads";
+  public static final String CACHED_THREADS_PREFIX = "cached-threads";
+  public static final String CLASS_PREFIX = "class";
+
+}

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -493,8 +493,8 @@
             }
             let metrics = data.responseJSON['gauges'];
             //Memory
-            let usedHeap = metrics['heap.used'].value;
-            let maxHeap = metrics['heap.max'].value;
+            let usedHeap = metrics['memory.heap.used'].value;
+            let maxHeap = metrics['memory.heap.max'].value;
             let usedDirect = metrics['drill.allocator.root.used'].value;
             let peakDirect = metrics['drill.allocator.root.peak'].value;
             let heapUsage = computeMemUsage(usedHeap, maxHeap);
@@ -515,7 +515,7 @@
             //AvgSysLoad
             let avgSysLoad = metrics['os.load.avg'].value;
             let sysLoadElem = rowElem.getElementsByClassName("avgload")[0];
-            sysLoadElem.innerHTML = avgSysLoad;
+            sysLoadElem.innerHTML = avgSysLoad.toFixed(2);
             //Uptime
             let uptimeValue = metrics['drillbit.uptime'].value;
             let uptimeElem = rowElem.getElementsByClassName("uptime")[0];

--- a/exec/java-exec/src/main/resources/rest/metrics/metrics.ftl
+++ b/exec/java-exec/src/main/resources/rest/metrics/metrics.ftl
@@ -38,21 +38,25 @@
         <div id="heapUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
       </div>
-      Non heap
+      <div id="heapValue" class="progress-value"></div>
+      Non Heap
       <div class="progress">
         <div id="non-heapUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
       </div>
+      <div id="non-heapValue" class="progress-value"></div>
       Total
       <div class="progress">
         <div id="totalUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
       </div>
+      <div id="totalValue" class="progress-value"></div>
       Actively Used Direct (Estimate)
       <div class="progress">
         <div id="estDirectUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
       </div>
+      <div id="estDirectValue" class="progress-value"></div>
     </div>
 
     <div id="mainDiv" class="col-md-9" role="main">
@@ -129,22 +133,27 @@
 
     function updateBars(gauges) {
       $.each(["heap","non-heap","total","drill.allocator.root"], function(i, key) {
-        var used = gauges[key + ".used"].value;
+      	var used;
+      	if (isAllocator(key)) {
+      	  used = gauges[key + ".used"].value;
+      	} else {
+      	  used = gauges["memory." + key + ".used"].value;
+      	}
         var max;
         if (isAllocator(key)) {
           max = gauges[key + ".peak"].value;
         } else {
-          max = gauges[key + ".max"].value;
+          max = gauges["memory." + key + ".max"].value;
         }
         var percent = round((100 * used / max), 2);
         var usage = getGBUsageText(used, percent);
-
-        var styleVal = "width: " + percent + "%;color: #202020;white-space: nowrap"
+        var styleVal = "width: " + percent + "%;color: transparent;white-space: nowrap"
         $("#" + (isAllocator(key) ? "estDirect" : key) + "Usage").attr({
           "aria-valuenow" : percent,
           "style" : styleVal
         });
-        $("#" + (isAllocator(key) ? "estDirect" : key) + "Usage").html(usage);
+        $("#" + (isAllocator(key) ? "estDirect" : key) + "Usage").html("-");
+        $("#" + (isAllocator(key) ? "estDirect" : key) + "Value").html(usage);
       });
     };
 

--- a/exec/java-exec/src/main/resources/rest/static/css/drillStyle.css
+++ b/exec/java-exec/src/main/resources/rest/static/css/drillStyle.css
@@ -1,9 +1,11 @@
 body {
     padding-top: 80px;
 }
+
 .material-icons, .icon-text {
     vertical-align: middle;
 }
+
 .close {
     outline: none;
 }
@@ -30,4 +32,8 @@ body {
   direction: ltr;
   -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
+}
+
+.progress-value {
+  color: gray
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.11.0</avro.version>
-    <metrics.version>4.0.2</metrics.version>
+    <metrics.version>4.2.10</metrics.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jersey.version>2.34</jersey.version>
     <javax.validation.api>2.0.1.Final</javax.validation.api>


### PR DESCRIPTION
# [DRILL-8269](https://issues.apache.org/jira/browse/DRILL-8269): Classified metrics for easier maintenance

## Description

1. Add classified prefix for metrics indicators like thread, heap, jvm and etc, so that user can easily make sense of each indicators.
2. Change the key reference of usage summary on Drill Web UI Main Page and Metrics page due to the key of each indicators has been changed. The usage can be shown correctly.
![image](https://user-images.githubusercontent.com/15710469/180781857-4a07a68e-ef92-4b73-9300-23cd711ccea5.png)

3. Drill Web UI Metrics page usage part cannot fully show the numbers if the bar isn't long enough.
![image](https://user-images.githubusercontent.com/15710469/180780993-dfb013d4-2347-4810-8865-5e09aa94d6b3.png)
After Optimized UI,
![image](https://user-images.githubusercontent.com/15710469/180782088-954435eb-7cd1-4eaa-976e-4cbeb1e0927b.png)



## Documentation

I will also update the corresponding Drill Doc later.
https://drill.apache.org/docs/monitoring-metrics/

## Testing
Manually test and UT.
