### PR TITLE
DRILL-8279: Use thick Phoenix driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     name: Main Build
     runs-on: ubuntu-latest
-    timeout-minutes: 100
+    timeout-minutes: 120
     strategy:
       matrix:
         # Java versions to run unit tests

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -76,6 +76,14 @@
           <groupId>io.airlift</groupId>
           <artifactId>aircompressor</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>co.cask.tephra</groupId>
+          <artifactId>tephra-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>co.cask.tephra</groupId>
+          <artifactId>tephra-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -29,12 +29,12 @@
   <name>Drill : Contrib : Storage : Phoenix</name>
   
   <properties>
-    <phoenix.queryserver.version>6.0.0</phoenix.queryserver.version>
     <phoenix.version>5.1.2</phoenix.version>
     <!-- Keep the 2.4.2 to reduce dependency conflict -->
     <hbase.minicluster.version>2.4.2</hbase.minicluster.version>
+    <phoenix.skip.tests>false</phoenix.skip.tests>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -55,60 +55,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-	<dependency>
-	  <groupId>org.apache.phoenix</groupId>
-	  <artifactId>phoenix-queryserver-client</artifactId>
-	  <version>${phoenix.queryserver.version}</version>
-	</dependency>
- 
-    <!-- Test Dependency versions -->
-    <dependency>
-      <!-- PHOENIX-6605 -->
-      <groupId>com.github.luocooong.phoenix-queryserver</groupId>
-      <artifactId>phoenix-queryserver</artifactId>
-      <version>6.0.0-drill-r1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <!-- PHOENIX-6605 -->
-      <groupId>com.github.luocooong.phoenix-queryserver</groupId>
-      <artifactId>phoenix-queryserver-it</artifactId>
-      <version>6.0.0-drill-r1</version>
-      <scope>test</scope>
-      <classifier>tests</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-jaxrs</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-xc</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-core</artifactId>
@@ -136,13 +82,53 @@
           <groupId>org.ow2.asm</groupId>
           <artifactId>asm</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-configuration</groupId>
