### PR TITLE
DRILL-8273: Complex typed columns cannot be made implicit

### DIFF
--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -867,7 +867,6 @@ public class ExcelBatchReader implements ManagedReader {
     }
   }
 
-
   public static class TimestampCellWriter extends ExcelBatchReader.CellWriter {
     TimestampCellWriter(ScalarWriter columnWriter) {
       super(columnWriter);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestTupleProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestTupleProjection.java
@@ -60,10 +60,13 @@ public class TestTupleProjection extends BaseTest {
       MetadataUtils.newScalar("a", Types.required(MinorType.INT));
   private static final ColumnMetadata UNPROJECTED_SPECIAL_COLUMN =
       MetadataUtils.newScalar("bar", Types.required(MinorType.INT));
+  private static final ColumnMetadata COMPLEX_SPECIAL_COLUMN =
+      MetadataUtils.newMap("a_map");
 
   static {
     SPECIAL_COLUMN.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
     UNPROJECTED_SPECIAL_COLUMN.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
+    COMPLEX_SPECIAL_COLUMN.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
   }
 
   /**
@@ -76,6 +79,7 @@ public class TestTupleProjection extends BaseTest {
     assertTrue(projSet.isProjected("foo"));
     assertTrue(projSet.isProjected(NORMAL_COLUMN));
     assertFalse(projSet.isProjected(SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
     assertTrue(projSet.projections().isEmpty());
     assertFalse(projSet.isEmpty());
   }
@@ -91,6 +95,7 @@ public class TestTupleProjection extends BaseTest {
     assertNull(projSet.get("foo"));
     assertTrue(projSet.isProjected(NORMAL_COLUMN));
     assertFalse(projSet.isProjected(SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
     assertEquals(1, projSet.projections().size());
     assertFalse(projSet.isEmpty());
   }
@@ -107,6 +112,7 @@ public class TestTupleProjection extends BaseTest {
     assertFalse(projSet.isProjected("foo"));
     assertFalse(projSet.isProjected(NORMAL_COLUMN));
     assertFalse(projSet.isProjected(SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
     assertTrue(projSet.projections().isEmpty());
     assertTrue(projSet.isEmpty());
   }
@@ -128,6 +134,7 @@ public class TestTupleProjection extends BaseTest {
     assertTrue(projSet.isProjected(SPECIAL_COLUMN));
     assertFalse(projSet.isProjected(UNPROJECTED_COLUMN));
     assertFalse(projSet.isProjected(UNPROJECTED_SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
 
     List<RequestedColumn> cols = projSet.projections();
     assertEquals(3, cols.size());

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/DictColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/DictColumnMetadata.java
@@ -72,7 +72,9 @@ public class DictColumnMetadata extends AbstractMapColumnMetadata {
 
   @Override
   public ColumnMetadata cloneEmpty() {
-    return new DictColumnMetadata(name, mode, new TupleSchema());
+    ColumnMetadata colMeta = new DictColumnMetadata(name, mode, new TupleSchema());
+    colMeta.setProperties(this.properties());
+    return colMeta;
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MapColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MapColumnMetadata.java
@@ -64,7 +64,9 @@ public class MapColumnMetadata extends AbstractMapColumnMetadata {
 
   @Override
   public ColumnMetadata cloneEmpty() {
-    return new MapColumnMetadata(name, mode, new TupleSchema());
+    ColumnMetadata colMeta = new MapColumnMetadata(name, mode, new TupleSchema());
+    colMeta.setProperties(this.properties());
+    return colMeta;
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/RepeatedListColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/RepeatedListColumnMetadata.java
@@ -79,7 +79,9 @@ public class RepeatedListColumnMetadata extends AbstractColumnMetadata {
 
   @Override
   public ColumnMetadata cloneEmpty() {
-    return new RepeatedListColumnMetadata(name, null);
+    ColumnMetadata colMeta = new RepeatedListColumnMetadata(name, null);
+    colMeta.setProperties(this.properties());
+    return colMeta;
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/VariantColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/VariantColumnMetadata.java
@@ -140,7 +140,9 @@ public class VariantColumnMetadata extends AbstractColumnMetadata {
 
   @Override
   public ColumnMetadata cloneEmpty() {
-    return new VariantColumnMetadata(name, type, mode, new VariantSchema());
+    VariantColumnMetadata colMeta = new VariantColumnMetadata(name, type, mode, new VariantSchema());
+    colMeta.setProperties(this.properties());
+    return colMeta;
   }
 
   @Override


### PR DESCRIPTION
# [DRILL-8273](https://issues.apache.org/jira/browse/DRILL-8273): Complex typed columns cannot be made implicit

## Description

A number of column metadata implementations drop column properties, including the wildcard exclusion property, when cloned with cloneEmpty. This PR makes those cloneEmpty methods copy the column properties too.

## Documentation
N/A

## Testing
New additions in TestTupleProjection.
