### PR TITLE
DRILL-8302: Tidy up some char conversions

### DIFF
--- a/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java
+++ b/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -193,7 +193,7 @@ public class ShpBatchReader implements ManagedReader<FileSchemaNegotiator> {
       switch (field.getDataType()) {
         case CHAR:
           byte[] strType = (byte[]) dbfRow[i];
-          String stringValue = new String( strType, Charset.forName("utf-8")).trim();
+          String stringValue = new String( strType, StandardCharsets.UTF_8).trim();
           writeStringColumn(rowWriter, field.getName(), stringValue);
           break;
         case FLOAT:

--- a/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergWork.java
+++ b/contrib/format-iceberg/src/main/java/org/apache/drill/exec/store/iceberg/IcebergWork.java
@@ -123,7 +123,7 @@ public class IcebergWork {
       try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
         objectOutputStream.writeObject(scanTask);
-        gen.writeStringField(SCAN_TASK_FIELD, new String(Base64.getEncoder().encode(byteArrayOutputStream.toByteArray())));
+        gen.writeStringField(SCAN_TASK_FIELD, Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray()));
       }
       gen.writeEndObject();
     }

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java
@@ -47,7 +47,6 @@ import org.apache.drill.exec.store.mapr.db.json.JsonTableGroupScan;
 import org.apache.hadoop.hbase.HConstants;
 import org.ojai.store.QueryCondition;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -846,22 +845,17 @@ public class MapRDBStatistics implements Statistics {
           if (isMaxVal) {
             stopKey = HConstants.EMPTY_END_ROW;
           }
-          try {
-            // TODO: This maybe a potential bug since we assume UTF-8 encoding. However, we follow the
-            // current DB implementation. See HBaseFilterBuilder.createHBaseScanSpec "like" CASE statement
-            RexLiteral startKeyLiteral = builder.makeLiteral(new String(startKey,
-                Charsets.UTF_8.toString()));
-            RexLiteral stopKeyLiteral = builder.makeLiteral(new String(stopKey,
-                Charsets.UTF_8.toString()));
-            if (arg != null) {
-              RexNode startPred = builder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-                  arg, startKeyLiteral);
-              RexNode stopPred = builder.makeCall(SqlStdOperatorTable.LESS_THAN, arg, stopKeyLiteral);
-              return builder.makeCall(SqlStdOperatorTable.AND, startPred, stopPred);
-            }
-          } catch (UnsupportedEncodingException ex) {
-            // Encoding not supported - Do nothing!
-            logger.debug("Statistics: convertLikeToRange: Unsupported Encoding Exception -> {}", ex.getMessage());
+          // TODO: This maybe a potential bug since we assume UTF-8 encoding. However, we follow the
+          // current DB implementation. See HBaseFilterBuilder.createHBaseScanSpec "like" CASE statement
+          RexLiteral startKeyLiteral = builder.makeLiteral(new String(startKey,
+              Charsets.UTF_8));
+          RexLiteral stopKeyLiteral = builder.makeLiteral(new String(stopKey,
+              Charsets.UTF_8));
+          if (arg != null) {
+            RexNode startPred = builder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                arg, startKeyLiteral);
+            RexNode stopPred = builder.makeCall(SqlStdOperatorTable.LESS_THAN, arg, stopKeyLiteral);
+            return builder.makeCall(SqlStdOperatorTable.AND, startPred, stopPred);
           }
         }
       }

