### PR TITLE
DRILL-8320: Prevent Infinite Pagination for Index Paginator

### DIFF
--- a/contrib/storage-http/.gitignore
+++ b/contrib/storage-http/.gitignore
@@ -1,0 +1,1 @@
+./src/test/resources/logback-test.xml

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.physical.impl.scan.v3.FixedReceiver;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoader;
-import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
 import org.apache.drill.exec.store.http.HttpApiConfig.PostLocation;
@@ -67,7 +66,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
   private final int maxRecords;
   protected final Paginator paginator;
   protected String baseUrl;
-  private JsonLoaderImpl jsonLoader;
+  private JsonLoader jsonLoader;
   private ResultSetLoader resultSetLoader;
   private final List<SchemaPath> projectedColumns;
   protected ImplicitColumns implicitColumns;
@@ -160,7 +159,7 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
         jsonBuilder.providedSchema(getSchema(negotiator));
       }
 
-      jsonLoader = (JsonLoaderImpl) jsonBuilder.build();
+      jsonLoader = jsonBuilder.build();
     } catch (Throwable t) {
 
       // Paranoia: ensure stream is closed if anything goes wrong.

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -113,7 +113,6 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     negotiator.setErrorContext(errorContext);
 
     logger.debug("Executing request with url: {}", url);
-    System.out.println("Executing request: " + url);
 
     // Http client setup
     SimpleHttp http = SimpleHttp.builder()

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPaginatorConfig.java
@@ -120,12 +120,7 @@ public class HttpPaginatorConfig {
         break;
       case INDEX:
         // Either the nextPageParam OR the indexParam must be populated
-        if (StringUtils.isEmpty(this.hasMoreParam)) {
-          throw UserException
-            .validationError()
-            .message("Invalid paginator configuration.  For INDEX pagination, the hasMoreParam must be defined.")
-            .build(logger);
-        } else if ((StringUtils.isEmpty(this.nextPageParam) && StringUtils.isNotEmpty(this.indexParam)) &&
+        if ((StringUtils.isEmpty(this.nextPageParam) && StringUtils.isNotEmpty(this.indexParam)) &&
           (StringUtils.isNotEmpty(this.nextPageParam) && StringUtils.isEmpty(this.indexParam))) {
           throw UserException
             .validationError()

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -71,7 +71,6 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
     builder.projection(subScan.columns());
     builder.providedSchema(subScan.schema());
     builder.setUserName(subScan.getUserName());
-    builder.limit(subScan.maxRecords());
 
     // Provide custom error context
     builder.errorContext(

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -71,6 +71,7 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
     builder.projection(subScan.columns());
     builder.providedSchema(subScan.schema());
     builder.setUserName(subScan.getUserName());
+    builder.limit(subScan.maxRecords());
 
     // Provide custom error context
     builder.errorContext(
@@ -86,9 +87,6 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
     ReaderFactory readerFactory = new HttpReaderFactory(subScan);
     builder.setReaderFactory(readerFactory);
     builder.nullType(Types.optional(MinorType.VARCHAR));
-
-    // TODO Add page size limit here to ScanFramework Builder
-
     return builder;
   }
 
@@ -139,8 +137,9 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
           paginatorConfig.pageSizeParam());
       } else if (paginatorConfig.getMethodType() == PaginatorMethod.INDEX) {
         paginator = new IndexPaginator(urlBuilder,
+          0,  // Page size not used for Index/Keyset pagination
           subScan.maxRecords(),
-          0, paginatorConfig.hasMoreParam(),
+          paginatorConfig.hasMoreParam(),
           paginatorConfig.indexParam(),
           paginatorConfig.nextPageParam());
       }

--- a/contrib/storage-http/src/test/resources/data/nested_pagination_fields.json
+++ b/contrib/storage-http/src/test/resources/data/nested_pagination_fields.json
@@ -1,0 +1,17 @@
+{
+  "results": [
+    {
+      "id": "1",
+      "properties": {
+        "company": "HubSpot"
+      },
+      "archived": false
+    }
+  ],
+  "paging": {
+    "next": {
+      "after": "2",
+      "link": "https://api.hubapi.com/crm/v3/objects/contacts?includeAssociations=true&properties=record_id&properties=company&properties=createdate&properties=email&properties=firstname&properties=lastmodifieddate&properties=lastname&properties=phone&properties=website&limit=1&after=2"
+    }
+  }
+}

--- a/contrib/storage-http/src/test/resources/data/nested_pagination_fields2.json
+++ b/contrib/storage-http/src/test/resources/data/nested_pagination_fields2.json
@@ -1,0 +1,14 @@
+{
+  "results": [
+    {
+      "id": "2",
+      "properties": {
+        "company": "HubSpot2"
+      },
+      "archived": false
+    }
+  ],
+  "paging": {
+
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
@@ -264,7 +264,6 @@ public class JsonStructureParser {
     }
     while (true) {
       try {
-        // System.out.println(tokenizer.stringValue());
         return rootState.parseRoot(tokenizer);
       } catch (RecoverableJsonException e) {
         if (! recover()) {


### PR DESCRIPTION
# [DRILL-8320](https://issues.apache.org/jira/browse/DRILL-8320): Prevent Infinite Pagination for Index Paginator

## Description
In some cases that use keyset/index pagination, if the API does not have a boolean column that indicates when to stop, Drill will send requests until the API stops returning data.  This PR fixes this by making the boolean parameter optional.  

If that parameter is not present, if the index result is blank or the same as the previous request, pagination will end.

Note, if the pagination parameters are buried in nested objects, this cannot be configured with a `dataPath`.  If the user uses a `dataPath`, pagination will stop at the first page.

## Documentation
No user facing changes.

## Testing
Added unit test and tested manually with Hubspot API.