### PR TITLE
DRILL-8287: Add Support for Keyset Based Pagination

### DIFF
--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsStoragePluginConfig.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsStoragePluginConfig.java
@@ -126,7 +126,7 @@ public class GoogleSheetsStoragePluginConfig extends StoragePluginConfig {
       .build();
   }
 
-  @JsonProperty("clientID")
+  @JsonIgnore
   public String getClientID() {
     if(getOAuthCredentials().isPresent()) {
       return getOAuthCredentials().get().getClientID();
@@ -135,7 +135,7 @@ public class GoogleSheetsStoragePluginConfig extends StoragePluginConfig {
     }
   }
 
-  @JsonProperty("clientSecret")
+  @JsonIgnore
   public String getClientSecret() {
     if (getOAuthCredentials().isPresent()) {
       return getOAuthCredentials().get().getClientSecret();

--- a/contrib/storage-http/Pagination.md
+++ b/contrib/storage-http/Pagination.md
@@ -42,4 +42,31 @@ Page pagination is very similar to offset pagination except instead of using an 
 In either case, the `pageSize` parameter should be set to the maximum page size allowable by the API.  This will minimize the number of requests Drill is making.
 
 ## Index / KeySet Pagination
+Index or KeySet pagination is when the API itself returns values to generate the next page. 
 
+Consider an API that returned data like this: 
+
+```json
+{
+  "companies": [
+    ...
+  ],
+  "has-more": true,
+  "index": 3849945478
+}
+
+```
+In this case, the `has-more` parameter is a boolean value which indicates whether or not there are more pages. The `index` parameter gets appended to the URL in question to generate the next page.
+
+`https://api.myapi.com/paged?properties=name&properties=website&offset=3856722038`
+
+There is a slight variant of this where the API will return the actual URL of the next page.
+
+There are three possible parameters:
+
+* `hasMoreParam`: This is the name of the boolean parameter which indicates whether the API has more pages.
+* `indexParam`:  The parameter name of the key or offset that will be used to generate the next page.
+* `nextPageParam`: The parameter name which returns a complete URL of the next page.
+
+
+** Note: Index / Keyset Pagination is only implemented for APIs that return JSON ** 

--- a/contrib/storage-http/Pagination.md
+++ b/contrib/storage-http/Pagination.md
@@ -40,3 +40,6 @@ Page pagination is very similar to offset pagination except instead of using an 
       }
 ```
 In either case, the `pageSize` parameter should be set to the maximum page size allowable by the API.  This will minimize the number of requests Drill is making.
+
+## Index / KeySet Pagination
+

--- a/contrib/storage-http/Pagination.md
+++ b/contrib/storage-http/Pagination.md
@@ -5,7 +5,7 @@ data into one larger dataset.  Drill's auto-pagination features allow this to ha
 To use a paginator, you simply have to configure the paginator in the connection for the particular API.  
 
 ## Words of Caution
-While extremely powerful, the auto-pagination feature has the potential to run afoul of APIs rate limits and even potentially DDOS an API. 
+While extremely powerful, the auto-pagination feature has the potential to run afoul of APIs rate limits and even potentially DDoS an API. Please use with extreme care.
 
 
 ## Offset Pagination

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -110,7 +110,6 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
       }
     };
     negotiator.setErrorContext(errorContext);
-    
 
     // Http client setup
     SimpleHttp http = SimpleHttp.builder()

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -339,31 +339,33 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
       // to the next page.
       //
       // In ether case, we first need the boolean "has more" parameter so let's grab that.
-      Object hasMore = paginationFields.get(indexPaginator.getHasMoreParam());
-      boolean hasMoreValues;
-      if (hasMore instanceof Boolean) {
-        hasMoreValues = (Boolean) hasMore;
-      } else {
-        String hasMoreString = hasMore.toString();
-        // Attempt to convert to boolean
-        hasMoreValues = Boolean.parseBoolean(hasMoreString);
-      }
-      indexPaginator.setHasMoreValue(hasMoreValues);
+      if (paginationFields.get(indexPaginator.getHasMoreParam()) != null) {
+        Object hasMore = paginationFields.get(indexPaginator.getHasMoreParam());
+        boolean hasMoreValues;
 
-      // If there are no more values, notify the paginator
-      if (!hasMoreValues) {
-        paginator.notifyPartialPage();
-      }
-      logger.debug("Ending index/keyset pagination.");
+        if (hasMore instanceof Boolean) {
+          hasMoreValues = (Boolean) hasMore;
+        } else {
+          String hasMoreString = hasMore.toString();
+          // Attempt to convert to boolean
+          hasMoreValues = Boolean.parseBoolean(hasMoreString);
+        }
+        indexPaginator.setHasMoreValue(hasMoreValues);
 
-      // At this point we know that there are more pages to come.  Send the data to the paginator and
-      // use that to generate the next page.
-      if (StringUtils.isNotEmpty(indexPaginator.getIndexParam())) {
-        indexPaginator.setIndexValue(paginationFields.get(indexPaginator.getIndexParam()).toString());
-      }
+        // If there are no more values, notify the paginator
+        if (!hasMoreValues) {
+          paginator.notifyPartialPage();
+        }
 
-      if (StringUtils.isNotEmpty(indexPaginator.getNextPageParam())) {
-        indexPaginator.setNextPageValue(paginationFields.get(indexPaginator.getNextPageParam()).toString());
+        // At this point we know that there are more pages to come.  Send the data to the paginator and
+        // use that to generate the next page.
+        if (StringUtils.isNotEmpty(indexPaginator.getIndexParam())) {
+          indexPaginator.setIndexValue(paginationFields.get(indexPaginator.getIndexParam()).toString());
+        }
+
+        if (StringUtils.isNotEmpty(indexPaginator.getNextPageParam())) {
+          indexPaginator.setNextPageValue(paginationFields.get(indexPaginator.getNextPageParam()).toString());
+        }
       }
     } else if (paginator != null &&
       maxRecords < 0 && (resultSetLoader.totalRowCount()) < paginator.getPageSize()) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -138,7 +138,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
           .maxRows(maxRecords)
           .dataPath(subScan.tableSpec().connectionConfig().dataPath())
           .errorContext(errorContext)
-          .paginationFields(paginationFields)
+          .listenerColumnMap(paginationFields)
           .fromStream(inStream);
 
       if (subScan.tableSpec().connectionConfig().jsonOptions() != null) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -110,8 +110,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
       }
     };
     negotiator.setErrorContext(errorContext);
-
-    System.out.println("URL: " + url);
+    
 
     // Http client setup
     SimpleHttp http = SimpleHttp.builder()

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -31,17 +31,22 @@ import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.v3.FixedReceiver;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.drill.exec.physical.resultSet.impl.ResultVectorCacheImpl;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
 import org.apache.drill.exec.store.http.HttpApiConfig.PostLocation;
+import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
+import org.apache.drill.exec.store.http.paginator.IndexPaginator;
 import org.apache.drill.exec.store.http.paginator.Paginator;
 import org.apache.drill.exec.store.http.util.HttpProxyConfig;
 import org.apache.drill.exec.store.http.util.HttpProxyConfig.ProxyBuilder;
 import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.apache.drill.exec.store.ImplicitColumnUtils.ImplicitColumns;
 import org.apache.drill.exec.store.security.UsernamePasswordWithProxyCredentials;
+import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -294,6 +299,13 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
   @Override
   public boolean next() {
     boolean result = jsonLoader.readBatch();
+
+    // TODO Start here... pull the value(s) from the ResultVectorCache
+    if (paginator != null && paginator.getMode() == PaginatorMethod.INDEX) {
+      IndexPaginator indexPaginator = (IndexPaginator) paginator;
+      ResultVectorCacheImpl cache = (ResultVectorCacheImpl) resultSetLoader.vectorCache();
+      logger.debug("tet");
+    }
 
     // Allows limitless pagination.
     if (paginator != null &&

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -27,12 +27,15 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.v3.FixedReceiver;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
 import org.apache.drill.exec.physical.resultSet.impl.ResultVectorCacheImpl;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
@@ -300,10 +303,11 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
   public boolean next() {
     boolean result = jsonLoader.readBatch();
 
-    // TODO Start here... pull the value(s) from the ResultVectorCache
+    // TODO Start here... pull the value(s) from the Output Container
     if (paginator != null && paginator.getMode() == PaginatorMethod.INDEX) {
       IndexPaginator indexPaginator = (IndexPaginator) paginator;
-      ResultVectorCacheImpl cache = (ResultVectorCacheImpl) resultSetLoader.vectorCache();
+      VectorContainer vectorContainer = resultSetLoader.writer().loader().outputSchema().
+
       logger.debug("tet");
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -69,7 +69,6 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
   private JsonLoader jsonLoader;
   private ResultSetLoader resultSetLoader;
   protected ImplicitColumns implicitColumns;
-  protected TupleMetadata outputSchema;
   private final Map<String, Object> paginationFields;
 
   public HttpBatchReader(HttpSubScan subScan) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
@@ -23,9 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.PlanStringBuilder;
-import org.apache.drill.common.exceptions.UserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonDeserialize(builder = HttpPaginatorConfig.HttpPaginatorBuilder.class)
+@JsonDeserialize(builder = HttpPaginatorConfig.HttpPaginatorConfigBuilder.class)
 public class HttpPaginatorConfig {
 
   private static final Logger logger = LoggerFactory.getLogger(HttpPaginatorConfig.class);
@@ -176,7 +176,7 @@ public class HttpPaginatorConfig {
     INDEX
   }
 
-  private HttpPaginatorConfig(HttpPaginatorConfig.HttpPaginatorBuilder builder) {
+  /*private HttpPaginatorConfig(HttpPaginatorConfig.HttpPaginatorConfigBuilder builder) {
     this.limitParam = builder.limitParam;
     this.offsetParam = builder.offsetParam;
     this.pageSize = builder.pageSize;
@@ -196,7 +196,7 @@ public class HttpPaginatorConfig {
     * For pagination to function key fields must be defined.  This block validates the required fields for
     * each type of paginator.
      */
-    switch (paginatorMethod) {
+    /*switch (paginatorMethod) {
       case OFFSET:
         if (StringUtils.isEmpty(this.limitParam) || StringUtils.isEmpty(this.offsetParam)) {
           throw UserException
@@ -243,7 +243,7 @@ public class HttpPaginatorConfig {
           .message("Invalid paginator method: %s.  Drill supports 'OFFSET', 'INDEX' and 'PAGE'", method)
           .build(logger);
     }
-  }
+  }*/
 
   @JsonIgnore
   public PaginatorMethod getMethodType() {
@@ -251,122 +251,6 @@ public class HttpPaginatorConfig {
   }
 
   @JsonPOJOBuilder(withPrefix = "")
-  public static class HttpPaginatorBuilder {
-    public String limitParam;
-
-    public String offsetParam;
-
-    public int maxRecords;
-
-    public int pageSize;
-
-    public String pageParam;
-
-    public String pageSizeParam;
-
-    public String method;
-
-    public String hasMoreParam;
-
-    public String indexParam;
-
-    public String nextPageParam;
-
-
-    public HttpPaginatorConfig build() {
-      return new HttpPaginatorConfig(this);
-    }
-
-    public String hasMoreParam() {
-      return this.hasMoreParam;
-    }
-
-    public String indexParam() {
-      return this.indexParam;
-    }
-
-    public String nextPageParam() {
-      return this.nextPageParam;
-    }
-    public String limitParam() {
-      return this.limitParam;
-    }
-
-    public String offsetParam() {
-      return this.offsetParam;
-    }
-
-    public int maxRecords() {
-      return this.maxRecords;
-    }
-
-    public int pageSize() {
-      return this.pageSize;
-    }
-
-    public String pageParam() {
-      return this.pageParam;
-    }
-
-    public String pageSizeParam() {
-      return this.pageSizeParam;
-    }
-
-    public String method() {
-      return this.method;
-    }
-
-    public HttpPaginatorBuilder hasMoreParam(String hasMoreParam) {
-      this.hasMoreParam = hasMoreParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder indexParam(String indexParam) {
-      this.indexParam = indexParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder nextPageParam(String nextPageParam) {
-      this.nextPageParam = nextPageParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder limitParam(String limitParam) {
-      this.limitParam = limitParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder offsetParam(String offsetParam) {
-      this.offsetParam = offsetParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder maxRecords(int maxRecords) {
-      this.maxRecords = maxRecords;
-      return this;
-    }
-
-    public HttpPaginatorBuilder pageSize(int pageSize) {
-      this.pageSize = pageSize;
-      return this;
-    }
-
-    public HttpPaginatorBuilder pageParam(String pageParam) {
-      this.pageParam = pageParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder pageSizeParam(String pageSizeParam) {
-      this.pageSizeParam = pageSizeParam;
-      return this;
-    }
-
-    public HttpPaginatorBuilder method(String method) {
-      this.method = method;
-      return this;
-    }
-  }
-
   public static class HttpPaginatorConfigBuilder {
     private String limitParam;
     private String offsetParam;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
@@ -61,6 +61,15 @@ public class HttpPaginatorConfig {
   @JsonProperty
   private final String method;
 
+  @JsonProperty
+  private final String hasMoreParam;
+
+  @JsonProperty
+  private final String indexParam;
+
+  @JsonProperty
+  private final String nextPageParam;
+
   public HttpPaginatorConfig(HttpPaginatorConfigBuilder builder) {
     this.limitParam = builder.limitParam;
     this.offsetParam = builder.offsetParam;
@@ -69,6 +78,9 @@ public class HttpPaginatorConfig {
     this.pageSize = builder.pageSize;
     this.maxRecords = builder.maxRecords;
     this.method = builder.method;
+    this.hasMoreParam = builder.hasMoreParam;
+    this.indexParam = builder.indexParam;
+    this.nextPageParam = builder.nextPageParam;
   }
 
   public static HttpPaginatorConfigBuilder builder() {
@@ -103,6 +115,17 @@ public class HttpPaginatorConfig {
     return this.method;
   }
 
+  public String hasMoreParam() {
+    return hasMoreParam;
+  }
+
+  public String nextPageParam() {
+    return nextPageParam;
+  }
+  public String indexParam() {
+    return indexParam;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -118,13 +141,16 @@ public class HttpPaginatorConfig {
       && Objects.equals(offsetParam, that.offsetParam)
       && Objects.equals(pageParam, that.pageParam)
       && Objects.equals(pageSizeParam, that.pageSizeParam)
-      && Objects.equals(method, that.method);
+      && Objects.equals(method, that.method)
+      && Objects.equals(hasMoreParam, that.hasMoreParam)
+      && Objects.equals(indexParam, that.indexParam)
+      && Objects.equals(nextPageParam, that.nextPageParam);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(limitParam, offsetParam, pageParam, pageSizeParam,
-      pageSize, maxRecords, method);
+      pageSize, maxRecords, method, nextPageParam, indexParam, hasMoreParam);
   }
 
   @Override
@@ -137,12 +163,16 @@ public class HttpPaginatorConfig {
       .field("pageSize", pageSize)
       .field("maxRecords", maxRecords)
       .field("method", method)
+      .field("indexParam", indexParam)
+      .field("hasMoreParam", hasMoreParam)
+      .field("nextPageParam", nextPageParam)
       .toString();
   }
 
   public enum PaginatorMethod {
     OFFSET,
-    PAGE
+    PAGE,
+    INDEX
   }
 
   private HttpPaginatorConfig(HttpPaginatorConfig.HttpPaginatorBuilder builder) {
@@ -152,6 +182,9 @@ public class HttpPaginatorConfig {
     this.pageParam = builder.pageParam;
     this.pageSizeParam = builder.pageSizeParam;
     this.maxRecords = builder.maxRecords;
+    this.nextPageParam = builder.nextPageParam;
+    this.hasMoreParam = builder.hasMoreParam;
+    this.indexParam = builder.indexParam;
 
     this.method = StringUtils.isEmpty(builder.method)
       ? PaginatorMethod.OFFSET.toString() : builder.method.trim().toUpperCase();
@@ -189,10 +222,23 @@ public class HttpPaginatorConfig {
             .build(logger);
         }
         break;
+      case INDEX:
+        // Either the nextPageParam OR the indexParam must be populated
+        if (StringUtils.isEmpty(hasMoreParam)) {
+          throw UserException
+            .validationError()
+            .message("Invalid paginator configuration.  For INDEX pagination, the hasMoreParam must be defined.")
+            .build(logger);
+        } else if (StringUtils.isEmpty(nextPageParam) || StringUtils.isEmpty(indexParam)) {
+          throw UserException
+            .validationError()
+            .message("Invalid paginator configuration.  For INDEX pagination, the nextPageParam or indexParam must be defined.")
+            .build(logger);
+        }
       default:
         throw UserException
           .validationError()
-          .message("Invalid paginator method: %s.  Drill supports 'OFFSET' and 'PAGE'", method)
+          .message("Invalid paginator method: %s.  Drill supports 'OFFSET', 'INDEX' and 'PAGE'", method)
           .build(logger);
     }
   }
@@ -218,10 +264,28 @@ public class HttpPaginatorConfig {
 
     public String method;
 
+    public String hasMoreParam;
+
+    public String indexParam;
+
+    public String nextPageParam;
+
+
     public HttpPaginatorConfig build() {
       return new HttpPaginatorConfig(this);
     }
 
+    public String hasMoreParam() {
+      return this.hasMoreParam;
+    }
+
+    public String indexParam() {
+      return this.indexParam;
+    }
+
+    public String nextPageParam() {
+      return this.nextPageParam;
+    }
     public String limitParam() {
       return this.limitParam;
     }
@@ -248,6 +312,21 @@ public class HttpPaginatorConfig {
 
     public String method() {
       return this.method;
+    }
+
+    public HttpPaginatorBuilder hasMoreParam(String hasMoreParam) {
+      this.hasMoreParam = hasMoreParam;
+      return this;
+    }
+
+    public HttpPaginatorBuilder indexParam(String indexParam) {
+      this.indexParam = indexParam;
+      return this;
+    }
+
+    public HttpPaginatorBuilder nextPageParam(String nextPageParam) {
+      this.nextPageParam = nextPageParam;
+      return this;
     }
 
     public HttpPaginatorBuilder limitParam(String limitParam) {
@@ -288,18 +367,30 @@ public class HttpPaginatorConfig {
 
   public static class HttpPaginatorConfigBuilder {
     private String limitParam;
-
     private String offsetParam;
-
     private String pageParam;
-
     private String pageSizeParam;
-
     private int pageSize;
-
     private int maxRecords;
-
     private String method;
+    private String hasMoreParam;
+    private String indexParam;
+    private String nextPageParam;
+
+    public HttpPaginatorConfigBuilder hasMoreParam(String hasMoreParam) {
+      this.hasMoreParam = hasMoreParam;
+      return this;
+    }
+
+    public HttpPaginatorConfigBuilder indexParam(String indexParam) {
+      this.indexParam = indexParam;
+      return this;
+    }
+
+    public HttpPaginatorConfigBuilder nextPageParam(String nextPageParam) {
+      this.nextPageParam = nextPageParam;
+      return this;
+    }
 
     public HttpPaginatorConfigBuilder limitParam(String limitParam) {
       this.limitParam = limitParam;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
@@ -61,6 +61,7 @@ public class HttpPaginatorConfig {
   @JsonProperty
   private final String method;
 
+  // For index/keyset pagination
   @JsonProperty
   private final String hasMoreParam;
 
@@ -235,6 +236,7 @@ public class HttpPaginatorConfig {
             .message("Invalid paginator configuration.  For INDEX pagination, the nextPageParam or indexParam must be defined.")
             .build(logger);
         }
+        break;
       default:
         throw UserException
           .validationError()

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -25,7 +25,6 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ops.ExecutorFragmentContext;
 import org.apache.drill.exec.physical.impl.BatchCreator;
-import org.apache.drill.exec.physical.impl.protocol.OperatorRecordBatch;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ReaderFactory;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -25,6 +25,7 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ops.ExecutorFragmentContext;
 import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.physical.impl.protocol.OperatorRecordBatch;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ReaderFactory;
@@ -34,6 +35,7 @@ import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
+import org.apache.drill.exec.store.http.paginator.IndexPaginator;
 import org.apache.drill.exec.store.http.paginator.OffsetPaginator;
 import org.apache.drill.exec.store.http.paginator.PagePaginator;
 import org.apache.drill.exec.store.http.paginator.Paginator;
@@ -136,6 +138,12 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
           paginatorConfig.pageSize(),
           paginatorConfig.pageParam(),
           paginatorConfig.pageSizeParam());
+      } else if (paginatorConfig.getMethodType() == PaginatorMethod.INDEX) {
+        paginator = new IndexPaginator(urlBuilder,
+          subScan.maxRecords(),
+          0, paginatorConfig.hasMoreParam(),
+          paginatorConfig.indexParam(),
+          paginatorConfig.nextPageParam());
       }
       return paginator;
     }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.AbstractBase;
@@ -35,7 +34,6 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
-import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
 
 @JsonTypeName("http-sub-scan")
 public class HttpSubScan extends AbstractBase implements SubScan {
@@ -58,50 +56,10 @@ public class HttpSubScan extends AbstractBase implements SubScan {
     ) {
     super(tableSpec.queryUserName());
     this.tableSpec = tableSpec;
-    // this.columns = addColumnsToSchemaPath(columns);
     this.columns = columns;
     this.filters = filters;
     this.maxRecords = maxRecords;
     this.schema = schema;
-  }
-
-  private List<SchemaPath> addColumnsToSchemaPath(List<SchemaPath> columns) {
-    // This function handles an edge case when a data path is specified, the pagination columns may
-    // not be read. This logic adds these columns to the projection list to ensure they are projected
-    // This is only relevant for index pagination.
-    if (tableSpec.connectionConfig().paginator() != null &&
-      tableSpec.connectionConfig().paginator().getMethodType() != PaginatorMethod.INDEX &&
-      StringUtils.isEmpty(tableSpec.connectionConfig().dataPath())) {
-      return columns;
-    }
-
-    HttpPaginatorConfig paginatorConfig = tableSpec.connectionConfig().paginator();
-
-    if (StringUtils.isNotEmpty(paginatorConfig.hasMoreParam())) {
-      columns.add(SchemaPath.parseFromString(cleanUpColumnName(paginatorConfig.hasMoreParam())));
-    }
-
-    if (StringUtils.isNotEmpty(paginatorConfig.indexParam())) {
-      columns.add(SchemaPath.parseFromString(cleanUpColumnName(paginatorConfig.indexParam())));
-    }
-
-    if (StringUtils.isNotEmpty(paginatorConfig.nextPageParam())) {
-      columns.add(SchemaPath.parseFromString(cleanUpColumnName(paginatorConfig.nextPageParam())));
-    }
-
-    return columns;
-  }
-
-  private String cleanUpColumnName(String columnName) {
-    if (! columnName.startsWith("`")) {
-      columnName = "`" + columnName;
-    }
-
-    if (! columnName.endsWith("`")) {
-      columnName = columnName + "`";
-    }
-
-    return columnName;
   }
 
   @JsonProperty("tableSpec")

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
@@ -68,6 +68,9 @@ public class IndexPaginator extends Paginator {
   }
 
   public void setIndexValue(String indexValue) {
+    if (StringUtils.isNumeric(indexValue)) {
+
+    }
     this.indexValue = indexValue;
   }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
