### PR TITLE
DRILL-8295: Probable resource leak in the HTTP storage plugin

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -127,6 +127,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
       buildImplicitColumns();
     }
 
+    // Should be closed by the JsonLoader.
     InputStream inStream = http.getInputStream();
     populateImplicitFieldMap(http);
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -127,7 +127,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
       buildImplicitColumns();
     }
 
-    // Should be closed by the JsonLoader.
+    // inStream is expected to be closed by the JsonLoader.
     InputStream inStream = http.getInputStream();
     populateImplicitFieldMap(http);
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
@@ -143,7 +143,7 @@ public class HttpXMLBatchReader extends HttpBatchReader {
 
   @Override
   public void close() {
-    AutoCloseables.closeSilently(inStream);
     AutoCloseables.closeSilently(xmlReader);
+    AutoCloseables.closeSilently(inStream);
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -78,7 +78,7 @@ public class HttpHelperFunctions {
         return;
       }
       String finalUrl = org.apache.drill.exec.store.http.util.SimpleHttp.mapPositionalParameters(url, args);
-      // Make the API call
+      // Make the API call, we expect that results will be closed by the JsonLoader
       java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.getRequestAndStreamResponse(finalUrl);
       // If the result string is null or empty, return an empty map
       if (results == null) {
@@ -175,6 +175,7 @@ public class HttpHelperFunctions {
       if (args == null) {
         return;
       }
+      // we expect that results will be closed by the JsonLoader
       java.io.InputStream results = org.apache.drill.exec.store.http.util.SimpleHttp.apiCall(plugin, endpointConfig, drillbitContext, args)
         .getInputStream();
       // If the result string is null or empty, return an empty map

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -93,6 +93,8 @@ public class HttpHelperFunctions {
         rowWriter.start();
         if (jsonLoader.parser().next()) {
           rowWriter.save();
+        } else {
+          jsonLoader.close();
         }
       } catch (Exception e) {
         throw org.apache.drill.common.exceptions.UserException.dataReadError(e)
@@ -189,6 +191,8 @@ public class HttpHelperFunctions {
         rowWriter.start();
         if (jsonLoader.parser().next()) {
           rowWriter.save();
+        } else {
+          jsonLoader.close();
         }
       } catch (Exception e) {
         throw org.apache.drill.common.exceptions.UserException.dataReadError(e)

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.logical.OAuthConfig;
 import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
+import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
@@ -321,7 +322,8 @@ public class SimpleHttp {
   /**
    * Returns an InputStream based on the URL and config in the scanSpec. If anything goes wrong
    * the method throws a UserException.
-   * @return An Inputstream of the data from the URL call.
+   * @return An Inputstream of the data from the URL call. The caller is responsible for calling
+   *         close() on the InputStream.
    */
   public InputStream getInputStream() {
 
@@ -369,13 +371,14 @@ public class SimpleHttp {
 
     // Build the request object
     Request request = requestBuilder.build();
+    Response response = null;
 
     try {
       logger.debug("Executing request: {}", request);
       logger.debug("Headers: {}", request.headers());
 
       // Execute the request
-      Response response = client
+      response = client
         .newCall(request)
         .execute();
 
@@ -392,22 +395,28 @@ public class SimpleHttp {
         paginator.notifyPartialPage();
       }
 
-      // If the request is unsuccessful, throw a UserException
+      // If the request is unsuccessful clean up and throw a UserException
       if (!isSuccessful(responseCode)) {
-        throw UserException
-          .dataReadError()
-          .message("HTTP request failed")
-          .addContext("Response code", response.code())
-          .addContext("Response message", response.message())
-          .addContext(errorContext)
-          .build(logger);
+        try {
+          AutoCloseables.closeSilently(response);
+        } finally {
+          throw UserException
+            .dataReadError()
+            .message("HTTP request failed")
+            .addContext("Response code", response.code())
+            .addContext("Response message", response.message())
+            .addContext(errorContext)
+            .build(logger);
+        }
       }
       logger.debug("HTTP Request for {} successful.", url());
       logger.debug("Response Headers: {} ", response.headers());
 
-      // Return the InputStream of the response
+      // Return the InputStream of the response. Note that it is necessary and
+      // and sufficient that the caller invokes close() on the returned stream.
       return Objects.requireNonNull(response.body()).byteStream();
     } catch (IOException e) {
+      // response can only be null at this location so we do not attempt to close it.
       throw UserException
         .dataReadError(e)
         .message("Failed to read the HTTP response body")

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -428,10 +428,14 @@ public class SimpleHttp {
 
   public String getResultsFromApiCall() {
     InputStream inputStream = getInputStream();
-    return new BufferedReader(
-      new InputStreamReader(inputStream, StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining("\n"));
+    try {
+      return new BufferedReader(
+        new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+        .lines()
+        .collect(Collectors.joining("\n"));
+    } finally {
+      AutoCloseables.closeSilently(inputStream);
+    }
   }
 
   public static HttpProxyConfig getProxySettings(HttpStoragePluginConfig config, Config drillConfig, HttpUrl url) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -371,44 +371,46 @@ public class SimpleHttp {
 
     // Build the request object
     Request request = requestBuilder.build();
+    Response response = null;
 
     try {
       logger.debug("Executing request: {}", request);
       logger.debug("Headers: {}", request.headers());
 
       // Execute the request
-      try (Response response = client.newCall(request).execute()) {
+      response = client.newCall(request).execute();
 
-        // Preserve the response
-        responseMessage = response.message();
-        responseCode = response.code();
-        responseProtocol = response.protocol().toString();
-        responseURL = response.request().url().toString();
+      // Preserve the response
+      responseMessage = response.message();
+      responseCode = response.code();
+      responseProtocol = response.protocol().toString();
+      responseURL = response.request().url().toString();
 
-        // Case for pagination without limit
-        if (paginator != null && (
-          response.code() != 200 || response.body() == null ||
-          response.body().contentLength() == 0)) {
-          paginator.notifyPartialPage();
-        }
-
-        // If the request is unsuccessful clean up and throw a UserException
-        if (!isSuccessful(responseCode)) {
-          throw UserException
-            .dataReadError()
-            .message("HTTP request failed")
-            .addContext("Response code", response.code())
-            .addContext("Response message", response.message())
-            .addContext(errorContext)
-            .build(logger);
-        }
-        logger.debug("HTTP Request for {} successful.", url());
-        logger.debug("Response Headers: {} ", response.headers());
-
-        // Return the InputStream of the response. Note that it is necessary and
-        // and sufficient that the caller invokes close() on the returned stream.
-        return Objects.requireNonNull(response.body()).byteStream();
+      // Case for pagination without limit
+      if (paginator != null && (
+        response.code() != 200 || response.body() == null ||
+        response.body().contentLength() == 0)) {
+        paginator.notifyPartialPage();
       }
+
+      // If the request is unsuccessful clean up and throw a UserException
+      if (!isSuccessful(responseCode)) {
+        AutoCloseables.closeSilently(response);
+        throw UserException
+          .dataReadError()
+          .message("HTTP request failed")
+          .addContext("Response code", response.code())
+          .addContext("Response message", response.message())
+          .addContext(errorContext)
+          .build(logger);
+      }
+      logger.debug("HTTP Request for {} successful.", url());
+      logger.debug("Response Headers: {} ", response.headers());
+
+      // Return the InputStream of the response. Note that it is necessary and
+      // and sufficient that the caller invokes close() on the returned stream.
+      return Objects.requireNonNull(response.body()).byteStream();
+
     } catch (IOException e) {
       // response can only be null at this location so we do not attempt to close it.
       throw UserException

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -922,16 +922,25 @@ public class SimpleHttp {
   }
 
   public static String getRequestAndStringResponse(String url) {
+    ResponseBody respBody = null;
     try {
-      return makeSimpleGetRequest(url).string();
+      respBody = makeSimpleGetRequest(url);
+      return respBody.string();
     } catch (IOException e) {
       throw UserException
         .dataReadError(e)
         .message("HTTP request failed")
         .build(logger);
+    } finally {
+      AutoCloseables.closeSilently(respBody);
     }
   }
 
+  /**
+   *
+   * @param url
+   * @return an input stream which the caller is responsible for closing.
+   */
   public static InputStream getRequestAndStreamResponse(String url) {
     try {
       return makeSimpleGetRequest(url).byteStream();
@@ -943,6 +952,12 @@ public class SimpleHttp {
     }
   }
 
+  /**
+   *
+   * @param url
+   * @return response body which the caller is responsible for closing.
+   * @throws IOException
+   */
   public static ResponseBody makeSimpleGetRequest(String url) throws IOException {
     OkHttpClient client = getSimpleHttpClient();
     Request.Builder requestBuilder = new Request.Builder()
@@ -952,9 +967,8 @@ public class SimpleHttp {
     Request request = requestBuilder.build();
 
     // Execute the request
-    try (Response response = client.newCall(request).execute()) {
-      return response.body();
-    }
+    Response response = client.newCall(request).execute();
+    return response.body();
   }
 
   /**


### PR DESCRIPTION
# [DRILL-8295](https://issues.apache.org/jira/browse/DRILL-8295): Probable resource leak in the HTTP storage plugin

## Description

Adds close() calls in a number of places where HTTP requests are made in the HTTP storage plugin.

## Documentation
N/A

## Testing
Existing unit tests.
