### PR TITLE
DRILL-8276: Add Support for User Translation for Splunk Plugin

### DIFF
--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.splunk</groupId>
       <artifactId>splunk</artifactId>
-      <version>1.7.1</version>
+      <version>1.9.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.plugins</groupId>

--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.splunk</groupId>
       <artifactId>splunk</artifactId>
-      <version>1.9.0</version>
+      <version>1.7.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.plugins</groupId>

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkBatchReader.java
@@ -81,7 +81,7 @@ public class SplunkBatchReader implements ManagedReader<SchemaNegotiator> {
     this.subScan = subScan;
     this.projectedColumns = subScan.getColumns();
     this.subScanSpec = subScan.getScanSpec();
-    SplunkConnection connection = new SplunkConnection(config);
+    SplunkConnection connection = new SplunkConnection(config, subScan.getUserName());
     this.splunkService = connection.connect();
 
     this.csvSettings = new CsvParserSettings();

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
@@ -26,6 +26,7 @@ import com.splunk.SSLSecurityProtocol;
 import com.splunk.Service;
 import com.splunk.ServiceArgs;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,12 +44,18 @@ public class SplunkConnection {
   private final Optional<UsernamePasswordCredentials> credentials;
   private final String hostname;
   private final int port;
+  private final String queryUserName;
   private Service service;
   private int connectionAttempts;
 
-  public SplunkConnection(SplunkPluginConfig config) {
-    this.credentials = config.getUsernamePasswordCredentials();
+  public SplunkConnection(SplunkPluginConfig config, String queryUserName) {
+    if (config.getAuthMode() == AuthMode.USER_TRANSLATION) {
+      this.credentials = config.getUsernamePasswordCredentials(queryUserName);
+    } else {
+      this.credentials = config.getUsernamePasswordCredentials();
+    }
     this.hostname = config.getHostname();
+    this.queryUserName = queryUserName;
     this.port = config.getPort();
     this.connectionAttempts = config.getReconnectRetries();
     service = connect();
@@ -58,10 +65,15 @@ public class SplunkConnection {
   /**
    * This constructor is used for testing only
    */
-  public SplunkConnection(SplunkPluginConfig config, Service service) {
-    this.credentials = config.getUsernamePasswordCredentials();
+  public SplunkConnection(SplunkPluginConfig config, Service service, String queryUserName) {
+    if (config.getAuthMode() == AuthMode.USER_TRANSLATION) {
+      this.credentials = config.getUsernamePasswordCredentials(queryUserName);
+    } else {
+      this.credentials = config.getUsernamePasswordCredentials();
+    }
     this.hostname = config.getHostname();
     this.port = config.getPort();
+    this.queryUserName = queryUserName;
     this.service = service;
   }
 

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
@@ -80,11 +80,11 @@ public class SplunkConnection {
       connectionAttempts--;
       service = Service.connect(loginArgs);
     } catch (Exception e) {
-      if(connectionAttempts > 0) {
+      if (connectionAttempts > 0) {
         try {
           TimeUnit.SECONDS.sleep(2);
         } catch (InterruptedException interruptedException) {
-          logger.error("Unable to wait 2 secs before next connection trey to Splunk");
+          logger.error("Unable to wait 2 secs before next connection try to Splunk");
         }
         return connect();
       }

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkGroupScan.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkGroupScan.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.metastore.MetadataProviderManager;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
@@ -30,10 +31,13 @@ import org.apache.drill.exec.physical.base.ScanStats;
 import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.planner.logical.DrillScanRel;
 import org.apache.drill.exec.proto.CoordinationProtos;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.base.filter.ExprNode;
 import org.apache.drill.exec.util.Utilities;
+import org.apache.drill.metastore.metadata.TableMetadataProvider;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,17 +54,20 @@ public class SplunkGroupScan extends AbstractGroupScan {
 
   private int hashCode;
 
+  private MetadataProviderManager metadataProviderManager;
+
   /**
    * Creates a new group scan from the storage plugin.
    */
-  public SplunkGroupScan (SplunkScanSpec scanSpec) {
-    super("no-user");
+  public SplunkGroupScan (String username, SplunkScanSpec scanSpec, MetadataProviderManager metadataProviderManager) {
+    super(username);
     this.splunkScanSpec = scanSpec;
     this.config = scanSpec.getConfig();
     this.columns = ALL_COLUMNS;
     this.filters = null;
     this.filterSelectivity = 0.0;
     this.maxRecords = -1;
+    this.metadataProviderManager = metadataProviderManager;
     this.scanStats = computeScanStats();
 
   }
@@ -76,6 +83,7 @@ public class SplunkGroupScan extends AbstractGroupScan {
     this.filters = that.filters;
     this.filterSelectivity = that.filterSelectivity;
     this.maxRecords = that.maxRecords;
+    this.metadataProviderManager = that.metadataProviderManager;
 
     // Calcite makes many copies in the later stage of planning
     // without changing anything. Retain the previous stats.
@@ -97,8 +105,8 @@ public class SplunkGroupScan extends AbstractGroupScan {
     this.filters = that.filters;
     this.filterSelectivity = that.filterSelectivity;
     this.maxRecords = that.maxRecords;
+    this.metadataProviderManager = that.metadataProviderManager;
     this.scanStats = computeScanStats();
-
   }
 
   /**
@@ -115,6 +123,7 @@ public class SplunkGroupScan extends AbstractGroupScan {
     this.filters = filters;
     this.filterSelectivity = filterSelectivity;
     this.maxRecords = that.maxRecords;
+    this.metadataProviderManager = that.metadataProviderManager;
     this.scanStats = computeScanStats();
   }
 
@@ -182,7 +191,7 @@ public class SplunkGroupScan extends AbstractGroupScan {
 
   @Override
   public SubScan getSpecificScan(int minorFragmentId) {
-    return new SplunkSubScan(config, splunkScanSpec, columns, filters, maxRecords);
+    return new SplunkSubScan(userName, config, splunkScanSpec, columns, filters, maxRecords);
   }
 
   @Override
@@ -206,6 +215,25 @@ public class SplunkGroupScan extends AbstractGroupScan {
       return null;
     }
     return new SplunkGroupScan(this, maxRecords);
+  }
+
+  public TupleMetadata getSchema() {
+    if (metadataProviderManager == null) {
+      return null;
+    }
+    try {
+      return metadataProviderManager.getSchemaProvider().read().getSchema();
+    } catch (IOException | NullPointerException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public TableMetadataProvider getMetadataProvider() {
+    if (metadataProviderManager == null) {
+      return null;
+    }
+    return metadataProviderManager.getTableMetadataProvider();
   }
 
   @Override

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkGroupScan.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkGroupScan.java
@@ -59,8 +59,8 @@ public class SplunkGroupScan extends AbstractGroupScan {
   /**
    * Creates a new group scan from the storage plugin.
    */
-  public SplunkGroupScan (String username, SplunkScanSpec scanSpec, MetadataProviderManager metadataProviderManager) {
-    super(username);
+  public SplunkGroupScan (SplunkScanSpec scanSpec, MetadataProviderManager metadataProviderManager) {
+    super(scanSpec.queryUserName());
     this.splunkScanSpec = scanSpec;
     this.config = scanSpec.getConfig();
     this.columns = ALL_COLUMNS;
@@ -88,6 +88,7 @@ public class SplunkGroupScan extends AbstractGroupScan {
     // Calcite makes many copies in the later stage of planning
     // without changing anything. Retain the previous stats.
     this.scanStats = that.scanStats;
+    this.hashCode = that.hashCode;
   }
 
   /**
@@ -191,7 +192,7 @@ public class SplunkGroupScan extends AbstractGroupScan {
 
   @Override
   public SubScan getSpecificScan(int minorFragmentId) {
-    return new SplunkSubScan(userName, config, splunkScanSpec, columns, filters, maxRecords);
+    return new SplunkSubScan(config, splunkScanSpec, columns, filters, maxRecords);
   }
 
   @Override

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
@@ -76,6 +76,10 @@ public class SplunkPluginConfig extends StoragePluginConfig {
     this.reconnectRetries = that.reconnectRetries;
   }
 
+  /**
+   * Gets the credentials. This method is used when user translation is not enabled.
+   * @return An {@link Optional} containing {@link UsernamePasswordCredentials} from the config.
+   */
   @JsonIgnore
   public Optional<UsernamePasswordCredentials> getUsernamePasswordCredentials() {
     return new UsernamePasswordCredentials.Builder()
@@ -83,6 +87,10 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       .build();
   }
 
+  /**
+   * Gets the credentials. This method is used when user translation is enabled.
+   * @return An {@link Optional} containing {@link UsernamePasswordCredentials} from the config.
+   */
   @JsonIgnore
   public Optional<UsernamePasswordCredentials> getUsernamePasswordCredentials(String username) {
     return new UsernamePasswordCredentials.Builder()

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
@@ -41,7 +41,6 @@ public class SplunkPluginConfig extends StoragePluginConfig {
   private final String hostname;
   private final String earliestTime;
   private final String latestTime;
-
   private final int port;
   private final Integer reconnectRetries;
 
@@ -56,7 +55,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
                             @JsonProperty("reconnectRetries") Integer reconnectRetries,
                             @JsonProperty("authMode") String authMode) {
     super(CredentialProviderUtils.getCredentialsProvider(username, password, credentialsProvider),
-        credentialsProvider == null);
+        credentialsProvider == null, AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER));
     this.hostname = hostname;
     this.port = port;
     this.earliestTime = earliestTime;
@@ -141,12 +140,13 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       Objects.equals(hostname, thatConfig.hostname) &&
       Objects.equals(port, thatConfig.port) &&
       Objects.equals(earliestTime, thatConfig.earliestTime) &&
-      Objects.equals(latestTime, thatConfig.latestTime);
+      Objects.equals(latestTime, thatConfig.latestTime) &&
+      Objects.equals(authMode, thatConfig.authMode);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(credentialsProvider, hostname, port, earliestTime, latestTime);
+    return Objects.hash(credentialsProvider, hostname, port, earliestTime, latestTime, authMode);
   }
 
   @Override
@@ -157,6 +157,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       .field("port", port)
       .field("earliestTime", earliestTime)
       .field("latestTime", latestTime)
+      .field("Authentication Mode", authMode)
       .toString();
   }
 

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
@@ -28,12 +28,16 @@ import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.exec.store.security.CredentialProviderUtils;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.Optional;
 
 @JsonTypeName(SplunkPluginConfig.NAME)
 public class SplunkPluginConfig extends StoragePluginConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(SplunkPluginConfig.class);
 
   public static final String NAME = "splunk";
   public static final int DISABLED_RECONNECT_RETRIES = 1;
@@ -79,12 +83,20 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       .build();
   }
 
+  @JsonIgnore
+  public Optional<UsernamePasswordCredentials> getUsernamePasswordCredentials(String username) {
+    return new UsernamePasswordCredentials.Builder()
+      .setCredentialsProvider(credentialsProvider)
+      .setQueryUser(username)
+      .build();
+  }
+
   @JsonProperty("username")
   public String getUsername() {
     if (!directCredentials) {
       return null;
     }
-    return getUsernamePasswordCredentials()
+    return getUsernamePasswordCredentials(null)
       .map(UsernamePasswordCredentials::getUsername)
       .orElse(null);
   }
@@ -94,7 +106,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
     if (!directCredentials) {
       return null;
     }
-    return getUsernamePasswordCredentials()
+    return getUsernamePasswordCredentials(null)
       .map(UsernamePasswordCredentials::getPassword)
       .orElse(null);
   }

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkScanSpec.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkScanSpec.java
@@ -29,14 +29,17 @@ public class SplunkScanSpec implements DrillTableSelection {
   private final String pluginName;
   private final String indexName;
   private final SplunkPluginConfig config;
+  private final String queryUserName;
 
   @JsonCreator
   public SplunkScanSpec(@JsonProperty("pluginName") String pluginName,
                         @JsonProperty("indexName") String indexName,
-                        @JsonProperty("config") SplunkPluginConfig config) {
+                        @JsonProperty("config") SplunkPluginConfig config,
+                        @JsonProperty("queryUserName") String queryUserName) {
     this.pluginName = pluginName;
     this.indexName = indexName;
     this.config = config;
+    this.queryUserName = queryUserName;
   }
 
   @JsonProperty("pluginName")
@@ -48,12 +51,18 @@ public class SplunkScanSpec implements DrillTableSelection {
   @JsonProperty("config")
   public SplunkPluginConfig getConfig() { return config; }
 
+  @JsonProperty("queryUserName")
+  public String queryUserName() {
+    return queryUserName;
+  }
+
   @Override
   public String toString() {
     return new PlanStringBuilder(this)
       .field("config", config)
       .field("schemaName", pluginName)
       .field("indexName", indexName)
+      .field("queryUserName", queryUserName)
       .toString();
   }
 

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSchemaFactory.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSchemaFactory.java
@@ -112,7 +112,7 @@ public class SplunkSchemaFactory extends AbstractSchemaFactory {
       } catch (Exception e) {
         // Catch any connection errors that may happen.
         throw UserException.connectionError()
-          .message("Unable to connect to Splunk {}. {} ", plugin.getName(), e.getMessage())
+          .message("Unable to connect to Splunk: " +  plugin.getName() + " " + e.getMessage())
           .build(logger);
       }
 

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSchemaFactory.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSchemaFactory.java
@@ -50,7 +50,7 @@ public class SplunkSchemaFactory extends AbstractSchemaFactory {
     SchemaPlus plusOfThis = parent.add(schema.getName(), schema);
   }
 
-  class SplunkSchema extends AbstractSchema {
+  static class SplunkSchema extends AbstractSchema {
 
     private final Map<String, DynamicDrillTable> activeTables = new HashMap<>();
     private final SplunkStoragePlugin plugin;

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSchemaFactory.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSchemaFactory.java
@@ -47,8 +47,8 @@ public class SplunkSchemaFactory extends AbstractSchemaFactory {
 
   @Override
   public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) {
-    SplunkSchema schema = new SplunkSchema(plugin, queryUserName);
     this.queryUserName = schemaConfig.getUserName();
+    SplunkSchema schema = new SplunkSchema(plugin, queryUserName);
     SchemaPlus plusOfThis = parent.add(schema.getName(), schema);
   }
 
@@ -62,6 +62,8 @@ public class SplunkSchemaFactory extends AbstractSchemaFactory {
       super(Collections.emptyList(), plugin.getName());
       this.plugin = plugin;
       this.queryUserName = queryUserName;
+
+
       registerIndexes();
     }
 
@@ -105,8 +107,14 @@ public class SplunkSchemaFactory extends AbstractSchemaFactory {
 
       // Retrieve and add all other Splunk indexes
       SplunkPluginConfig config = plugin.getConfig();
-      SplunkConnection connection = new SplunkConnection(config, queryUserName);
-      connection.connect();
+      SplunkConnection connection;
+      try {
+        connection = new SplunkConnection(config, queryUserName);
+        connection.connect();
+      } catch (Exception e) {
+        logger.error("Unable to connect to Splunk {}. {} ", plugin.getName(), e.getMessage());
+        return;
+      }
 
       for (String indexName : connection.getIndexes().keySet()) {
         logger.debug("Registering {}", indexName);

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkStoragePlugin.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkStoragePlugin.java
@@ -92,7 +92,7 @@ public class SplunkStoragePlugin extends AbstractStoragePlugin {
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options,
                                            MetadataProviderManager metadataProviderManager) throws IOException {
     SplunkScanSpec scanSpec = selection.getListWith(context.getLpPersistence().getMapper(), new TypeReference<SplunkScanSpec>() {});
-    return new SplunkGroupScan(userName, scanSpec, metadataProviderManager);
+    return new SplunkGroupScan(scanSpec, metadataProviderManager);
   }
 
   @Override

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSubScan.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSubScan.java
@@ -47,12 +47,13 @@ public class SplunkSubScan extends AbstractBase implements SubScan {
 
   @JsonCreator
   public SplunkSubScan(
+    @JsonProperty("username") String username,
     @JsonProperty("config") SplunkPluginConfig config,
     @JsonProperty("tableSpec") SplunkScanSpec splunkScanSpec,
     @JsonProperty("columns") List<SchemaPath> columns,
     @JsonProperty("filters") Map<String, ExprNode.ColRelOpConstNode> filters,
     @JsonProperty("maxRecords") int maxRecords) {
-      super("user");
+      super(username);
       this.config = config;
       this.splunkScanSpec = splunkScanSpec;
       this.columns = columns;
@@ -93,7 +94,7 @@ public class SplunkSubScan extends AbstractBase implements SubScan {
 
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
-    return new SplunkSubScan(config, splunkScanSpec, columns, filters, maxRecords);
+    return new SplunkSubScan(userName, config, splunkScanSpec, columns, filters, maxRecords);
   }
 
   @Override

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSubScan.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkSubScan.java
@@ -47,13 +47,12 @@ public class SplunkSubScan extends AbstractBase implements SubScan {
 
   @JsonCreator
   public SplunkSubScan(
-    @JsonProperty("username") String username,
     @JsonProperty("config") SplunkPluginConfig config,
     @JsonProperty("tableSpec") SplunkScanSpec splunkScanSpec,
     @JsonProperty("columns") List<SchemaPath> columns,
     @JsonProperty("filters") Map<String, ExprNode.ColRelOpConstNode> filters,
     @JsonProperty("maxRecords") int maxRecords) {
-      super(username);
+      super(splunkScanSpec.queryUserName());
       this.config = config;
       this.splunkScanSpec = splunkScanSpec;
       this.columns = columns;
@@ -94,7 +93,7 @@ public class SplunkSubScan extends AbstractBase implements SubScan {
 
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
-    return new SplunkSubScan(userName, config, splunkScanSpec, columns, filters, maxRecords);
+    return new SplunkSubScan(config, splunkScanSpec, columns, filters, maxRecords);
   }
 
   @Override

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkConnectionTest.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkConnectionTest.java
@@ -36,7 +36,7 @@ public class SplunkConnectionTest extends SplunkBaseTest {
 
   @Test
   public void testConnection() {
-    SplunkConnection sc = new SplunkConnection(SPLUNK_STORAGE_PLUGIN_CONFIG);
+    SplunkConnection sc = new SplunkConnection(SPLUNK_STORAGE_PLUGIN_CONFIG, null);
     sc.connect();
   }
 
@@ -54,7 +54,7 @@ public class SplunkConnectionTest extends SplunkBaseTest {
               SPLUNK_STORAGE_PLUGIN_CONFIG.getReconnectRetries(),
               StoragePluginConfig.AuthMode.SHARED_USER.name()
       );
-      SplunkConnection sc = new SplunkConnection(invalidSplunkConfig);
+      SplunkConnection sc = new SplunkConnection(invalidSplunkConfig, null);
       sc.connect();
       fail();
     } catch (UserException e) {
@@ -64,7 +64,7 @@ public class SplunkConnectionTest extends SplunkBaseTest {
 
   @Test
   public void testGetIndexes() {
-    SplunkConnection sc = new SplunkConnection(SPLUNK_STORAGE_PLUGIN_CONFIG);
+    SplunkConnection sc = new SplunkConnection(SPLUNK_STORAGE_PLUGIN_CONFIG, null);
     EntityCollection<Index> indexes = sc.getIndexes();
     assertEquals(9, indexes.size());
 

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkPluginTest.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkPluginTest.java
@@ -311,7 +311,7 @@ public class SplunkPluginTest extends SplunkBaseTest {
           .thenThrow(new RuntimeException("Fail second connection to Splunk"))
           .thenThrow(new RuntimeException("Fail third connection to Splunk"))
           .thenReturn(new Service(loginArgs)); // fourth connection is successful
-      new SplunkConnection(SPLUNK_STORAGE_PLUGIN_CONFIG); // it will fail, in case "reconnectRetries": 1 is specified in configs
+      new SplunkConnection(SPLUNK_STORAGE_PLUGIN_CONFIG, null); // it will fail, in case "reconnectRetries": 1 is specified in configs
       splunk.verify(
           () -> Service.connect(loginArgs),
           times(4)

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -37,7 +37,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
@@ -97,7 +96,6 @@ public class SplunkTestSuite extends ClusterTest {
         // Add unauthorized user
         credentialsProvider.setUserCredentials("nope", "no way dude", TEST_USER_2);
 
-        // TODO Start here.. add config for Splunk with user translation
         SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION = new SplunkPluginConfig(null, null, hostname, port, "1", "now",
           credentialsProvider, 4, AuthMode.USER_TRANSLATION.name());
         cluster.defineStoragePlugin("ut_splunk", SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION);

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -20,6 +20,8 @@ package org.apache.drill.exec.store.splunk;
 
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
@@ -34,7 +36,12 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
 
 
 @RunWith(Suite.class)
@@ -44,7 +51,8 @@ import java.util.concurrent.atomic.AtomicInteger;
   SplunkLimitPushDownTest.class,
   SplunkIndexesTest.class,
   SplunkPluginTest.class,
-  SplunkTestSplunkUtils.class
+  SplunkTestSplunkUtils.class,
+  TestSplunkUserTranslation.class
 })
 
 @Category({SlowTest.class})
@@ -52,6 +60,8 @@ public class SplunkTestSuite extends ClusterTest {
   private static final Logger logger = LoggerFactory.getLogger(SplunkTestSuite.class);
 
   protected static SplunkPluginConfig SPLUNK_STORAGE_PLUGIN_CONFIG = null;
+
+  protected static SplunkPluginConfig SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION = null;
   public static final String SPLUNK_LOGIN = "admin";
   public static final String SPLUNK_PASS = "password";
 
@@ -79,6 +89,19 @@ public class SplunkTestSuite extends ClusterTest {
         runningSuite = true;
         logger.info("Take a time to ready more Splunk events (10 sec)...");
         Thread.sleep(10000);
+
+
+        PlainCredentialsProvider credentialsProvider = new PlainCredentialsProvider(new HashMap<>());
+        // Add authorized user
+        credentialsProvider.setUserCredentials(SPLUNK_LOGIN, SPLUNK_PASS, TEST_USER_1);
+        // Add unauthorized user
+        credentialsProvider.setUserCredentials("nope", "no way dude", TEST_USER_2);
+
+        // TODO Start here.. add config for Splunk with user translation
+        SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION = new SplunkPluginConfig(null, null, hostname, port, "1", "now",
+          credentialsProvider, 4, AuthMode.USER_TRANSLATION.name());
+        cluster.defineStoragePlugin("ut_splunk", SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION);
+
       }
       initCount.incrementAndGet();
       runningSuite = true;

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -22,8 +22,9 @@ import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.StoragePluginRegistry;
-import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -76,7 +77,12 @@ public class SplunkTestSuite extends ClusterTest {
   public static void initSplunk() throws Exception {
     synchronized (SplunkTestSuite.class) {
       if (initCount.get() == 0) {
-        startCluster(ClusterFixture.builder(dirTestWatcher));
+        ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher)
+          .configProperty(ExecConstants.HTTP_ENABLE, true)
+          .configProperty(ExecConstants.HTTP_PORT_HUNT, true)
+          .configProperty(ExecConstants.IMPERSONATION_ENABLED, true);
+        startCluster(builder);
+
         splunk.start();
         String hostname = splunk.getHost();
         Integer port = splunk.getFirstMappedPort();
@@ -98,7 +104,8 @@ public class SplunkTestSuite extends ClusterTest {
 
         SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION = new SplunkPluginConfig(null, null, hostname, port, "1", "now",
           credentialsProvider, 4, AuthMode.USER_TRANSLATION.name());
-        cluster.defineStoragePlugin("ut_splunk", SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION);
+        SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION.setEnabled(true);
+        pluginRegistry.put("ut_splunk", SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION);
 
       }
       initCount.incrementAndGet();

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -34,8 +34,10 @@ import org.junit.experimental.categories.Category;
 import java.util.Map;
 
 import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Category({SlowTest.class})
 public class TestSplunkUserTranslation extends SplunkBaseTest {
@@ -48,7 +50,6 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
       .configProperty(ExecConstants.IMPERSONATION_ENABLED, true);
     startCluster(builder);
   }
-  
   @Test
   public void testEmptyUserCredentials() throws Exception {
     ClientFixture client = cluster
@@ -85,6 +86,4 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
       assertTrue(e.getMessage().contains("You do not have valid credentials for this API."));
     }
   }
-
-
 }

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.splunk;
+
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({SlowTest.class})
+public class TestSplunkUserTranslation extends SplunkBaseTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher)
+      .configProperty(ExecConstants.HTTP_ENABLE, true)
+      .configProperty(ExecConstants.HTTP_PORT_HUNT, true)
+      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true);
+    startCluster(builder);
+  }
+
+  @Test
+  public void testUserTranslation() throws Exception {
+
+  }
+}

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -20,71 +20,61 @@ package org.apache.drill.exec.store.splunk;
 
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.config.DrillProperties;
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.common.logical.security.PlainCredentialsProvider;
-import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.store.StoragePlugin;
-import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.test.ClientFixture;
-import org.apache.drill.test.ClusterFixtureBuilder;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.util.Map;
 
 import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER;
 import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER_PASSWORD;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
+import static org.junit.Assert.assertEquals;
 
 @Category({SlowTest.class})
 public class TestSplunkUserTranslation extends SplunkBaseTest {
 
-  @BeforeClass
-  public static void setup() throws Exception {
-    ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher)
-      .configProperty(ExecConstants.HTTP_ENABLE, true)
-      .configProperty(ExecConstants.HTTP_PORT_HUNT, true)
-      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true);
-    startCluster(builder);
-  }
-  @Test
-  public void testEmptyUserCredentials() throws Exception {
-    ClientFixture client = cluster
-      .clientBuilder()
-      .property(DrillProperties.USER, ADMIN_USER)
-      .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
-      .build();
-
-    // First verify that the user has no credentials
-    StoragePluginRegistry registry = cluster.storageRegistry();
-    StoragePlugin plugin = registry.getPlugin("ut_splunk");
-    PlainCredentialsProvider credentialsProvider = (PlainCredentialsProvider) plugin.getConfig().getCredentialsProvider();
-    Map<String, String> credentials = credentialsProvider.getUserCredentials(ADMIN_USER);
-    assertNotNull(credentials);
-    assertNull(credentials.get("username"));
-    assertNull(credentials.get("password"));
-  }
-
   @Test
   public void testQueryWithMissingCredentials() throws Exception {
     // This test validates that the correct credentials are sent down to Splunk.
-    // The query should fail, but Drill should not crash
+    // This user should not see the ut_splunk because they do not have valid credentials
     ClientFixture client = cluster
       .clientBuilder()
       .property(DrillProperties.USER, ADMIN_USER)
       .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
       .build();
 
-    String sql = "SELECT `component` FROM splunk.`_introspection` ORDER BY `component` LIMIT 2";
-    try {
-      client.queryBuilder().sql(sql).run();
-      fail();
-    } catch (UserException e) {
-      assertTrue(e.getMessage().contains("You do not have valid credentials for this API."));
-    }
+    String sql = "SHOW DATABASES";
+
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(8, results.rowCount());
+  }
+
+  @Test
+  public void testQueryWithValidCredentials() throws Exception {
+    ClientFixture client = cluster
+      .clientBuilder()
+      .property(DrillProperties.USER, TEST_USER_1)
+      .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+      .build();
+
+    String sql = "SHOW DATABASES";
+
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(9, results.rowCount());
+  }
+
+  @Test
+  public void testSplunkQueryWithUserTranslation() throws Exception {
+    ClientFixture client = cluster
+      .clientBuilder()
+      .property(DrillProperties.USER, TEST_USER_1)
+      .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+      .build();
+
+    String sql = "SELECT acceleration_id, action, add_offset, add_timestamp FROM ut_splunk._audit LIMIT 2";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(2, results.rowCount());
   }
 }

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -19,11 +19,23 @@
 package org.apache.drill.exec.store.splunk;
 
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.store.StoragePlugin;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.util.Map;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.*;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 @Category({SlowTest.class})
 public class TestSplunkUserTranslation extends SplunkBaseTest {
@@ -36,9 +48,43 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
       .configProperty(ExecConstants.IMPERSONATION_ENABLED, true);
     startCluster(builder);
   }
+  
+  @Test
+  public void testEmptyUserCredentials() throws Exception {
+    ClientFixture client = cluster
+      .clientBuilder()
+      .property(DrillProperties.USER, ADMIN_USER)
+      .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+      .build();
+
+    // First verify that the user has no credentials
+    StoragePluginRegistry registry = cluster.storageRegistry();
+    StoragePlugin plugin = registry.getPlugin("ut_splunk");
+    PlainCredentialsProvider credentialsProvider = (PlainCredentialsProvider) plugin.getConfig().getCredentialsProvider();
+    Map<String, String> credentials = credentialsProvider.getUserCredentials(ADMIN_USER);
+    assertNotNull(credentials);
+    assertNull(credentials.get("username"));
+    assertNull(credentials.get("password"));
+  }
 
   @Test
-  public void testUserTranslation() throws Exception {
+  public void testQueryWithMissingCredentials() throws Exception {
+    // This test validates that the correct credentials are sent down to Splunk.
+    // The query should fail, but Drill should not crash
+    ClientFixture client = cluster
+      .clientBuilder()
+      .property(DrillProperties.USER, ADMIN_USER)
+      .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+      .build();
 
+    String sql = "SELECT `component` FROM splunk.`_introspection` ORDER BY `component` LIMIT 2";
+    try {
+      client.queryBuilder().sql(sql).run();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("You do not have valid credentials for this API."));
+    }
   }
+
+
 }

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -33,7 +33,8 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Map;
 
-import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.*;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER_PASSWORD;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <commons.cli.version>1.4</commons.cli.version>
     <snakeyaml.version>1.26</snakeyaml.version>
     <commons.lang3.version>3.10</commons.lang3.version>
-    <testcontainers.version>1.16.3</testcontainers.version>
+    <testcontainers.version>1.17.3</testcontainers.version>
     <typesafe.config.version>1.4.2</typesafe.config.version>
     <commons.codec.version>1.14</commons.codec.version>
     <xerces.version>2.12.2</xerces.version>


### PR DESCRIPTION
# [DRILL-8276](https://issues.apache.org/jira/browse/DRILL-8276): Add Support for User Translation for Splunk Plugin

## Description
Adds support for user translation in the Splunk plugin.

## Documentation
Not really much to add here.  Splunk plugin now supports user translation in a similar manner as the JDBC plugin. 

## Testing
Added unit tests, tested manually. 