@@ -35,14 +35,14 @@ public class IndexPaginator extends Paginator {
   private String indexValue;
   private Boolean hasMoreValue;
   private String nextPageValue;
-  private boolean firstRun;
+  private int pageCount;
 
   public IndexPaginator(Builder builder, int pageSize, int limit, String hasMoreParam, String indexParam, String nextPageParam) {
     super(builder, PaginatorMethod.INDEX, pageSize, limit);
     this.hasMoreParam = hasMoreParam;
     this.indexParam = indexParam;
-    this.firstRun = true;
     this.nextPageParam = nextPageParam;
+    pageCount = 0;
   }
 
   @Override
@@ -75,11 +75,15 @@ public class IndexPaginator extends Paginator {
     this.nextPageValue = nextPageValue;
   }
 
+  public boolean isFirstPage() {
+    return pageCount < 1;
+  }
+
   @Override
   public String next() {
     // If the paginator has never been run before, just return the base URL.
-    if (firstRun) {
-      firstRun = false;
+    if (pageCount == 0) {
+      pageCount++;
       return builder.build().url().toString();
     }
 
@@ -98,7 +102,7 @@ public class IndexPaginator extends Paginator {
       builder.removeAllEncodedQueryParameters(indexParam);
       builder.addQueryParameter(indexParam, indexValue);
     }
-
+    pageCount++;
     return builder.build().url().toString();
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.http.paginator;
+
+import okhttp3.HttpUrl.Builder;
+import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
+
+import java.util.NoSuchElementException;
+
+public class IndexPaginator extends Paginator {
+
+  private final String hasMoreParam;
+  private final String indexParam;
+  private final String nextPageParam;
+
+  private String indexValue;
+  private String hasMoreValue;
+  private String nextPageValue;
+
+  public IndexPaginator(Builder builder, int pageSize, int limit, String hasMoreParam, String indexParam, String nextPageParam) {
+    super(builder, PaginatorMethod.INDEX, pageSize, limit);
+    this.hasMoreParam = hasMoreParam;
+    this.indexParam = indexParam;
+    this.nextPageParam = nextPageParam;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !partialPageReceived;
+
+  }
+
+  public String getIndexParam() {
+    return this.indexParam;
+  }
+
+  public String getHasMoreParam() {
+    return this.hasMoreParam;
+  }
+
+  public String getNextPageParam() {
+    return this.nextPageParam;
+  }
+
+  public void setIndexParam(String indexValue) {
+    this.indexValue = indexValue;
+  }
+
+  public void setNextPageValue(String nextPageValue) {
+    this.nextPageValue = nextPageValue;
+  }
+
+  public void setHasMoreValue(String hasMoreValue) {
+    this.hasMoreValue = hasMoreValue;
+  }
+
+  @Override
+  public String next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    return builder.build().url().toString();
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/IndexPaginator.java
@@ -29,6 +29,10 @@ public class IndexPaginator extends Paginator {
   private final String indexParam;
   private final String nextPageParam;
 
+  private int indexParamIndex;
+  private int hasMoreIndex;
+  private int nextPageIndex;
+
   private String indexValue;
   private String hasMoreValue;
   private String nextPageValue;
@@ -68,6 +72,14 @@ public class IndexPaginator extends Paginator {
 
   public void setHasMoreValue(String hasMoreValue) {
     this.hasMoreValue = hasMoreValue;
+  }
+
+  public void setIndexParamIndex(int index) {
+    this.indexParamIndex = index;
+  }
+
+  public int getIndexParamIndex() {
+    return this.indexParamIndex;
   }
 
   @Override

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/OffsetPaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/OffsetPaginator.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.http.paginator;
 
 import okhttp3.HttpUrl.Builder;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ public class OffsetPaginator extends Paginator {
    * @param offsetParam The field name which corresponds to the offset field from the API
    */
   public OffsetPaginator(Builder builder, int limit, int pageSize, String limitParam, String offsetParam) {
-    super(builder, paginationMode.OFFSET, pageSize, limit);
+    super(builder, PaginatorMethod.OFFSET, pageSize, limit);
     this.limit = limit;
     this.limitParam = limitParam;
     this.offsetParam = offsetParam;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/PagePaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/PagePaginator.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.http.paginator;
 
 import okhttp3.HttpUrl.Builder;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class PagePaginator extends Paginator {
    * @param pageSizeParam The API Query parameter which specifies how many results per page
    */
   public PagePaginator(Builder builder, int limit, int pageSize, String pageParam, String pageSizeParam) {
-    super(builder, paginationMode.PAGE, pageSize, limit);
+    super(builder, PaginatorMethod.PAGE, pageSize, limit);
     this.limit = limit;
     this.pageParam = pageParam;
     this.pageSizeParam = pageSizeParam;

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/Paginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/Paginator.java
@@ -19,6 +19,7 @@
 package org.apache.drill.exec.store.http.paginator;
 
 import okhttp3.HttpUrl.Builder;
+import org.apache.drill.exec.store.http.HttpPaginatorConfig.PaginatorMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,17 +42,12 @@ public abstract class Paginator implements Iterator<String> {
   private static final int MAX_ATTEMPTS = 100;
   protected final int pageSize;
 
-  public enum paginationMode {
-    OFFSET,
-    PAGE
-  }
-
-  protected final paginationMode MODE;
+  protected final PaginatorMethod MODE;
   protected final int limit;
   protected boolean partialPageReceived;
   protected Builder builder;
 
-  public Paginator(Builder builder, paginationMode mode, int pageSize, int limit) {
+  public Paginator(Builder builder, PaginatorMethod mode, int pageSize, int limit) {
     this.MODE = mode;
     this.builder = builder;
     this.pageSize = pageSize;
@@ -78,4 +74,8 @@ public abstract class Paginator implements Iterator<String> {
   }
 
   public int getPageSize() { return pageSize; }
+
+  public PaginatorMethod getMode() {
+    return MODE;
+  }
 }

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -63,6 +63,9 @@ public class TestPagination extends ClusterTest {
 
   private static String TEST_JSON_INDEX_PAGE1;
   private static String TEST_JSON_INDEX_PAGE2;
+  private static String TEST_JSON_INDEX_PAGE3;
+  private static String TEST_JSON_INDEX_PAGE4;
+
   private static String TEST_XML_PAGE1;
   private static String TEST_XML_PAGE2;
   private static String TEST_XML_PAGE3;
@@ -82,6 +85,9 @@ public class TestPagination extends ClusterTest {
 
     TEST_JSON_INDEX_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response1.json"), Charsets.UTF_8).read();
     TEST_JSON_INDEX_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response2.json"), Charsets.UTF_8).read();
+
+    TEST_JSON_INDEX_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response3.json"), Charsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE4 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response4.json"), Charsets.UTF_8).read();
 
     TEST_XML_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_1.xml"), Charsets.UTF_8).read();
     TEST_XML_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_2.xml"), Charsets.UTF_8).read();
@@ -326,8 +332,8 @@ public class TestPagination extends ClusterTest {
     String sql = "SELECT * FROM `local`.`json_index_datapath` LIMIT 4";
     try (MockWebServer server = startServer()) {
 
-      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE1));
-      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE3));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE4));
 
       List<QueryDataBatch> results = client.queryBuilder()
         .sql(sql)
@@ -339,7 +345,7 @@ public class TestPagination extends ClusterTest {
         b.release();
       }
       assertEquals(2, results.size());
-      assertEquals(2, count);
+      assertEquals(4, count);
     }
   }
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -60,6 +60,9 @@ public class TestPagination extends ClusterTest {
   private static String TEST_JSON_PAGE1;
   private static String TEST_JSON_PAGE2;
   private static String TEST_JSON_PAGE3;
+
+  private static String TEST_JSON_INDEX_PAGE1;
+  private static String TEST_JSON_INDEX_PAGE2;
   private static String TEST_XML_PAGE1;
   private static String TEST_XML_PAGE2;
   private static String TEST_XML_PAGE3;
@@ -76,6 +79,9 @@ public class TestPagination extends ClusterTest {
     TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
     TEST_JSON_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p2.json"), Charsets.UTF_8).read();
     TEST_JSON_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p3.json"), Charsets.UTF_8).read();
+
+    TEST_JSON_INDEX_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response1.json"), Charsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response2.json"), Charsets.UTF_8).read();
 
     TEST_XML_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_1.xml"), Charsets.UTF_8).read();
     TEST_XML_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_2.xml"), Charsets.UTF_8).read();
@@ -140,6 +146,21 @@ public class TestPagination extends ClusterTest {
       .pageSize(2)
       .build();
 
+    HttpPaginatorConfig indexPaginator = HttpPaginatorConfig.builder()
+      .indexParam("offset")
+      .hasMoreParam("has-more")
+      .method("index")
+      .build();
+
+    HttpApiConfig mockJsonConfigWithKeyset = HttpApiConfig.builder()
+      .url("http://localhost:8092/json")
+      .method("get")
+      .headers(headers)
+      .requireTail(false)
+      .paginator(indexPaginator)
+      .inputType("json")
+      .build();
+
     HttpApiConfig mockJsonConfigWithPaginator = HttpApiConfig.builder()
       .url("http://localhost:8092/json")
       .method("get")
@@ -192,6 +213,7 @@ public class TestPagination extends ClusterTest {
 
     Map<String, HttpApiConfig> configs = new HashMap<>();
     configs.put("csv_paginator", mockCsvConfigWithPaginator);
+    configs.put("json_index", mockJsonConfigWithKeyset);
     configs.put("json_paginator", mockJsonConfigWithPaginator);
     configs.put("xml_paginator", mockXmlConfigWithPaginator);
     configs.put("xml_paginator_url_params", mockXmlConfigWithPaginatorAndUrlParams);
@@ -228,6 +250,28 @@ public class TestPagination extends ClusterTest {
       server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
       server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE2));
       server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE3));
+
+      List<QueryDataBatch> results = client.queryBuilder()
+        .sql(sql)
+        .results();
+
+      int count = 0;
+      for(QueryDataBatch b : results){
+        count += b.getHeader().getRowCount();
+        b.release();
+      }
+      assertEquals(2, results.size());
+      assertEquals(4, count);
+    }
+  }
+
+  @Test
+  public void simpleJSONIndexQuery() throws Exception {
+    String sql = "SELECT * FROM `local`.`json_index` LIMIT 4";
+    try (MockWebServer server = startServer()) {
+
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE1));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
 
       List<QueryDataBatch> results = client.queryBuilder()
         .sql(sql)

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -271,12 +271,9 @@ public class TestPagination extends ClusterTest {
     try (MockWebServer server = startServer()) {
 
       server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE1));
-      //server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
 
-      RowSet results = client.queryBuilder().sql(sql).rowSet();
-      results.print();
-
-      /*List<QueryDataBatch> results = client.queryBuilder()
+      List<QueryDataBatch> results = client.queryBuilder()
         .sql(sql)
         .results();
 
@@ -286,7 +283,7 @@ public class TestPagination extends ClusterTest {
         b.release();
       }
       assertEquals(2, results.size());
-      assertEquals(4, count);*/
+      assertEquals(4, count);
     }
   }
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -271,9 +271,12 @@ public class TestPagination extends ClusterTest {
     try (MockWebServer server = startServer()) {
 
       server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE1));
-      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
+      //server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
 
-      List<QueryDataBatch> results = client.queryBuilder()
+      RowSet results = client.queryBuilder().sql(sql).rowSet();
+      results.print();
+
+      /*List<QueryDataBatch> results = client.queryBuilder()
         .sql(sql)
         .results();
 
@@ -283,7 +286,7 @@ public class TestPagination extends ClusterTest {
         b.release();
       }
       assertEquals(2, results.size());
-      assertEquals(4, count);
+      assertEquals(4, count);*/
     }
   }
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -300,6 +300,28 @@ public class TestPagination extends ClusterTest {
   }
 
   @Test
