### PR TITLE
DRILL-8272: Skip MAP column without children when creating parquet tables

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/AbstractRecordWriter.java
+++ b/exec/java-exec/src/main/codegen/templates/AbstractRecordWriter.java
@@ -24,6 +24,8 @@ import java.lang.UnsupportedOperationException;
 package org.apache.drill.exec.store;
 
 import org.apache.drill.exec.expr.holders.*;
+import org.apache.drill.exec.planner.physical.WriterPrel;
+import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
 import org.apache.drill.exec.vector.BitVector;
 import org.apache.drill.exec.vector.BitVector.Accessor;
@@ -95,5 +97,10 @@ public abstract class AbstractRecordWriter implements RecordWriter {
   @Override
   public void postProcessing() throws IOException {
     // no op
+  }
+
+  @Override
+  public boolean supportsField(MaterializedField field) {
+    return !field.getName().equalsIgnoreCase(WriterPrel.PARTITION_COMPARATOR_FIELD);
   }
 }

--- a/exec/java-exec/src/main/codegen/templates/EventBasedRecordWriter.java
+++ b/exec/java-exec/src/main/codegen/templates/EventBasedRecordWriter.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.apache.drill.exec.planner.physical.WriterPrel;
 
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="org/apache/drill/exec/store/EventBasedRecordWriter.java" />
@@ -27,7 +26,6 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 
 import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.planner.physical.WriterPrel;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.vector.complex.impl.UnionReader;
@@ -81,7 +79,7 @@ public class EventBasedRecordWriter {
     try {
       int fieldId = 0;
       for (VectorWrapper w : batch) {
-        if (w.getField().getName().equalsIgnoreCase(WriterPrel.PARTITION_COMPARATOR_FIELD)) {
+        if (!recordWriter.supportsField(w.getField())) {
           continue;
         }
         FieldReader reader = w.getValueVector().getReader();

--- a/exec/java-exec/src/main/codegen/templates/RecordWriter.java
+++ b/exec/java-exec/src/main/codegen/templates/RecordWriter.java
@@ -23,6 +23,7 @@ package org.apache.drill.exec.store;
 
 import org.apache.drill.exec.expr.holders.*;
 import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
@@ -94,4 +95,9 @@ public interface RecordWriter {
   void postProcessing() throws IOException;
   void abort() throws IOException;
   void cleanup() throws IOException;
+
+  /**
+   * Checks whether this writer supports writing of the given field.
+   */
+  boolean supportsField(MaterializedField field);
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.physical.impl.writer;
 
 import org.apache.calcite.util.Pair;
+import org.apache.commons.io.FileUtils;
 import org.apache.drill.categories.ParquetTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.categories.UnlikelyTest;
@@ -57,6 +58,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -1511,6 +1513,23 @@ public class TestParquetWriter extends ClusterTest {
     } finally {
       cluster.defineFormat("dfs", "parquet", backupConfig);
     }
+  }
+
+  @Test
+  public void testResultWithEmptyMap() throws Exception {
+    String fileName = "emptyMap.json";
+
+    FileUtils.writeStringToFile(new File(dirTestWatcher.getRootDir(), fileName),
+      "{\"sample\": {}, \"a\": \"a\"}", Charset.defaultCharset());
+
+    run("create table dfs.tmp.t1 as SELECT * from dfs.`%s` t", fileName);
+
+    testBuilder()
+      .sqlQuery("select * from dfs.tmp.t1")
+      .unOrdered()
+      .baselineColumns("a")
+      .baselineValues("a")
+      .go();
   }
 
   /**


### PR DESCRIPTION
# [DRILL-8272](https://issues.apache.org/jira/browse/DRILL-8272): Skip MAP column without children when creating parquet tables

## Description
TBA

## Documentation
NA

## Testing
Unit tests pass