+          <artifactId>commons-configuration</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-csv</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-endpoint</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.salesforce.i18n</groupId>
+          <artifactId>i18n-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-graphite</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-hbase-compat-2.4.1</artifactId>
+      <version>${phoenix.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-core</artifactId>
       <version>${phoenix.version}</version>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -151,6 +137,62 @@
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-configuration</groupId>
+          <artifactId>commons-configuration</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-testing-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.htrace</groupId>
+          <artifactId>htrace-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-csv</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-endpoint</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.salesforce.i18n</groupId>
+          <artifactId>i18n-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-graphite</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -170,21 +212,20 @@
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-it</artifactId>
       <version>${hbase.minicluster.version}</version>
-      <type>test-jar</type>
+      <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-endpoint</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>
       <version>${hbase.minicluster.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-server</artifactId>
-      <version>${hbase.minicluster.version}</version>
-      <type>test-jar</type>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -214,7 +255,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-asyncfs</artifactId>
-      <type>test-jar</type>
+      <classifier>tests</classifier>
       <version>${hbase.minicluster.version}</version>
       <scope>test</scope>
       <exclusions>
@@ -288,28 +329,11 @@
           <groupId>com.zaxxer</groupId>
           <artifactId>HikariCP-java7</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-csv</artifactId>
+        </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.univocity</groupId>
-      <artifactId>univocity-parsers</artifactId>
-      <version>${univocity-parsers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -339,8 +363,12 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skipTests>${phoenix.skip.tests}</skipTests>
+          <forkCount combine.self="override">1</forkCount>
+          <reuseForks>false</reuseForks>
           <includes>
             <include>**/PhoenixTestSuite.class</include>
+            <include>**/SecuredPhoenixTestSuite.class</include>
           </includes>
           <excludes>
             <exclude>**/*Test.java</exclude>
@@ -353,6 +381,9 @@
   <profiles>
     <profile>
       <id>hadoop-2</id>
+      <properties>
+        <phoenix.skip.tests>true</phoenix.skip.tests>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixReader.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixReader.java
@@ -236,7 +236,11 @@ public class PhoenixReader implements AutoCloseable {
     public void load(ResultSet row) throws SQLException {
       Array array = row.getArray(index);
       if (array != null && array.getArray() != null) {
-        Object[] values = (Object[]) array.getArray();
+        // Phoenix can create an array of primitives, so need to convert them
+        Object[] values = new Object[java.lang.reflect.Array.getLength(array.getArray())];
+        for (int i = 0; i < values.length; i++) {
+          values[i] = java.lang.reflect.Array.get(array.getArray(), i);
+        }
         ((ScalarArrayWriter) writer).setObjectArray(values);
       }
     }

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePlugin.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePlugin.java
@@ -121,7 +121,7 @@ public class PhoenixStoragePlugin extends AbstractStoragePlugin {
     try {
       return CACHE.get(userName);
     } catch (final ExecutionException e) {
-      throw new SQLException("Failure setting up Phoenix DataSource (PQS client)", e);
+      throw new SQLException("Failure setting up Phoenix DataSource (Phoenix client)", e);
     }
   }
 
@@ -135,6 +135,6 @@ public class PhoenixStoragePlugin extends AbstractStoragePlugin {
     boolean impersonationEnabled = context.getConfig().getBoolean(ExecConstants.IMPERSONATION_ENABLED);
     return StringUtils.isNotBlank(config.getJdbcURL())
       ? new PhoenixDataSource(config.getJdbcURL(), userName, props, impersonationEnabled) // the props is initiated.
-      : new PhoenixDataSource(config.getHost(), config.getPort(), userName, props, impersonationEnabled);
+      : new PhoenixDataSource(config.getZkQuorum(), config.getPort(), config.getZkPath(), userName, props, impersonationEnabled);
   }
 }

--- a/contrib/storage-phoenix/src/main/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-phoenix/src/main/resources/bootstrap-storage-plugins.json
@@ -2,10 +2,10 @@
   "storage": {
     "phoenix": {
       "type": "phoenix",
-      "host": "the.queryserver.hostname",
+      "zkQuorum": "zk.quorum.hostnames",
       "port": 8765,
       "props" : {
-        "phoenix.query.timeoutMs": 60000
+        "hbase.client.retries.number": 10
       },
       "enabled": false
     }

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixBaseTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixBaseTest.java
@@ -59,15 +59,15 @@ public class PhoenixBaseTest extends ClusterTest {
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    PhoenixTestSuite.initPhoenixQueryServer();
+    PhoenixTestSuite.initPhoenix();
     if (PhoenixTestSuite.isRunningSuite()) {
-      QueryServerBasicsIT.testCatalogs();
+      PhoenixBasicsIT.testCatalogs();
     }
     startDrillCluster();
     if (initCount.incrementAndGet() == 1) {
-      createSchema(QueryServerBasicsIT.CONN_STRING);
-      createTables(QueryServerBasicsIT.CONN_STRING);
-      createSampleData(QueryServerBasicsIT.CONN_STRING);
+      createSchema(PhoenixBasicsIT.CONN_STRING);
+      createTables(PhoenixBasicsIT.CONN_STRING);
+      createSampleData(PhoenixBasicsIT.CONN_STRING);
     }
   }
 
@@ -85,8 +85,8 @@ public class PhoenixBaseTest extends ClusterTest {
     props.put("phoenix.query.timeoutMs", 90000);
     props.put("phoenix.query.keepAliveMs", "30000");
     StoragePluginRegistry registry = cluster.drillbit().getContext().getStorage();
-    PhoenixStoragePluginConfig config = new PhoenixStoragePluginConfig(null, 0, null, null,
-      QueryServerBasicsIT.CONN_STRING, null, props);
+    PhoenixStoragePluginConfig config = new PhoenixStoragePluginConfig(null, 0, null, null, null,
+      PhoenixBasicsIT.CONN_STRING, null, props);
     config.setEnabled(true);
     registry.put(PhoenixStoragePluginConfig.NAME + "123", config);
     dirTestWatcher.copyResourceToRoot(Paths.get(""));

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixSQLTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixSQLTest.java
@@ -220,7 +220,7 @@ public class PhoenixSQLTest extends PhoenixBaseTest {
     sets.clear();
   }
 
-  @Ignore("use the remote query server directly without minicluster")
+  @Ignore("use the remote phoenix directly without minicluster")
   @Test
   public void testJoinWithFilterPushdown() throws Exception {
     String sql = "select 10 as DRILL, a.n_name, b.r_name from phoenix123.v1.nation a join phoenix123.v1.region b "

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixTestSuite.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixTestSuite.java
@@ -24,7 +24,6 @@ import org.apache.drill.categories.SlowTest;
 import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -38,22 +37,21 @@ import org.slf4j.LoggerFactory;
    PhoenixSQLTest.class,
    PhoenixCommandTest.class
 })
-@Ignore
 @Category({ SlowTest.class })
 public class PhoenixTestSuite extends BaseTest {
 
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(PhoenixTestSuite.class);
 
   private static volatile boolean runningSuite = false;
-  private static AtomicInteger initCount = new AtomicInteger(0);
+  private static final AtomicInteger initCount = new AtomicInteger(0);
 
   @BeforeClass
-  public static void initPhoenixQueryServer() throws Exception {
+  public static void initPhoenix() throws Exception {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     synchronized (PhoenixTestSuite.class) {
       if (initCount.get() == 0) {
         logger.info("Boot the test cluster...");
-        QueryServerBasicsIT.doSetup();
+        PhoenixBasicsIT.doSetup();
       }
       initCount.incrementAndGet();
       runningSuite = true;
@@ -65,7 +63,7 @@ public class PhoenixTestSuite extends BaseTest {
     synchronized (PhoenixTestSuite.class) {
       if (initCount.decrementAndGet() == 0) {
         logger.info("Shutdown all instances of test cluster.");
-        QueryServerBasicsIT.afterClass();
+        PhoenixBasicsIT.afterClass();
       }
     }
   }

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixCommandTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixCommandTest.java
@@ -26,12 +26,12 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.QueryBuilder;
 import org.apache.drill.test.rowSet.RowSetComparison;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-@Tag(SlowTest.TAG)
-@Tag(RowSetTest.TAG)
+import static org.junit.Assert.assertEquals;
+
+@Category({ SlowTest.class, RowSetTest.class })
 public class SecuredPhoenixCommandTest extends SecuredPhoenixBaseTest {
 
   @Test
@@ -42,7 +42,7 @@ public class SecuredPhoenixCommandTest extends SecuredPhoenixBaseTest {
   private void doTestShowTablesLike() throws Exception {
     runAndPrint("SHOW SCHEMAS");
     run("USE phoenix123.V1");
-    Assertions.assertEquals(1, queryBuilder().sql("SHOW TABLES LIKE '%REGION%'").run().recordCount());
+    assertEquals(1, queryBuilder().sql("SHOW TABLES LIKE '%REGION%'").run().recordCount());
   }
 
   @Test
@@ -77,6 +77,6 @@ public class SecuredPhoenixCommandTest extends SecuredPhoenixBaseTest {
 
   private void doTestDescribe() throws Exception {
     run("USE phoenix123.v1");
-    Assertions.assertEquals(4, queryBuilder().sql("DESCRIBE NATION").run().recordCount());
+    assertEquals(4, queryBuilder().sql("DESCRIBE NATION").run().recordCount());
   }
 }

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixDataTypeTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixDataTypeTest.java
@@ -26,8 +26,8 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.QueryBuilder;
 import org.apache.drill.test.rowSet.RowSetComparison;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -43,8 +43,7 @@ import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.shortArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
 
-@Tag(SlowTest.TAG)
-@Tag(RowSetTest.TAG)
+@Category({ SlowTest.class, RowSetTest.class })
 public class SecuredPhoenixDataTypeTest extends SecuredPhoenixBaseTest {
 
   @Test

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixSQLTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixSQLTest.java
@@ -28,14 +28,13 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.test.QueryBuilder;
 import org.apache.drill.test.rowSet.RowSetComparison;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
-@Tag(SlowTest.TAG)
-@Tag(RowSetTest.TAG)
+@Category({ SlowTest.class, RowSetTest.class })
 public class SecuredPhoenixSQLTest extends SecuredPhoenixBaseTest {
 
   @Test
@@ -175,7 +174,7 @@ public class SecuredPhoenixSQLTest extends SecuredPhoenixBaseTest {
     String sql = "select count(*) as total from phoenix123.v1.nation";
     String plan = queryBuilder().sql(sql).explainJson();
     long cnt = queryBuilder().physical(plan).singletonLong();
-    assertEquals(25, cnt, "Counts should match");
+    assertEquals("Counts should match", 25, cnt);
   }
 
   @Test
@@ -243,12 +242,12 @@ public class SecuredPhoenixSQLTest extends SecuredPhoenixBaseTest {
 
     builder.planMatcher().exclude("Join").match();
 
-    assertEquals(625, sets.rowCount(), "Counts should match");
+    assertEquals("Counts should match", 625, sets.rowCount());
     sets.clear();
   }
 
   @Test
-  @Disabled("use the remote query server directly without minicluster")
+  @Ignore("use the remote phoenix directly without minicluster")
   public void testJoinWithFilterPushdown() throws Exception {
     String sql = "select 10 as DRILL, a.n_name, b.r_name from phoenix123.v1.nation a join phoenix123.v1.region b "
         + "on a.n_regionkey = b.r_regionkey where b.r_name = 'ASIA'";

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixTestSuite.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/secured/SecuredPhoenixTestSuite.java
@@ -19,29 +19,26 @@ package org.apache.drill.exec.store.phoenix.secured;
 
 import org.apache.drill.categories.RowSetTest;
 import org.apache.drill.categories.SlowTest;
-import org.apache.drill.exec.store.phoenix.QueryServerBasicsIT;
+import org.apache.drill.exec.store.phoenix.PhoenixBasicsIT;
 import org.apache.drill.test.BaseTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 import org.slf4j.LoggerFactory;
 
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
-@Suite
-@SelectClasses({
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
   SecuredPhoenixDataTypeTest.class,
   SecuredPhoenixSQLTest.class,
   SecuredPhoenixCommandTest.class
 })
-@Disabled
-@Tag(SlowTest.TAG)
-@Tag(RowSetTest.TAG)
+@Category({ SlowTest.class, RowSetTest.class })
 public class SecuredPhoenixTestSuite extends BaseTest {
 
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SecuredPhoenixTestSuite.class);
@@ -49,25 +46,25 @@ public class SecuredPhoenixTestSuite extends BaseTest {
   private static volatile boolean runningSuite = false;
   private static final AtomicInteger initCount = new AtomicInteger(0);
 
-  @BeforeAll
-  public static void initPhoenixQueryServer() throws Exception {
+  @BeforeClass
+  public static void initPhoenix() throws Exception {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     synchronized (SecuredPhoenixTestSuite.class) {
       if (initCount.get() == 0) {
         logger.info("Boot the test cluster...");
-        HttpParamImpersonationQueryServerIT.startQueryServerEnvironment();
+        ImpersonationPhoenixIT.startPhoenixEnvironment();
       }
       initCount.incrementAndGet();
       runningSuite = true;
     }
   }
 
-  @AfterAll
+  @AfterClass
   public static void tearDownCluster() throws Exception {
     synchronized (SecuredPhoenixTestSuite.class) {
       if (initCount.decrementAndGet() == 0) {
         logger.info("Shutdown all instances of test cluster.");
-        QueryServerBasicsIT.afterClass();
+        PhoenixBasicsIT.afterClass();
       }
     }
   }

--- a/contrib/storage-phoenix/src/test/resources/hbase-site.xml
+++ b/contrib/storage-phoenix/src/test/resources/hbase-site.xml
@@ -28,4 +28,8 @@
     <name>phoenix.schema.isNamespaceMappingEnabled</name>
     <value>true</value>
   </property>
+  <property>
+    <name>hbase.wal.provider</name>
+    <value>filesystem</value>
+  </property>
 </configuration>


### PR DESCRIPTION
# [DRILL-8279](https://issues.apache.org/jira/browse/DRILL-8279): Use thick Phoenix driver

## Description

`phoenix-queryserver-client` shades Avatica classes, so it causes issues when starting Drill and shaded class from phoenix jars is loaded before official Avatica, so Drill wouldn't be able to start correctly.

- Fixed Phoenix unit tests to run with general tests suite without any extra checks
- Added support for Phoenix thick client
- Removed usage of custom dependencies

## Documentation
To use fat client, storage plugin configs should be updated as described in https://github.com/apache/drill/compare/master...vvysotskyi:DRILL-8279?expand=1#diff-81178bb7d4498bc22f7c54e71462b460f95b80f40f85e74ff8f1cc7f69d34351

## Testing
All unit tests pass, queried Phoenix using Drill.