+  public void simpleJSONIndexQueryWithProjectedColumns() throws Exception {
+    String sql = "SELECT companies FROM `local`.`json_index` LIMIT 4";
+    try (MockWebServer server = startServer()) {
+
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE1));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_INDEX_PAGE2));
+
+      List<QueryDataBatch> results = client.queryBuilder()
+        .sql(sql)
+        .results();
+
+      int count = 0;
+      for(QueryDataBatch b : results){
+        count += b.getHeader().getRowCount();
+        b.release();
+      }
+      assertEquals(2, results.size());
+      assertEquals(2, count);
+    }
+  }
+
+  @Test
   public void simpleJSONIndexQueryAndDataPath() throws Exception {
     String sql = "SELECT * FROM `local`.`json_index_datapath` LIMIT 4";
     try (MockWebServer server = startServer()) {

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -283,7 +283,7 @@ public class TestPagination extends ClusterTest {
         b.release();
       }
       assertEquals(2, results.size());
-      assertEquals(4, count);
+      assertEquals(2, count);
     }
   }
 

--- a/contrib/storage-http/src/test/resources/data/index_response1.json
+++ b/contrib/storage-http/src/test/resources/data/index_response1.json
@@ -1,0 +1,96 @@
+{
+  "companies": [
+    {
+      "portalId": 62515,
+      "additionalDomains": [
+
+      ],
+      "properties": {
+        "website": {
+          "sourceId": null,
+          "timestamp": 1457513066540,
+          "versions": [
+            {
+              "timestamp": 1457513066540,
+              "sourceVid": [
+
+              ],
+              "name": "website",
+              "value": "example.com",
+              "source": "COMPANIES"
+            }
+          ],
+          "value": "example.com",
+          "source": "COMPANIES"
+        },
+        "name": {
+          "sourceId": "name",
+          "timestamp": 1464484587592,
+          "versions": [
+            {
+              "name": "name",
+              "sourceId": "name",
+              "timestamp": 1464484587592,
+              "value": "Example Company",
+              "source": "BIDEN",
+              "sourceVid": [
+
+              ]
+            }
+          ],
+          "value": "Example Company",
+          "source": "BIDEN"
+        }
+      },
+      "isDeleted": false,
+      "companyId": 115200636
+    },
+    {
+      "portalId": 62515,
+      "additionalDomains": [
+
+      ],
+      "properties": {
+        "website": {
+          "sourceId": null,
+          "timestamp": 1457535205549,
+          "versions": [
+            {
+              "timestamp": 1457535205549,
+              "sourceVid": [
+
+              ],
+              "name": "website",
+              "value": "test.com",
+              "source": "COMPANIES"
+            }
+          ],
+          "value": "test.com",
+          "source": "COMPANIES"
+        },
+        "name": {
+          "sourceId": "name",
+          "timestamp": 1468832771769,
+          "versions": [
+            {
+              "name": "name",
+              "sourceId": "name",
+              "timestamp": 1468832771769,
+              "value": "Test Company",
+              "source": "BIDEN",
+              "sourceVid": [
+
+              ]
+            }
+          ],
+          "value": "Test Company",
+          "source": "BIDEN"
+        }
+      },
+      "isDeleted": false,
+      "companyId": 115279791
+    }
+  ],
+  "has-more": true,
+  "offset": 115279791
+}