--- a/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/index/TableIndexCmd.java
+++ b/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/index/TableIndexCmd.java
@@ -80,9 +80,9 @@ public class TableIndexCmd {
   public static void main(String[] args) {
     GuavaPatcher.patch();
 
-    String inHost = new String("localhost");
-    String inPort = new String("5181");
-    String inTable = new String("/tmp/population");
+    String inHost = "localhost";
+    String inPort = "5181";
+    String inTable = "/tmp/population";
     String dictPath = "hbase";
     boolean waitKeyPress = true;
     long inSize = 10000;

--- a/contrib/storage-druid/src/test/java/org/apache/drill/exec/store/druid/rest/DruidQueryClientTest.java
+++ b/contrib/storage-druid/src/test/java/org/apache/drill/exec/store/druid/rest/DruidQueryClientTest.java
@@ -87,7 +87,7 @@ public class DruidQueryClientTest {
   public void executeQueryCalledNoResponsesFoundReturnsEmptyEventList()
       throws Exception {
     InputStream inputStream =
-        new ByteArrayInputStream("[]".getBytes(StandardCharsets.UTF_8.name()));
+        new ByteArrayInputStream("[]".getBytes(StandardCharsets.UTF_8));
     when(httpEntity.getContent()).thenReturn(inputStream);
 
     DruidScanResponse response = druidQueryClient.executeQuery(QUERY);
@@ -99,7 +99,7 @@ public class DruidQueryClientTest {
       throws Exception {
     String result = "[{\"segmentId\":\"wikipedia_2016-06-27T14:00:00.000Z_2016-06-27T15:00:00.000Z_2021-12-11T11:12:16.106Z\",\"columns\":[\"__time\",\"channel\",\"cityName\",\"comment\",\"countryIsoCode\",\"countryName\",\"diffUrl\",\"flags\",\"isAnonymous\",\"isMinor\",\"isNew\",\"isRobot\",\"isUnpatrolled\",\"metroCode\",\"namespace\",\"page\",\"regionIsoCode\",\"regionName\",\"user\",\"sum_deleted\",\"sum_deltaBucket\",\"sum_added\",\"sum_commentLength\",\"count\",\"sum_delta\"],\"events\":[{\"__time\":1467036000000,\"channel\":\"#de.wikipedia\",\"cityName\":null,\"comment\":\"Bitte [[WP:Literatur]] beachten.\",\"countryIsoCode\":null,\"countryName\":null,\"diffUrl\":\"https://de.wikipedia.org/w/index.php?diff=155672392&oldid=155667393\",\"flags\":null,\"isAnonymous\":\"false\",\"isMinor\":\"false\",\"isNew\":\"false\",\"isRobot\":\"false\",\"isUnpatrolled\":\"false\",\"metroCode\":null,\"namespace\":\"Main\",\"page\":\"Walfang\",\"regionIsoCode\":null,\"regionName\":null,\"user\":\"Dansker\",\"sum_deleted\":133,\"sum_deltaBucket\":-200,\"sum_added\":0,\"sum_commentLength\":32,\"count\":1,\"sum_delta\":-133}]}]";
     InputStream inputStream =
-        new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8.name()));
+        new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8));
     when(httpEntity.getContent()).thenReturn(inputStream);
 
     DruidScanResponse response = druidQueryClient.executeQuery(QUERY);

--- a/contrib/storage-kudu/src/main/codegen/templates/KuduRecordWriter.java
+++ b/contrib/storage-kudu/src/main/codegen/templates/KuduRecordWriter.java
@@ -20,58 +20,32 @@
 
 package org.apache.drill.exec.store.kudu;
 
+import java.io.IOException;
+import java.lang.UnsupportedOperationException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.expr.TypeHelper;
+import org.apache.drill.exec.expr.holders.*;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.store.*;
 import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
+import org.apache.drill.exec.util.DecimalUtility;
+import org.apache.drill.exec.vector.*;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.fn.JsonOutput;
-import java.io.IOException;
-import java.lang.UnsupportedOperationException;
-import java.util.List;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.exec.expr.TypeHelper;
-import org.apache.drill.exec.expr.holders.*;
-import org.apache.drill.exec.record.BatchSchema;
-import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
-import org.apache.drill.exec.vector.*;
-import org.apache.drill.exec.util.DecimalUtility;
-import org.apache.drill.exec.vector.complex.reader.FieldReader;
-import org.apache.parquet.io.api.RecordConsumer;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.io.api.Binary;
-import io.netty.buffer.DrillBuf;
-import org.apache.drill.exec.record.BatchSchema;
-import org.apache.drill.exec.record.MaterializedField;
-import org.apache.drill.common.types.TypeProtos;
-import org.joda.time.DateTimeUtils;
-import java.io.IOException;
-import java.lang.UnsupportedOperationException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.exec.expr.TypeHelper;
-import org.apache.drill.exec.expr.holders.*;
-import org.apache.drill.exec.record.BatchSchema;
-import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
-import org.apache.drill.exec.vector.*;
-import org.apache.drill.exec.util.DecimalUtility;
-import org.apache.drill.exec.vector.complex.reader.FieldReader;
-import org.apache.parquet.io.api.RecordConsumer;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.io.api.Binary;
-import io.netty.buffer.DrillBuf;
-import org.apache.drill.exec.record.BatchSchema;
-import org.apache.drill.exec.record.MaterializedField;
-import org.apache.drill.common.types.TypeProtos;
-import org.joda.time.DateTimeUtils;
-import java.io.IOException;
-import java.lang.UnsupportedOperationException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+
 import org.apache.kudu.client.*;
-import org.apache.drill.exec.store.*;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.io.api.Binary;
+import org.joda.time.DateTimeUtils;
+import io.netty.buffer.DrillBuf;
 
 public abstract class KuduRecordWriter extends AbstractRecordWriter implements RecordWriter {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/CharSequenceWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/CharSequenceWrapper.java
@@ -20,9 +20,9 @@ package org.apache.drill.exec.expr.fn.impl;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.DrillBuf;
 
@@ -80,7 +80,7 @@ public class CharSequenceWrapper implements CharSequence {
   }
 
   /**
-   * When using the Java regex {@link Matcher} the subSequence is only called
+   * When using the Java regex {@link java.util.regex.Matcher} the subSequence is only called
    * when capturing groups. Drill does not currently use capture groups in the
    * UDF so this method is not required.<br>
    * It could be implemented by creating a new CharSequenceWrapper however
@@ -158,7 +158,7 @@ public class CharSequenceWrapper implements CharSequence {
       charBuffer = CharBuffer.allocate(INITIAL_CHAR_BUF);
     }
     if (decoder == null) {
-      decoder = Charset.forName("UTF-8").newDecoder();
+      decoder = StandardCharsets.UTF_8.newDecoder();
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/PluginConfigWrapper.java
@@ -172,7 +172,7 @@ public class PluginConfigWrapper {
    */
   private String URLEncodeValue(String value) {
     try {
-      return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+      return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
     } catch (UnsupportedEncodingException e) {
       throw UserException
         .internalError(e)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
@@ -16,14 +16,15 @@
  * limitations under the License.
  */
 package org.apache.drill.exec.expr.fn.impl;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -111,7 +112,7 @@ public class TestSqlPatterns extends BaseTest {
   public void setup() {
     allocator = RootAllocatorFactory.newRoot(16384);
     drillBuf = allocator.buffer(8192);
-    charsetEncoder = Charset.forName("UTF-8").newEncoder();
+    charsetEncoder = StandardCharsets.UTF_8.newEncoder();
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
@@ -365,11 +365,11 @@ public class TestCastFunctions extends PopUnitTestBase {
 
       final Object [][] expected = new Object[2][2];
 
-      expected[0][0] = new String("2001");
-      expected[0][1] = new String("1.2");
+      expected[0][0] = "2001";
+      expected[0][1] = "1.2";
 
-      expected[1][0] = new String("-2002");
-      expected[1][1] = new String("-1.2");
+      expected[1][0] = "-2002";
+      expected[1][1] = "-1.2";
 
       assertEquals(result.length, expected.length);
       assertEquals(result[0].length, expected[0].length);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.categories.VectorTest;
@@ -86,10 +87,10 @@ public class TestValueVector extends ExecTest {
     allocator = RootAllocatorFactory.newRoot(drillConfig);
   }
 
-  private final static Charset utf8Charset = Charset.forName("UTF-8");
-  private final static byte[] STR1 = new String("AAAAA1").getBytes(utf8Charset);
-  private final static byte[] STR2 = new String("BBBBBBBBB2").getBytes(utf8Charset);
-  private final static byte[] STR3 = new String("CCCC3").getBytes(utf8Charset);
+  private final static Charset utf8Charset = StandardCharsets.UTF_8;
+  private final static byte[] STR1 = "AAAAA1".getBytes(utf8Charset);
+  private final static byte[] STR2 = "BBBBBBBBB2".getBytes(utf8Charset);
+  private final static byte[] STR3 = "CCCC3".getBytes(utf8Charset);
 
   @After
   public void terminate() throws Exception {

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -874,8 +874,8 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       <#default>
       java.nio.charset.Charset charset = Charsets.UTF_8;
       </#switch>
-      byte[] evenValue = new String("aaaaa").getBytes(charset);
-      byte[] oddValue = new String("bbbbbbbbbb").getBytes(charset);
+      byte[] evenValue = "aaaaa".getBytes(charset);
+      byte[] oddValue = "bbbbbbbbbb".getBytes(charset);
       for(int i =0; i < size; i++, even = !even){
         set(i, even ? evenValue : oddValue);
         }

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/Text.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/Text.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.Arrays;
@@ -47,7 +47,7 @@ public class Text {
       new ThreadLocal<CharsetEncoder>() {
         @Override
         protected CharsetEncoder initialValue() {
-          return Charset.forName("UTF-8").newEncoder().
+          return StandardCharsets.UTF_8.newEncoder().
               onMalformedInput(CodingErrorAction.REPORT).
               onUnmappableCharacter(CodingErrorAction.REPORT);
         }
@@ -57,7 +57,7 @@ public class Text {
       new ThreadLocal<CharsetDecoder>() {
         @Override
         protected CharsetDecoder initialValue() {
-          return Charset.forName("UTF-8").newDecoder().
+          return StandardCharsets.UTF_8.newDecoder().
               onMalformedInput(CodingErrorAction.REPORT).
               onUnmappableCharacter(CodingErrorAction.REPORT);
         }

--- a/exec/vector/src/test/java/org/apache/drill/exec/record/TestMaterializedField.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/record/TestMaterializedField.java
@@ -27,9 +27,9 @@ public class TestMaterializedField {
 
   @Test
   public void testHashCodeContact() {
-    MaterializedField childField = MaterializedField.create(new String("child"), Types.OPTIONAL_BIT);
-    MaterializedField field = MaterializedField.create(new String("field"), Types.OPTIONAL_INT);
-    MaterializedField equalField = MaterializedField.create(new String("field"), Types.OPTIONAL_INT);
+    MaterializedField childField = MaterializedField.create("child", Types.OPTIONAL_BIT);
+    MaterializedField field = MaterializedField.create("field", Types.OPTIONAL_INT);
+    MaterializedField equalField = MaterializedField.create("field", Types.OPTIONAL_INT);
     field.addChild(childField);
     equalField.addChild(childField);
 
@@ -37,12 +37,12 @@ public class TestMaterializedField {
     assertEquals(field.hashCode(), equalField.hashCode());
 
     //equal fields with different case of field name
-    equalField = MaterializedField.create(new String("FIELD"), Types.OPTIONAL_INT);
+    equalField = MaterializedField.create("FIELD", Types.OPTIONAL_INT);
     equalField.addChild(childField);
     assertEquals(field.hashCode(), equalField.hashCode());
 
     //not equal fields
-    MaterializedField differentField = MaterializedField.create(new String("other"), Types.OPTIONAL_BIT);
+    MaterializedField differentField = MaterializedField.create("other", Types.OPTIONAL_BIT);
     differentField.addChild(childField);
     assertNotEquals(field.hashCode(), differentField.hashCode());
 
@@ -53,9 +53,9 @@ public class TestMaterializedField {
 
   @Test
   public void testEqualsContract() {
-    MaterializedField childField = MaterializedField.create(new String("child"), Types.OPTIONAL_BIT);
-    MaterializedField field = MaterializedField.create(new String("field"), Types.OPTIONAL_INT);
-    MaterializedField equalField = MaterializedField.create(new String("field"), Types.OPTIONAL_INT);
+    MaterializedField childField = MaterializedField.create("child", Types.OPTIONAL_BIT);
+    MaterializedField field = MaterializedField.create("field", Types.OPTIONAL_INT);
+    MaterializedField equalField = MaterializedField.create("field", Types.OPTIONAL_INT);
     field.addChild(childField);
     equalField.addChild(childField);
 
@@ -70,12 +70,12 @@ public class TestMaterializedField {
     assertNotEquals(field, null);
 
     //different type
-    MaterializedField differentField = MaterializedField.create(new String("field"), Types.OPTIONAL_BIT);
+    MaterializedField differentField = MaterializedField.create("field", Types.OPTIONAL_BIT);
     differentField.addChild(childField);
     assertNotEquals(field, differentField);
 
     //different name
-    differentField = MaterializedField.create(new String("other"), Types.OPTIONAL_INT);
+    differentField = MaterializedField.create("other", Types.OPTIONAL_INT);
     differentField.addChild(childField);
     assertNotEquals(field, differentField);
 


### PR DESCRIPTION
## Description

Code tidy-up. Basically a subset of #2637 but with none of the changes that affect the char encoding used in existing conversions.

* uses of a pattern like `new String("aaaa")` - IntelliJ and other tools highlight this as unnecessary
* uses of `new String(bytes, StandardCharsets.UTF_8.name())` - better to use `new String(bytes, StandardCharsets.UTF_8)`
* use Base64 encodeToString instead of case where we encode to bytes and then do our own encoding of those bytes to a String
* Change existing code with `Charset.forName("UTF-8")` to use `StandardCharsets.UTF_8`

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
