### PR TITLE
DRILL-8275: Prevent the JDBC Client from creating spurious paths in Zookeeper

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.server;
 
 import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.utils.ZKPaths;
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.StackTrace;
 import org.apache.drill.common.concurrent.ExtendedLatch;
@@ -179,7 +180,7 @@ public class Drillbit implements AutoCloseable {
     } else {
       String clusterId = config.getString(ExecConstants.SERVICE_NAME);
       String zkRoot = config.getString(ExecConstants.ZK_ROOT);
-      String drillClusterPath = "/" + zkRoot + "/" +  clusterId;
+      String drillClusterPath = ZKPaths.PATH_SEPARATOR + zkRoot + ZKPaths.PATH_SEPARATOR + clusterId;
       ACLProvider aclProvider = ZKACLProviderFactory.getACLProvider(config, drillClusterPath, context);
       coord = new ZKClusterCoordinator(config, aclProvider);
       storeProvider = new PersistentStoreRegistry<>(this.coord, config).newPStoreProvider();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientStateTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientStateTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.client;
+
+import org.apache.curator.utils.ZKPaths;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.TestWithZookeeper;
+import org.apache.drill.exec.coord.zk.ZKClusterCoordinator;
+import org.junit.Test;
+
+public class DrillClientStateTest extends TestWithZookeeper {
+
+  @Test
+  public void testNotExistZkRoot() throws Exception {
+    // There is no drillbit startup, therefore the root path is not saved in ZK.
+    thrownException.expect(NullPointerException.class);
+    thrownException.expectMessage("root path does not exist");
+    DrillConfig config = DrillConfig.create();
+    String connString = zkHelper.getConnectionString();
+    String zkRoot = config.getString(ExecConstants.ZK_ROOT); // does not exist
+    connString = connString + ZKPaths.PATH_SEPARATOR + zkRoot;
+    try (ZKClusterCoordinator coordinator = new ZKClusterCoordinator(config, connString)) {
+      coordinator.start(10000);
+    }
+  }
+
+}


### PR DESCRIPTION
# [DRILL-8275](https://issues.apache.org/jira/browse/DRILL-8275): Prevent the JDBC Client from creating spurious paths in Zookeeper

## Description
Use the ZK style on the connection string and the zkRoot does not match the actual path of the cluster, then the client always creates a spurious path (as a permanent) in the Zookeeper.

The reason is that after `CuratorFramework` creates the builder, if `zkRoot` is already specified (called `namespace` in curator), it will force to create the root path (even if the path is inconsistent with the real cluster).
As the result, many useless roots may be created in Zookeeper.

## Documentation
N/A

## Testing
Added the tests.