--- a/contrib/storage-http/src/test/resources/data/index_response1.json
+++ b/contrib/storage-http/src/test/resources/data/index_response1.json
@@ -92,5 +92,5 @@
     }
   ],
   "has-more": true,
-  "offset": 115279791
+  "offset": 3849945478
 }

--- a/contrib/storage-http/src/test/resources/data/index_response2.json
+++ b/contrib/storage-http/src/test/resources/data/index_response2.json
@@ -1,0 +1,96 @@
+{
+  "companies": [
+    {
+      "portalId": 62515,
+      "additionalDomains": [
+
+      ],
+      "properties": {
+        "website": {
+          "sourceId": null,
+          "timestamp": 1457513066540,
+          "versions": [
+            {
+              "timestamp": 1457513066540,
+              "sourceVid": [
+
+              ],
+              "name": "website",
+              "value": "example.com",
+              "source": "COMPANIES"
+            }
+          ],
+          "value": "example.com",
+          "source": "COMPANIES"
+        },
+        "name": {
+          "sourceId": "name",
+          "timestamp": 1464484587592,
+          "versions": [
+            {
+              "name": "name",
+              "sourceId": "name",
+              "timestamp": 1464484587592,
+              "value": "Example Company",
+              "source": "BIDEN",
+              "sourceVid": [
+
+              ]
+            }
+          ],
+          "value": "Example Company",
+          "source": "BIDEN"
+        }
+      },
+      "isDeleted": false,
+      "companyId": 115200636
+    },
+    {
+      "portalId": 62515,
+      "additionalDomains": [
+
+      ],
+      "properties": {
+        "website": {
+          "sourceId": null,
+          "timestamp": 1457535205549,
+          "versions": [
+            {
+              "timestamp": 1457535205549,
+              "sourceVid": [
+
+              ],
+              "name": "website",
+              "value": "test.com",
+              "source": "COMPANIES"
+            }
+          ],
+          "value": "test.com",
+          "source": "COMPANIES"
+        },
+        "name": {
+          "sourceId": "name",
+          "timestamp": 1468832771769,
+          "versions": [
+            {
+              "name": "name",
+              "sourceId": "name",
+              "timestamp": 1468832771769,
+              "value": "Test Company",
+              "source": "BIDEN",
+              "sourceVid": [
+
+              ]
+            }
+          ],
+          "value": "Test Company",
+          "source": "BIDEN"
+        }
+      },
+      "isDeleted": false,
+      "companyId": 115279791
+    }
+  ],
+  "has-more": false,
+  "offset": 115279791
+}

