### PR TITLE
DRILL-8273: Complex typed columns cannot be made implicit (extend unit tests)

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestTupleProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestTupleProjection.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.apache.drill.categories.RowSetTest;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.TupleProjectionType;
@@ -60,13 +61,25 @@ public class TestTupleProjection extends BaseTest {
       MetadataUtils.newScalar("a", Types.required(MinorType.INT));
   private static final ColumnMetadata UNPROJECTED_SPECIAL_COLUMN =
       MetadataUtils.newScalar("bar", Types.required(MinorType.INT));
-  private static final ColumnMetadata COMPLEX_SPECIAL_COLUMN =
+  private static final ColumnMetadata SPECIAL_DICT =
+      MetadataUtils.newDict("a_dict");
+  private static final ColumnMetadata SPECIAL_MAP =
       MetadataUtils.newMap("a_map");
+  private static final ColumnMetadata SPECIAL_REP_LIST =
+      MetadataUtils.newRepeatedList(
+        "a_repeated_list",
+        MetadataUtils.newScalar("child", Types.repeated(MinorType.INT))
+      );
+  private static final ColumnMetadata SPECIAL_VARIANT =
+      MetadataUtils.newVariant("a_variant", DataMode.OPTIONAL);
 
   static {
     SPECIAL_COLUMN.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
     UNPROJECTED_SPECIAL_COLUMN.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
-    COMPLEX_SPECIAL_COLUMN.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
+    SPECIAL_DICT.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
+    SPECIAL_MAP.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
+    SPECIAL_REP_LIST.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
+    SPECIAL_VARIANT.setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
   }
 
   /**
@@ -79,7 +92,10 @@ public class TestTupleProjection extends BaseTest {
     assertTrue(projSet.isProjected("foo"));
     assertTrue(projSet.isProjected(NORMAL_COLUMN));
     assertFalse(projSet.isProjected(SPECIAL_COLUMN));
-    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(SPECIAL_DICT));
+    assertFalse(projSet.isProjected(SPECIAL_MAP));
+    assertFalse(projSet.isProjected(SPECIAL_REP_LIST));
+    assertFalse(projSet.isProjected(SPECIAL_VARIANT));
     assertTrue(projSet.projections().isEmpty());
     assertFalse(projSet.isEmpty());
   }
@@ -95,7 +111,10 @@ public class TestTupleProjection extends BaseTest {
     assertNull(projSet.get("foo"));
     assertTrue(projSet.isProjected(NORMAL_COLUMN));
     assertFalse(projSet.isProjected(SPECIAL_COLUMN));
-    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(SPECIAL_DICT));
+    assertFalse(projSet.isProjected(SPECIAL_MAP));
+    assertFalse(projSet.isProjected(SPECIAL_REP_LIST));
+    assertFalse(projSet.isProjected(SPECIAL_VARIANT));
     assertEquals(1, projSet.projections().size());
     assertFalse(projSet.isEmpty());
   }
@@ -112,7 +131,10 @@ public class TestTupleProjection extends BaseTest {
     assertFalse(projSet.isProjected("foo"));
     assertFalse(projSet.isProjected(NORMAL_COLUMN));
     assertFalse(projSet.isProjected(SPECIAL_COLUMN));
-    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(SPECIAL_DICT));
+    assertFalse(projSet.isProjected(SPECIAL_MAP));
+    assertFalse(projSet.isProjected(SPECIAL_REP_LIST));
+    assertFalse(projSet.isProjected(SPECIAL_VARIANT));
     assertTrue(projSet.projections().isEmpty());
     assertTrue(projSet.isEmpty());
   }
@@ -134,7 +156,7 @@ public class TestTupleProjection extends BaseTest {
     assertTrue(projSet.isProjected(SPECIAL_COLUMN));
     assertFalse(projSet.isProjected(UNPROJECTED_COLUMN));
     assertFalse(projSet.isProjected(UNPROJECTED_SPECIAL_COLUMN));
-    assertFalse(projSet.isProjected(COMPLEX_SPECIAL_COLUMN));
+    assertFalse(projSet.isProjected(SPECIAL_MAP));
 
     List<RequestedColumn> cols = projSet.projections();
     assertEquals(3, cols.size());


### PR DESCRIPTION
# [DRILL-8273](https://issues.apache.org/jira/browse/DRILL-8273): Complex typed columns cannot be made implicit (extend unit tests)

## Description

The first PR (#2615) did not cover all of the affected column types with unit testing. This PR extends the unit tests to dict, repeated list and variant column types.

## Documentation
N/A

## Testing
This PR consists only of test code.
