### PR TITLE
DRILL-8278: The period character '.' is broken in SQL LIKE patterns

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/RegexpUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/RegexpUtil.java
@@ -28,7 +28,7 @@ package org.apache.drill.exec.expr.fn.impl;
  */
 
 public class RegexpUtil {
-  private static final String JAVA_REGEX_SPECIALS = "[]()|^-+*?{}$\\";
+  private static final String JAVA_REGEX_SPECIALS = "[]()|^-+*?{}$\\.";
   private static final String SQL_SIMILAR_SPECIALS = "[]()|^-+*_%?{}";
   private static final String [] REG_CHAR_CLASSES = {
       "[:ALPHA:]", "\\p{Alpha}",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
@@ -159,6 +159,13 @@ public class TestSqlPatterns extends BaseTest {
     assertEquals("AB", patternInfo.getSimplePatternString());
     assertEquals(RegexpUtil.SqlPatternType.CONSTANT, patternInfo.getPatternType());
 
+    // A.B is constant. DRILL-8278
+    patternInfo = RegexpUtil.sqlToRegexLike("A.B");
+    // The . should be escaped with a \ so that it represents a literal .
+    assertEquals("A\\.B", patternInfo.getJavaPatternString());
+    assertEquals("A.B", patternInfo.getSimplePatternString());
+    assertEquals(RegexpUtil.SqlPatternType.CONSTANT, patternInfo.getPatternType());
+
     // Test with escape characters.
 
     // A%#B is invalid escape sequence
@@ -449,7 +456,7 @@ public class TestSqlPatterns extends BaseTest {
   }
 
   @Test
-  public void testSqlPatternContainsMUltipleMatchers() {
+  public void testSqlPatternContainsMultipleMatchers() {
 
     final String longASCIIString = "Drill supports a variety of NoSQL databases and file systems, including HBase, MongoDB, MapR-DB, HDFS, MapR-FS, Amazon S3, Azure Blob Storage, Google Cloud Storage, Swift, "
       + "NAS and local files. A single query can join data from multiple datastores. For example, you can join a user profile collection in MongoDB with a directory of event logs in Hadoop.";


### PR DESCRIPTION
# [DRILL-8278](https://issues.apache.org/jira/browse/DRILL-8278): The period character '.' is broken in SQL LIKE patterns

## Description

The '.' character is added to the JAVA_REGEX_SPECIALS string in RegexpUtil (as has subsequently happened in the Calcite code that was originally copied to create this class).

It will now be possible to use '.' correctly in queries like `show databases where table_schema like 'dfs.%'`

## Documentation
No change.

## Testing
TestSqlPatterns#testSqlRegexLike