--- a/contrib/storage-http/src/test/resources/data/index_response3.json
+++ b/contrib/storage-http/src/test/resources/data/index_response3.json
@@ -1,0 +1,14 @@
+{
+  "has-more": true,
+  "offset": 115279791,
+  "companies": [
+    {
+      "portalId": 62515,
+      "companyId": 115200636
+    },
+    {
+      "portalId": 62515,
+      "companyId": 115279791
+    }
+  ]
+}

--- a/contrib/storage-http/src/test/resources/data/index_response4.json
+++ b/contrib/storage-http/src/test/resources/data/index_response4.json
@@ -1,0 +1,14 @@
+{
+  "has-more": false,
+  "offset": 115279791,
+  "companies": [
+    {
+      "portalId": 62515,
+      "companyId": 115200636
+    },
+    {
+      "portalId": 62515,
+      "companyId": 115279791
+    }
+  ]
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/RowBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/RowBatchReader.java
@@ -17,7 +17,9 @@
  */
 package org.apache.drill.exec.physical.impl.scan;
 
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.store.RecordReader;
 
 /**
  * Extended version of a record reader used by the revised
@@ -78,7 +80,7 @@ import org.apache.drill.exec.record.VectorContainer;
  * don't worry about it.
  * <p>
  * If an error occurs, the reader can throw a {@link RuntimeException}
- * from any method. A {@link UserException} is preferred to provide
+ * from any method. A {@link org.apache.drill.common.exceptions.UserException} is preferred to provide
  * detailed information about the source of the problem.
  */
 public interface RowBatchReader {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import io.netty.buffer.DrillBuf;
 import org.apache.commons.io.IOUtils;
@@ -153,6 +154,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     private MessageParser messageParser;
     private ImplicitColumns implicitFields;
     private int maxRows;
+    private Map<String, Object> paginationFields;
 
     public JsonLoaderBuilder resultSetLoader(ResultSetLoader rsLoader) {
       this.rsLoader = rsLoader;
@@ -161,6 +163,11 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
 
     public JsonLoaderBuilder providedSchema(TupleMetadata providedSchema) {
       this.providedSchema = providedSchema;
+      return this;
+    }
+
+    public JsonLoaderBuilder paginationFields(Map<String,Object> paginationFields) {
+      this.paginationFields = paginationFields;
       return this;
     }
 
@@ -248,6 +255,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
   private final ImplicitColumns implicitFields;
   private final int maxRows;
   private boolean eof;
+  private Map<String, Object> paginationFields;
 
   /**
    * List of "unknown" columns (have only seen nulls or empty values)
@@ -269,6 +277,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     this.maxRows = builder.maxRows;
     this.fieldFactory = buildFieldFactory(builder);
     this.parser = buildParser(builder);
+    this.paginationFields = builder.paginationFields;
   }
 
   private JsonStructureParser buildParser(JsonLoaderBuilder builder) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -276,8 +276,8 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     this.implicitFields = builder.implicitFields;
     this.maxRows = builder.maxRows;
     this.fieldFactory = buildFieldFactory(builder);
-    this.parser = buildParser(builder);
     this.paginationFields = builder.paginationFields;
+    this.parser = buildParser(builder);
   }
 
   private JsonStructureParser buildParser(JsonLoaderBuilder builder) {
@@ -288,6 +288,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
             .parserFactory(parser ->
                 new TupleParser(parser, JsonLoaderImpl.this, rsLoader.writer(), builder.providedSchema))
             .errorFactory(this)
+            .paginationFields(paginationFields)
             .messageParser(builder.messageParser)
             .dataPath(builder.dataPath)
             .build();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -253,9 +253,9 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
   private final JsonStructureParser parser;
   private final FieldFactory fieldFactory;
   private final ImplicitColumns implicitFields;
+  private final Map<String, Object> paginationFields;
   private final int maxRows;
   private boolean eof;
-  private Map<String, Object> paginationFields;
 
   /**
    * List of "unknown" columns (have only seen nulls or empty values)
@@ -307,6 +307,9 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
   public JsonLoaderOptions options() { return options; }
   public JsonStructureParser parser() { return parser; }
   public FieldFactory fieldFactory() { return fieldFactory; }
+  public Map<String, Object> paginationFields() {
+    return paginationFields;
+  }
 
   @Override // JsonLoader
   public boolean readBatch() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -154,7 +154,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     private MessageParser messageParser;
     private ImplicitColumns implicitFields;
     private int maxRows;
-    private Map<String, Object> paginationFields;
+    private Map<String, Object> listenerColumnMap;
 
     public JsonLoaderBuilder resultSetLoader(ResultSetLoader rsLoader) {
       this.rsLoader = rsLoader;
@@ -166,8 +166,8 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
       return this;
     }
 
-    public JsonLoaderBuilder paginationFields(Map<String,Object> paginationFields) {
-      this.paginationFields = paginationFields;
+    public JsonLoaderBuilder listenerColumnMap(Map<String,Object> listenerColumnMap) {
+      this.listenerColumnMap = listenerColumnMap;
       return this;
     }
 
@@ -253,7 +253,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
   private final JsonStructureParser parser;
   private final FieldFactory fieldFactory;
   private final ImplicitColumns implicitFields;
-  private final Map<String, Object> paginationFields;
+  private final Map<String, Object> listenerColumnMap;
   private final int maxRows;
   private boolean eof;
 
@@ -276,7 +276,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     this.implicitFields = builder.implicitFields;
     this.maxRows = builder.maxRows;
     this.fieldFactory = buildFieldFactory(builder);
-    this.paginationFields = builder.paginationFields;
+    this.listenerColumnMap = builder.listenerColumnMap;
     this.parser = buildParser(builder);
   }
 
@@ -288,7 +288,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
             .parserFactory(parser ->
                 new TupleParser(parser, JsonLoaderImpl.this, rsLoader.writer(), builder.providedSchema))
             .errorFactory(this)
-            .paginationFields(paginationFields)
+            .listenerColumnMap(listenerColumnMap)
             .messageParser(builder.messageParser)
             .dataPath(builder.dataPath)
             .build();
@@ -308,8 +308,8 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
   public JsonLoaderOptions options() { return options; }
   public JsonStructureParser parser() { return parser; }
   public FieldFactory fieldFactory() { return fieldFactory; }
-  public Map<String, Object> paginationFields() {
-    return paginationFields;
+  public Map<String, Object> listenerColumnMap() {
+    return listenerColumnMap;
   }
 
   @Override // JsonLoader

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
@@ -139,7 +139,7 @@ public class TupleParser extends ObjectParser {
     if (tupleWriter.isProjected(key)) {
       return true;
     } else {
-      return loader.paginationFields() != null && loader.paginationFields().containsKey(key);
+      return loader.listenerColumnMap() != null && loader.listenerColumnMap().containsKey(key);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
@@ -127,11 +127,6 @@ public class TupleParser extends ObjectParser {
 
   @Override
   public ElementParser onField(String key, TokenIterator tokenizer) {
-    /*if (!tupleWriter.isProjected(key)) {
-      return fieldFactory().ignoredFieldParser();
-    } else {
-      return fieldParserFor(key, tokenizer);
-    }*/
     if (projectField(key)) {
       return fieldParserFor(key, tokenizer);
     } else {
@@ -140,6 +135,7 @@ public class TupleParser extends ObjectParser {
   }
 
   private boolean projectField(String key) {
+    // This method makes sure that fields necessary for pagination are read.
     if (tupleWriter.isProjected(key)) {
       return true;
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
@@ -127,10 +127,23 @@ public class TupleParser extends ObjectParser {
 
   @Override
   public ElementParser onField(String key, TokenIterator tokenizer) {
-    if (!tupleWriter.isProjected(key)) {
+    /*if (!tupleWriter.isProjected(key)) {
       return fieldFactory().ignoredFieldParser();
     } else {
       return fieldParserFor(key, tokenizer);
+    }*/
+    if (projectField(key)) {
+      return fieldParserFor(key, tokenizer);
+    } else {
+      return fieldFactory().ignoredFieldParser();
+    }
+  }
+
+  private boolean projectField(String key) {
+    if (tupleWriter.isProjected(key)) {
+      return true;
+    } else {
+      return loader.paginationFields() != null && loader.paginationFields().containsKey(key);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/TupleParser.java
@@ -135,7 +135,7 @@ public class TupleParser extends ObjectParser {
   }
 
   private boolean projectField(String key) {
-    // This method makes sure that fields necessary for pagination are read.
+    // This method makes sure that fields necessary for column listeners are read.
     if (tupleWriter.isProjected(key)) {
       return true;
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/DummyValueParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/DummyValueParser.java
@@ -43,6 +43,20 @@ public class DummyValueParser implements ElementParser {
     }
   }
 
+  public JsonToken parseAndReturnToken(TokenIterator tokenizer) {
+    JsonToken token = tokenizer.requireNext();
+    switch (token) {
+      case START_ARRAY:
+      case START_OBJECT:
+        parseTail(tokenizer);
+        break;
+
+      default:
+        break;
+    }
+    return token;
+  }
+
   private void parseTail(TokenIterator tokenizer) {
 
     // Parse (field: value)* }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
@@ -84,7 +84,7 @@ public class JsonStructureParser {
     private ErrorFactory errorFactory;
     private String dataPath;
     private MessageParser messageParser;
-    private Map<String, Object> paginationFields;
+    private Map<String, Object> listenerColumnMap;
 
     public JsonStructureParserBuilder options(JsonStructureOptions options) {
       this.options = options;
@@ -127,8 +127,8 @@ public class JsonStructureParser {
       return this;
     }
 
-    public JsonStructureParserBuilder paginationFields(Map<String, Object> paginationFields) {
-      this.paginationFields = paginationFields;
+    public JsonStructureParserBuilder listenerColumnMap(Map<String, Object> listenerColumnMap) {
+      this.listenerColumnMap = listenerColumnMap;
       return this;
     }
 
@@ -138,7 +138,7 @@ public class JsonStructureParser {
         dataPath = dataPath.isEmpty() ? null : dataPath;
       }
       if (dataPath != null && messageParser == null) {
-        messageParser = new SimpleMessageParser(dataPath, paginationFields);
+        messageParser = new SimpleMessageParser(dataPath, listenerColumnMap);
       }
       return new JsonStructureParser(this);
     }
@@ -149,7 +149,7 @@ public class JsonStructureParser {
   private final TokenIterator tokenizer;
   private final RootParser rootState;
   private final FieldParserFactory fieldFactory;
-  private final Map<String, Object> paginationFields;
+  private final Map<String, Object> listenerColumnMap;
   private int errorRecoveryCount;
 
   /**
@@ -175,7 +175,7 @@ public class JsonStructureParser {
     fieldFactory = new FieldParserFactory(this,
         Preconditions.checkNotNull(builder.parserFactory));
 
-    this.paginationFields = builder.paginationFields;
+    this.listenerColumnMap = builder.listenerColumnMap;
 
     // Parse to the start of the data object(s), and create a root
     // state to parse objects and watch for the end of data.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.commons.collections4.IterableUtils;
@@ -83,6 +84,7 @@ public class JsonStructureParser {
     private ErrorFactory errorFactory;
     private String dataPath;
     private MessageParser messageParser;
+    private Map<String, Object> paginationFields;
 
     public JsonStructureParserBuilder options(JsonStructureOptions options) {
       this.options = options;
@@ -125,13 +127,18 @@ public class JsonStructureParser {
       return this;
     }
 
+    public JsonStructureParserBuilder paginationFields(Map<String, Object> paginationFields) {
+      this.paginationFields = paginationFields;
+      return this;
+    }
+
     public JsonStructureParser build() {
       if (dataPath != null) {
         dataPath = dataPath.trim();
         dataPath = dataPath.isEmpty() ? null : dataPath;
       }
       if (dataPath != null && messageParser == null) {
-        messageParser = new SimpleMessageParser(dataPath);
+        messageParser = new SimpleMessageParser(dataPath, paginationFields);
       }
       return new JsonStructureParser(this);
     }
@@ -142,6 +149,7 @@ public class JsonStructureParser {
   private final TokenIterator tokenizer;
   private final RootParser rootState;
   private final FieldParserFactory fieldFactory;
+  private final Map<String, Object> paginationFields;
   private int errorRecoveryCount;
 
   /**
@@ -166,6 +174,8 @@ public class JsonStructureParser {
     tokenizer = new TokenIterator(builder.streams, parserFunction, options, errorFactory());
     fieldFactory = new FieldParserFactory(this,
         Preconditions.checkNotNull(builder.parserFactory));
+
+    this.paginationFields = builder.paginationFields;
 
     // Parse to the start of the data object(s), and create a root
     // state to parse objects and watch for the end of data.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/SimpleMessageParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/SimpleMessageParser.java
@@ -143,7 +143,7 @@ public class SimpleMessageParser implements MessageParser {
    * without creating a ValueVector for them.
    *
    * @param tokenizer A {@link TokenIterator} of the parsed JSON data.
-   * @param fieldName A {@link String} of the pagination field name.
+   * @param fieldName A {@link String} of the column listener field name.
    */
   private void skipElementButRetainValue(TokenIterator tokenizer, String fieldName) {
     JsonToken token = ((DummyValueParser) DummyValueParser.INSTANCE).parseAndReturnToken(tokenizer);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BigIntListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BigIntListener.java
@@ -62,7 +62,7 @@ public class BigIntListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), value);
+    addValueToListenerMap(writer.schema().name(), value);
     writer.setLong(value);
   }
 
@@ -72,7 +72,7 @@ public class BigIntListener extends ScalarListener {
       setNull();
     } else {
       try {
-        addValueToPagination(writer.schema().name(), value);
+        addValueToListenerMap(writer.schema().name(), value);
         writer.setLong(Long.parseLong(value));
       } catch (NumberFormatException e) {
         throw loader.dataConversionError(schema(), "string", value);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BigIntListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BigIntListener.java
@@ -62,6 +62,7 @@ public class BigIntListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
+    addValueToPagination(writer.schema().name(), value);
     writer.setLong(value);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BigIntListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BigIntListener.java
@@ -72,6 +72,7 @@ public class BigIntListener extends ScalarListener {
       setNull();
     } else {
       try {
+        addValueToPagination(writer.schema().name(), value);
         writer.setLong(Long.parseLong(value));
       } catch (NumberFormatException e) {
         throw loader.dataConversionError(schema(), "string", value);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BooleanListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BooleanListener.java
@@ -70,6 +70,7 @@ public class BooleanListener extends ScalarListener {
     if (value.isEmpty()) {
       setNull();
     } else {
+      addValueToPagination(writer.schema().name(), value);
       writer.setBoolean(Boolean.parseBoolean(value.trim()));
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BooleanListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BooleanListener.java
@@ -61,6 +61,7 @@ public class BooleanListener extends ScalarListener {
         // errors.
         throw tokenizer.invalidValue(token);
     }
+    addValueToPagination(writer.schema().name(), value);
     writer.setBoolean(value);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BooleanListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/BooleanListener.java
@@ -61,7 +61,7 @@ public class BooleanListener extends ScalarListener {
         // errors.
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), value);
+    addValueToListenerMap(writer.schema().name(), value);
     writer.setBoolean(value);
   }
 
@@ -70,7 +70,7 @@ public class BooleanListener extends ScalarListener {
     if (value.isEmpty()) {
       setNull();
     } else {
-      addValueToPagination(writer.schema().name(), value);
+      addValueToListenerMap(writer.schema().name(), value);
       writer.setBoolean(Boolean.parseBoolean(value.trim()));
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DateValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DateValueListener.java
@@ -46,6 +46,7 @@ public class DateValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
+        addValueToPagination(writer.schema().name(), tokenizer.longValue());
         writer.setLong(tokenizer.longValue());
         break;
       case VALUE_STRING:
@@ -63,6 +64,7 @@ public class DateValueListener extends ScalarListener {
           LocalDate localDate = LocalDate.parse(tokenizer.stringValue(), dateTimeFormatter);
           writer.setLong(Duration.between(TimestampValueListener.LOCAL_EPOCH,
               localDate.atStartOfDay()).toMillis());
+          addValueToPagination(writer.schema().name(), Duration.between(TimestampValueListener.LOCAL_EPOCH, localDate.atStartOfDay()).toMillis());
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DateValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DateValueListener.java
@@ -46,7 +46,7 @@ public class DateValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
-        addValueToPagination(writer.schema().name(), tokenizer.longValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.longValue());
         writer.setLong(tokenizer.longValue());
         break;
       case VALUE_STRING:
@@ -64,7 +64,7 @@ public class DateValueListener extends ScalarListener {
           LocalDate localDate = LocalDate.parse(tokenizer.stringValue(), dateTimeFormatter);
           writer.setLong(Duration.between(TimestampValueListener.LOCAL_EPOCH,
               localDate.atStartOfDay()).toMillis());
-          addValueToPagination(writer.schema().name(), Duration.between(TimestampValueListener.LOCAL_EPOCH, localDate.atStartOfDay()).toMillis());
+          addValueToListenerMap(writer.schema().name(), Duration.between(TimestampValueListener.LOCAL_EPOCH, localDate.atStartOfDay()).toMillis());
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DecimalValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DecimalValueListener.java
@@ -41,7 +41,7 @@ public class DecimalValueListener extends ScalarListener {
       case VALUE_NUMBER_FLOAT:
       case VALUE_STRING:
         try {
-          addValueToPagination(writer.schema().name(), new BigDecimal(tokenizer.textValue()));
+          addValueToListenerMap(writer.schema().name(), new BigDecimal(tokenizer.textValue()));
           writer.setDecimal(new BigDecimal(tokenizer.textValue()));
         } catch (NumberFormatException e) {
           throw loader.dataConversionError(schema(), "DECIMAL", tokenizer.textValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DecimalValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DecimalValueListener.java
@@ -41,6 +41,7 @@ public class DecimalValueListener extends ScalarListener {
       case VALUE_NUMBER_FLOAT:
       case VALUE_STRING:
         try {
+          addValueToPagination(writer.schema().name(), new BigDecimal(tokenizer.textValue()));
           writer.setDecimal(new BigDecimal(tokenizer.textValue()));
         } catch (NumberFormatException e) {
           throw loader.dataConversionError(schema(), "DECIMAL", tokenizer.textValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DoubleListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DoubleListener.java
@@ -61,6 +61,7 @@ public class DoubleListener extends ScalarListener {
         // errors.
         throw tokenizer.invalidValue(token);
     }
+    addValueToPagination(writer.schema().name(), value);
     writer.setDouble(value);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DoubleListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DoubleListener.java
@@ -61,7 +61,7 @@ public class DoubleListener extends ScalarListener {
         // errors.
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), value);
+    addValueToPagination(writer.schema().name(), tokenizer.textValue());
     writer.setDouble(value);
   }
 
@@ -71,6 +71,7 @@ public class DoubleListener extends ScalarListener {
       setNull();
     } else {
       try {
+        addValueToPagination(writer.schema().name(), value);
         writer.setDouble(Double.parseDouble(value));
       } catch (NumberFormatException e) {
         throw loader.dataConversionError(schema(), "string", value);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DoubleListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/DoubleListener.java
@@ -61,7 +61,7 @@ public class DoubleListener extends ScalarListener {
         // errors.
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), tokenizer.textValue());
+    addValueToListenerMap(writer.schema().name(), tokenizer.textValue());
     writer.setDouble(value);
   }
 
@@ -71,7 +71,7 @@ public class DoubleListener extends ScalarListener {
       setNull();
     } else {
       try {
-        addValueToPagination(writer.schema().name(), value);
+        addValueToListenerMap(writer.schema().name(), value);
         writer.setDouble(Double.parseDouble(value));
       } catch (NumberFormatException e) {
         throw loader.dataConversionError(schema(), "string", value);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/IntervalValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/IntervalValueListener.java
@@ -45,6 +45,7 @@ public class IntervalValueListener extends ScalarListener {
         break;
       case VALUE_STRING:
         try {
+          addValueToPagination(writer.schema().name(), FORMATTER.parsePeriod(tokenizer.stringValue()));
           writer.setPeriod(FORMATTER.parsePeriod(tokenizer.stringValue()));
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/IntervalValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/IntervalValueListener.java
@@ -45,7 +45,7 @@ public class IntervalValueListener extends ScalarListener {
         break;
       case VALUE_STRING:
         try {
-          addValueToPagination(writer.schema().name(), FORMATTER.parsePeriod(tokenizer.stringValue()));
+          addValueToListenerMap(writer.schema().name(), FORMATTER.parsePeriod(tokenizer.stringValue()));
           writer.setPeriod(FORMATTER.parsePeriod(tokenizer.stringValue()));
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
@@ -83,7 +83,7 @@ public abstract class ScalarListener implements ValueListener {
   /**
    * Adds a field's most recent value to the column listener map.
    * This data is only stored if the listener column map is defined, and has keys.
-   * @param key The key of the pagination field
+   * @param key The key of the listener field
    * @param value The value of to be retained
    */
   protected void addValueToListenerMap(String key, String value) {
@@ -97,12 +97,12 @@ public abstract class ScalarListener implements ValueListener {
   }
 
   protected void addValueToListenerMap(String key, Object value) {
-    Map<String, Object> paginationMap = loader.listenerColumnMap();
+    Map<String, Object> listenerColumnMap = loader.listenerColumnMap();
 
-    if (paginationMap == null || paginationMap.isEmpty()) {
+    if (listenerColumnMap == null || listenerColumnMap.isEmpty()) {
       return;
-    } else if (paginationMap.containsKey(key) && value != null) {
-      paginationMap.put(key, value);
+    } else if (listenerColumnMap.containsKey(key) && value != null) {
+      listenerColumnMap.put(key, value);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
@@ -81,11 +81,8 @@ public abstract class ScalarListener implements ValueListener {
   }
 
   /**
-   * Adds a field's most recent value to the pagination map.  This is necessary for the HTTP plugin
-   * for index or keyset pagination where the API transmits values in the results that are used to
-   * generate the next page.
-   *
-   * This data is only stored if the pagination map is defined, and has keys.
+   * Adds a field's most recent value to the column listener map.
+   * This data is only stored if the listener column map is defined, and has keys.
    * @param key The key of the pagination field
    * @param value The value of to be retained
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.easy.json.values;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
@@ -26,6 +27,8 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
 
 import com.fasterxml.jackson.core.JsonToken;
+
+import java.util.Map;
 
 /**
  * Base class for scalar field listeners
@@ -75,5 +78,34 @@ public abstract class ScalarListener implements ValueListener {
 
   protected UserException typeConversionError(String jsonType) {
     return loader.typeConversionError(schema(), jsonType);
+  }
+
+  /**
+   * Adds a field's most recent value to the pagination map.  This is necessary for the HTTP plugin
+   * for index or keyset pagination where the API transmits values in the results that are used to
+   * generate the next page.
+   *
+   * This data is only stored if the pagination map is defined, and has keys.
+   * @param key The key of the pagination field
+   * @param value The value of to be retained
+   */
+  protected void addValueToPagination(String key, String value) {
+    Map<String,Object> paginationMap = loader.paginationFields();
+
+    if (paginationMap == null || paginationMap.isEmpty()) {
+      return;
+    } else if (paginationMap.containsKey(key) && StringUtils.isNotEmpty(value)) {
+      paginationMap.put(key, value);
+    }
+  }
+
+  protected void addValueToPagination(String key, Object value) {
+    Map<String, Object> paginationMap = loader.paginationFields();
+
+    if (paginationMap == null || paginationMap.isEmpty()) {
+      return;
+    } else if (paginationMap.containsKey(key) && value != null) {
+      paginationMap.put(key, value);
+    }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/ScalarListener.java
@@ -89,18 +89,18 @@ public abstract class ScalarListener implements ValueListener {
    * @param key The key of the pagination field
    * @param value The value of to be retained
    */
-  protected void addValueToPagination(String key, String value) {
-    Map<String,Object> paginationMap = loader.paginationFields();
+  protected void addValueToListenerMap(String key, String value) {
+    Map<String,Object> listenerColumnMap = loader.listenerColumnMap();
 
-    if (paginationMap == null || paginationMap.isEmpty()) {
+    if (listenerColumnMap == null || listenerColumnMap.isEmpty()) {
       return;
-    } else if (paginationMap.containsKey(key) && StringUtils.isNotEmpty(value)) {
-      paginationMap.put(key, value);
+    } else if (listenerColumnMap.containsKey(key) && StringUtils.isNotEmpty(value)) {
+      listenerColumnMap.put(key, value);
     }
   }
 
-  protected void addValueToPagination(String key, Object value) {
-    Map<String, Object> paginationMap = loader.paginationFields();
+  protected void addValueToListenerMap(String key, Object value) {
+    Map<String, Object> paginationMap = loader.listenerColumnMap();
 
     if (paginationMap == null || paginationMap.isEmpty()) {
       return;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictBigIntValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictBigIntValueListener.java
@@ -41,12 +41,12 @@ public class StrictBigIntValueListener extends ScalarListener {
         break;
       case VALUE_NUMBER_INT:
         writer.setLong(tokenizer.longValue());
-        addValueToPagination(writer.schema().name(), tokenizer.longValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           writer.setLong(Long.parseLong(tokenizer.stringValue()));
-          addValueToPagination(writer.schema().name(), Long.parseLong(tokenizer.stringValue()));
+          addValueToListenerMap(writer.schema().name(), Long.parseLong(tokenizer.stringValue()));
         } catch (NumberFormatException e) {
           throw loader.dataConversionError(schema(), "string", tokenizer.stringValue());
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictBigIntValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictBigIntValueListener.java
@@ -41,10 +41,12 @@ public class StrictBigIntValueListener extends ScalarListener {
         break;
       case VALUE_NUMBER_INT:
         writer.setLong(tokenizer.longValue());
+        addValueToPagination(writer.schema().name(), tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           writer.setLong(Long.parseLong(tokenizer.stringValue()));
+          addValueToPagination(writer.schema().name(), Long.parseLong(tokenizer.stringValue()));
         } catch (NumberFormatException e) {
           throw loader.dataConversionError(schema(), "string", tokenizer.stringValue());
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictDoubleValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictDoubleValueListener.java
@@ -52,7 +52,7 @@ public class StrictDoubleValueListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), value);
+    addValueToListenerMap(writer.schema().name(), value);
     writer.setDouble(value);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictDoubleValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictDoubleValueListener.java
@@ -52,6 +52,7 @@ public class StrictDoubleValueListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
+    addValueToPagination(writer.schema().name(), value);
     writer.setDouble(value);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictIntValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictIntValueListener.java
@@ -40,13 +40,13 @@ public class StrictIntValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
-        addValueToPagination(writer.schema().name(), tokenizer.longValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.longValue());
         writer.setInt((int) tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           writer.setInt(Integer.parseInt(tokenizer.stringValue()));
-          addValueToPagination(writer.schema().name(), Integer.parseInt(tokenizer.stringValue()));
+          addValueToListenerMap(writer.schema().name(), Integer.parseInt(tokenizer.stringValue()));
         } catch (NumberFormatException e) {
           throw loader.dataConversionError(schema(), "string", tokenizer.stringValue());
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictIntValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictIntValueListener.java
@@ -40,11 +40,13 @@ public class StrictIntValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
+        addValueToPagination(writer.schema().name(), tokenizer.longValue());
         writer.setInt((int) tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           writer.setInt(Integer.parseInt(tokenizer.stringValue()));
+          addValueToPagination(writer.schema().name(), Integer.parseInt(tokenizer.stringValue()));
         } catch (NumberFormatException e) {
           throw loader.dataConversionError(schema(), "string", tokenizer.stringValue());
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictStringValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictStringValueListener.java
@@ -36,7 +36,7 @@ public class StrictStringValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_STRING:
-        addValueToPagination(writer.schema().name(), tokenizer.stringValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.stringValue());
         writer.setString(tokenizer.stringValue());
         break;
       default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictStringValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/StrictStringValueListener.java
@@ -36,6 +36,7 @@ public class StrictStringValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_STRING:
+        addValueToPagination(writer.schema().name(), tokenizer.stringValue());
         writer.setString(tokenizer.stringValue());
         break;
       default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimeValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimeValueListener.java
@@ -48,11 +48,13 @@ public class TimeValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
+        addValueToPagination(writer.schema().name(), tokenizer.longValue());
         writer.setInt((int) tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           LocalTime localTime = LocalTime.parse(tokenizer.stringValue(), TIME_FORMAT);
+          addValueToPagination(writer.schema().name(), localTime);
           writer.setTime(localTime);
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "string", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimeValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimeValueListener.java
@@ -48,13 +48,13 @@ public class TimeValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
-        addValueToPagination(writer.schema().name(), tokenizer.longValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.longValue());
         writer.setInt((int) tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           LocalTime localTime = LocalTime.parse(tokenizer.stringValue(), TIME_FORMAT);
-          addValueToPagination(writer.schema().name(), localTime);
+          addValueToListenerMap(writer.schema().name(), localTime);
           writer.setTime(localTime);
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "string", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimestampValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimestampValueListener.java
@@ -46,13 +46,13 @@ public class TimestampValueListener extends ScalarListener {
         setNull();
         return;
       case VALUE_NUMBER_INT:
-        addValueToPagination(writer.schema().name(), tokenizer.longValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.longValue());
         writer.setLong(tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           LocalDateTime localDT = LocalDateTime.parse(tokenizer.stringValue());
-          addValueToPagination(writer.schema().name(), Duration.between(LOCAL_EPOCH, localDT).toMillis());
+          addValueToListenerMap(writer.schema().name(), Duration.between(LOCAL_EPOCH, localDT).toMillis());
           writer.setLong(Duration.between(LOCAL_EPOCH, localDT).toMillis());
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimestampValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/TimestampValueListener.java
@@ -46,11 +46,13 @@ public class TimestampValueListener extends ScalarListener {
         setNull();
         return;
       case VALUE_NUMBER_INT:
+        addValueToPagination(writer.schema().name(), tokenizer.longValue());
         writer.setLong(tokenizer.longValue());
         break;
       case VALUE_STRING:
         try {
           LocalDateTime localDT = LocalDateTime.parse(tokenizer.stringValue());
+          addValueToPagination(writer.schema().name(), Duration.between(LOCAL_EPOCH, localDT).toMillis());
           writer.setLong(Duration.between(LOCAL_EPOCH, localDT).toMillis());
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcDateValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcDateValueListener.java
@@ -48,6 +48,7 @@ public class UtcDateValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
+        addValueToPagination(writer.schema().name(), tokenizer.longValue());
         writer.setLong(tokenizer.longValue());
         break;
       case VALUE_STRING:
@@ -61,6 +62,7 @@ public class UtcDateValueListener extends ScalarListener {
           // is different locally than UTC. A mess.
           LocalDate localDate = LocalDate.parse(tokenizer.stringValue(), DateUtility.isoFormatDate);
           ZonedDateTime utc = localDate.atStartOfDay(ZoneOffset.UTC);
+          addValueToPagination(writer.schema().name(), utc.toEpochSecond() * 1000);
           writer.setLong(utc.toEpochSecond() * 1000);
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcDateValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcDateValueListener.java
@@ -48,7 +48,7 @@ public class UtcDateValueListener extends ScalarListener {
         setNull();
         break;
       case VALUE_NUMBER_INT:
-        addValueToPagination(writer.schema().name(), tokenizer.longValue());
+        addValueToListenerMap(writer.schema().name(), tokenizer.longValue());
         writer.setLong(tokenizer.longValue());
         break;
       case VALUE_STRING:
@@ -62,7 +62,7 @@ public class UtcDateValueListener extends ScalarListener {
           // is different locally than UTC. A mess.
           LocalDate localDate = LocalDate.parse(tokenizer.stringValue(), DateUtility.isoFormatDate);
           ZonedDateTime utc = localDate.atStartOfDay(ZoneOffset.UTC);
-          addValueToPagination(writer.schema().name(), utc.toEpochSecond() * 1000);
+          addValueToListenerMap(writer.schema().name(), utc.toEpochSecond() * 1000);
           writer.setLong(utc.toEpochSecond() * 1000);
         } catch (Exception e) {
           throw loader.dataConversionError(schema(), "date", tokenizer.stringValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcTimestampValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcTimestampValueListener.java
@@ -69,6 +69,7 @@ public class UtcTimestampValueListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
+    addValueToPagination(writer.schema().name(), instant.toEpochMilli() + LOCAL_ZONE_ID.getRules().getOffset(instant).getTotalSeconds() * 1000L);
     writer.setLong(instant.toEpochMilli() + LOCAL_ZONE_ID.getRules().getOffset(instant).getTotalSeconds() * 1000L);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcTimestampValueListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/UtcTimestampValueListener.java
@@ -69,7 +69,7 @@ public class UtcTimestampValueListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), instant.toEpochMilli() + LOCAL_ZONE_ID.getRules().getOffset(instant).getTotalSeconds() * 1000L);
+    addValueToListenerMap(writer.schema().name(), instant.toEpochMilli() + LOCAL_ZONE_ID.getRules().getOffset(instant).getTotalSeconds() * 1000L);
     writer.setLong(instant.toEpochMilli() + LOCAL_ZONE_ID.getRules().getOffset(instant).getTotalSeconds() * 1000L);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/VarCharListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/VarCharListener.java
@@ -63,7 +63,7 @@ public class VarCharListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
-    addValueToPagination(writer.schema().name(), value);
+    addValueToListenerMap(writer.schema().name(), value);
     writer.setString(value);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/VarCharListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/values/VarCharListener.java
@@ -63,6 +63,7 @@ public class VarCharListener extends ScalarListener {
       default:
         throw tokenizer.invalidValue(token);
     }
+    addValueToPagination(writer.schema().name(), value);
     writer.setString(value);
   }
 


### PR DESCRIPTION
# [DRILL-8287](https://issues.apache.org/jira/browse/DRILL-8287): Add Support for Keyset Based Pagination

## Description
Some APIs such as HubSpot use values in the result set to indicate whether there are additional pages.  This PR adds support for this kind of pagination.  Note that current implementation only works for JSON based APIs.

This PR also addresses [DRILL-8286](https://issues.apache.org/jira/browse/DRILL-8286), which is a minor bugfix for the GoogleSheets config. 

## Documentation
Updated Pagination.md.

## Testing
Added unit tests and manually tested against Hubspot API.