### PR TITLE
DRILL-8277: Publish SNAPSHOT artifacts to the Apache snapshots repo from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,27 +116,3 @@ jobs:
           else
             echo "All checks are passed!";
           fi
-
-  publish_snapshot_artifacts:
-    name: Publish snapshot artifacts
-    # TODO: change 'pull_request' to 'push' after testing a draft PR.
-    if: github.event_name == 'pull_request' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache Maven Repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Build and publish snapshot artifacts
-        # The total GitHub Actions memory is 7000Mb. But GitHub CI requires some memory for the container to perform tests
-        run: |
-          MAVEN_OPTS="-XX:+UseG1GC"
-          sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
-          mvn -P${{ matrix.profile }} install --batch-mode --no-transfer-progress \
-          -DexcludedGroups=org.apache.drill.categories.EasyOutOfMemory \
-          -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           -Dgroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
   checkstyle_protobuf:
-    name: Run checkstyle and generate protobufs
+    name: Run checkstyle, generate protobufs and publish SNAPSHOT artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -107,6 +107,12 @@ jobs:
           pushd protocol && mvn process-sources -P proto-compile && popd && \
           mkdir contrib/native/client/build && pushd contrib/native/client/build && cmake -G "Unix Makefiles" .. && make cpProtobufs && popd; \
       # Checks whether project files weren't changed after regenerating protobufs
+      - name: Publish SNAPSHOT artifacts
+        # TODO: change 'pull_request' to 'push' after testing a draft PR.
+        if: github.event_name == 'pull_request' && github.ref == 'refs/heads/master'
+        run: |
+          echo "Publishing SNAPSHOT artifacts because a new commit has been pushed to master."
+          MAVEN_OPTS="-Xms1G -Xmx1G" mvn deploy
       - name: Check protobufs
         run: |
           if [ "$(git status -s | grep -c "")" -gt 0 ]; then \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           -Dgroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
   checkstyle_protobuf:
-    name: Run checkstyle, generate protobufs and publish SNAPSHOT artifacts
+    name: Run checkstyle and generate protobufs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -107,12 +107,6 @@ jobs:
           pushd protocol && mvn process-sources -P proto-compile && popd && \
           mkdir contrib/native/client/build && pushd contrib/native/client/build && cmake -G "Unix Makefiles" .. && make cpProtobufs && popd; \
       # Checks whether project files weren't changed after regenerating protobufs
-      - name: Publish SNAPSHOT artifacts
-        # TODO: change 'pull_request' to 'push' after testing a draft PR.
-        if: github.event_name == 'pull_request' && github.ref == 'refs/heads/master'
-        run: |
-          echo "Publishing SNAPSHOT artifacts because a new commit has been pushed to master."
-          MAVEN_OPTS="-Xms1G -Xmx1G" mvn deploy
       - name: Check protobufs
         run: |
           if [ "$(git status -s | grep -c "")" -gt 0 ]; then \
@@ -122,3 +116,27 @@ jobs:
           else
             echo "All checks are passed!";
           fi
+
+  publish_snapshot_artifacts:
+    name: Publish snapshot artifacts
+    # TODO: change 'pull_request' to 'push' after testing a draft PR.
+    if: github.event_name == 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and publish snapshot artifacts
+        # The total GitHub Actions memory is 7000Mb. But GitHub CI requires some memory for the container to perform tests
+        run: |
+          MAVEN_OPTS="-XX:+UseG1GC"
+          sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
+          mvn -P${{ matrix.profile }} install --batch-mode --no-transfer-progress \
+          -DexcludedGroups=org.apache.drill.categories.EasyOutOfMemory \
+          -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -40,4 +40,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build and publish snapshot artifacts
-        run: mvn deploy
+        env:
+          ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+          ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+        run: |
+          echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
+          mvn --settings settings.xml deploy -DskipTests

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -18,10 +18,12 @@
 
 name: Publish snapshot artifacts
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
+# TODO: replace the above line with the below after testing.
+#on:
+#  push:
+#    branches:
+#      - master
 
 jobs:
   publish:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish snapshot artifacts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Publish snapshot artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and publish snapshot artifacts
+        run: mvn deploy

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -39,10 +39,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build and publish snapshot artifacts
+      - name: Deploy Maven snapshots
         env:
           ASF_USERNAME: ${{ secrets.NEXUS_USER }}
           ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
         run: |
           echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
-          mvn --settings settings.xml deploy -DskipTests
+          mvn --settings settings.xml -U -B -e -fae -ntp -DskipTests deploy

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -18,12 +18,10 @@
 
 name: Publish snapshot artifacts
 
-on: [push, pull_request]
-# TODO: replace the above line with the below after testing.
-#on:
-#  push:
-#    branches:
-#      - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   publish:


### PR DESCRIPTION
# [DRILL-8277](https://issues.apache.org/jira/browse/DRILL-8277): Publish SNAPSHOT artifacts to the Apache snapshots repo from CI

## Description
It is possible to publish snapshot artifiacts from the current, unrelased version of Drill by using the mvn deploy goal. This publishes the aritifacts to https://repository.apache.org/content/repositories/snapshots/org/apache/drill. Developers who would like to program against these artifacts in anticipation of the upcoming release, say 2.0.0, can do so by adding the Apache snapshots repository to their project and dependency entries like

```
    <dependency>
      <groupId>org.apache.drill.exec</groupId>
      <artifactId>drill-java-exec</artifactId>
      <version>2.0.0-SNAPSHOT</version>
    </dependency> 
```

## Documentation
New plugin authoring documentation once the question of feasability of developing plugins away from the Drill source tree is totally settled.

## Testing
I've been testing the `mvn deploy` command from my dev machine. The new step in the checkstyle and protobuf GitHub Actions job will be tested here in GitHub wit hthe PR in Draft mode. A final commit will modify the condition used to determine whether the new step will run so that it only runs when a new commit reaches master.
