### PR TITLE
DRILL-8271: Make Storage and Format Config Case Insensitive

### DIFF
--- a/logical/src/main/java/org/apache/drill/common/logical/FormatPluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/FormatPluginConfig.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.common.logical;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
@@ -33,5 +34,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * in {@see StoragePluginConfig}s.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
 public interface FormatPluginConfig {
 }

--- a/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
@@ -18,6 +18,7 @@
 package org.apache.drill.common.logical;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
 public abstract class StoragePluginConfig {
 
   Logger logger = LoggerFactory.getLogger(StoragePluginConfig.class);


### PR DESCRIPTION
# [DRILL-8271](https://issues.apache.org/jira/browse/DRILL-8271): Make Storage and Format Config Case Insensitive

## Description
Allows format and storage configs to be case insensitive.

## Documentation
N/A

## Testing
Ran existing unit tests.