### PR TITLE
DRILL-8322: Add a list of scanned plugin names to the query profile

### DIFF
--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -885,7 +885,7 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_UserBitShared_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_UserBitShared_2eproto = {
-  false, false, 4437, descriptor_table_protodef_UserBitShared_2eproto, "UserBitShared.proto",
+  false, false, 4437, descriptor_table_protodef_UserBitShared_2eproto, "UserBitShared.proto", 
   &descriptor_table_UserBitShared_2eproto_once, descriptor_table_UserBitShared_2eproto_deps, 3, 22,
   schemas, file_default_instances, TableStruct_UserBitShared_2eproto::offsets,
   file_level_metadata_UserBitShared_2eproto, file_level_enum_descriptors_UserBitShared_2eproto, file_level_service_descriptors_UserBitShared_2eproto,

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -220,6 +220,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT QueryInfoDefaultTypeInternal _Q
 constexpr QueryProfile::QueryProfile(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : fragment_profile_()
+  , scanned_plugins_()
   , query_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , plan_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , user_(nullptr)
@@ -581,6 +582,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_UserBitShared_2eproto::offsets
   PROTOBUF_FIELD_OFFSET(::exec::shared::QueryProfile, queue_name_),
   PROTOBUF_FIELD_OFFSET(::exec::shared::QueryProfile, queryid_),
   PROTOBUF_FIELD_OFFSET(::exec::shared::QueryProfile, autolimit_),
+  PROTOBUF_FIELD_OFFSET(::exec::shared::QueryProfile, scanned_plugins_),
   10,
   21,
   12,
@@ -604,6 +606,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_UserBitShared_2eproto::offsets
   8,
   9,
   17,
+  ~0u,
   PROTOBUF_FIELD_OFFSET(::exec::shared::MajorFragmentProfile, _has_bits_),
   PROTOBUF_FIELD_OFFSET(::exec::shared::MajorFragmentProfile, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -726,15 +729,15 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 124, 132, sizeof(::exec::shared::QueryResult)},
   { 135, 144, sizeof(::exec::shared::QueryData)},
   { 148, 161, sizeof(::exec::shared::QueryInfo)},
-  { 169, 197, sizeof(::exec::shared::QueryProfile)},
-  { 220, 227, sizeof(::exec::shared::MajorFragmentProfile)},
-  { 229, 245, sizeof(::exec::shared::MinorFragmentProfile)},
-  { 256, 270, sizeof(::exec::shared::OperatorProfile)},
-  { 279, 287, sizeof(::exec::shared::StreamProfile)},
-  { 290, 298, sizeof(::exec::shared::MetricValue)},
-  { 301, -1, sizeof(::exec::shared::Registry)},
-  { 307, 314, sizeof(::exec::shared::Jar)},
-  { 316, 324, sizeof(::exec::shared::SaslMessage)},
+  { 169, 198, sizeof(::exec::shared::QueryProfile)},
+  { 222, 229, sizeof(::exec::shared::MajorFragmentProfile)},
+  { 231, 247, sizeof(::exec::shared::MinorFragmentProfile)},
+  { 258, 272, sizeof(::exec::shared::OperatorProfile)},
+  { 281, 289, sizeof(::exec::shared::StreamProfile)},
+  { 292, 300, sizeof(::exec::shared::MetricValue)},
+  { 303, -1, sizeof(::exec::shared::Registry)},
+  { 309, 316, sizeof(::exec::shared::Jar)},
+  { 318, 326, sizeof(::exec::shared::SaslMessage)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -820,7 +823,7 @@ const char descriptor_table_protodef_UserBitShared_2eproto[] PROTOBUF_SECTION_VA
   "ult.QueryState\022\017\n\004user\030\004 \001(\t:\001-\022\'\n\007forem"
   "an\030\005 \001(\0132\026.exec.DrillbitEndpoint\022\024\n\014opti"
   "ons_json\030\006 \001(\t\022\022\n\ntotal_cost\030\007 \001(\001\022\025\n\nqu"
-  "eue_name\030\010 \001(\t:\001-\"\306\004\n\014QueryProfile\022 \n\002id"
+  "eue_name\030\010 \001(\t:\001-\"\337\004\n\014QueryProfile\022 \n\002id"
   "\030\001 \001(\0132\024.exec.shared.QueryId\022$\n\004type\030\002 \001"
   "(\0162\026.exec.shared.QueryType\022\r\n\005start\030\003 \001("
   "\003\022\013\n\003end\030\004 \001(\003\022\r\n\005query\030\005 \001(\t\022\014\n\004plan\030\006 "
@@ -835,45 +838,45 @@ const char descriptor_table_protodef_UserBitShared_2eproto[] PROTOBUF_SECTION_VA
   " \001(\t\022\017\n\007planEnd\030\022 \001(\003\022\024\n\014queueWaitEnd\030\023 "
   "\001(\003\022\022\n\ntotal_cost\030\024 \001(\001\022\025\n\nqueue_name\030\025 "
   "\001(\t:\001-\022\017\n\007queryId\030\026 \001(\t\022\021\n\tautoLimit\030\027 \001"
-  "(\005\"t\n\024MajorFragmentProfile\022\031\n\021major_frag"
-  "ment_id\030\001 \001(\005\022A\n\026minor_fragment_profile\030"
-  "\002 \003(\0132!.exec.shared.MinorFragmentProfile"
-  "\"\350\002\n\024MinorFragmentProfile\022)\n\005state\030\001 \001(\016"
-  "2\032.exec.shared.FragmentState\022(\n\005error\030\002 "
-  "\001(\0132\031.exec.shared.DrillPBError\022\031\n\021minor_"
-  "fragment_id\030\003 \001(\005\0226\n\020operator_profile\030\004 "
-  "\003(\0132\034.exec.shared.OperatorProfile\022\022\n\nsta"
-  "rt_time\030\005 \001(\003\022\020\n\010end_time\030\006 \001(\003\022\023\n\013memor"
-  "y_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(\003\022(\n"
-  "\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpoint\022"
-  "\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progress\030\013 "
-  "\001(\003\"\237\002\n\017OperatorProfile\0221\n\rinput_profile"
-  "\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023\n\013op"
-  "erator_id\030\003 \001(\005\022\031\n\roperator_type\030\004 \001(\005B\002"
-  "\030\001\022\023\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos"
-  "\030\006 \001(\003\022#\n\033peak_local_memory_allocated\030\007 "
-  "\001(\003\022(\n\006metric\030\010 \003(\0132\030.exec.shared.Metric"
-  "Value\022\022\n\nwait_nanos\030\t \001(\003\022\032\n\022operator_ty"
-  "pe_name\030\n \001(\t\"B\n\rStreamProfile\022\017\n\007record"
-  "s\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007schemas\030\003 \001("
-  "\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nl"
-  "ong_value\030\002 \001(\003\022\024\n\014double_value\030\003 \001(\001\")\n"
-  "\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.shared.Jar"
-  "\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022function_signat"
-  "ure\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmechanism\030\001 "
-  "\001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001(\0162\027.exec"
-  ".shared.SaslStatus*5\n\nRpcChannel\022\017\n\013BIT_"
-  "CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\tQue"
-  "ryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL"
-  "\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_STATEMENT\020"
-  "\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000\022\027\n\023AWAI"
-  "TING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISH"
-  "ED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCE"
-  "LLATION_REQUESTED\020\006*g\n\nSaslStatus\022\020\n\014SAS"
-  "L_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_P"
-  "ROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAIL"
-  "ED\020\004B.\n\033org.apache.drill.exec.protoB\rUse"
-  "rBitSharedH\001"
+  "(\005\022\027\n\017scanned_plugins\030\030 \003(\t\"t\n\024MajorFrag"
+  "mentProfile\022\031\n\021major_fragment_id\030\001 \001(\005\022A"
+  "\n\026minor_fragment_profile\030\002 \003(\0132!.exec.sh"
+  "ared.MinorFragmentProfile\"\350\002\n\024MinorFragm"
+  "entProfile\022)\n\005state\030\001 \001(\0162\032.exec.shared."
+  "FragmentState\022(\n\005error\030\002 \001(\0132\031.exec.shar"
+  "ed.DrillPBError\022\031\n\021minor_fragment_id\030\003 \001"
+  "(\005\0226\n\020operator_profile\030\004 \003(\0132\034.exec.shar"
+  "ed.OperatorProfile\022\022\n\nstart_time\030\005 \001(\003\022\020"
+  "\n\010end_time\030\006 \001(\003\022\023\n\013memory_used\030\007 \001(\003\022\027\n"
+  "\017max_memory_used\030\010 \001(\003\022(\n\010endpoint\030\t \001(\013"
+  "2\026.exec.DrillbitEndpoint\022\023\n\013last_update\030"
+  "\n \001(\003\022\025\n\rlast_progress\030\013 \001(\003\"\237\002\n\017Operato"
+  "rProfile\0221\n\rinput_profile\030\001 \003(\0132\032.exec.s"
+  "hared.StreamProfile\022\023\n\013operator_id\030\003 \001(\005"
+  "\022\031\n\roperator_type\030\004 \001(\005B\002\030\001\022\023\n\013setup_nan"
+  "os\030\005 \001(\003\022\025\n\rprocess_nanos\030\006 \001(\003\022#\n\033peak_"
+  "local_memory_allocated\030\007 \001(\003\022(\n\006metric\030\010"
+  " \003(\0132\030.exec.shared.MetricValue\022\022\n\nwait_n"
+  "anos\030\t \001(\003\022\032\n\022operator_type_name\030\n \001(\t\"B"
+  "\n\rStreamProfile\022\017\n\007records\030\001 \001(\003\022\017\n\007batc"
+  "hes\030\002 \001(\003\022\017\n\007schemas\030\003 \001(\003\"J\n\013MetricValu"
+  "e\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nlong_value\030\002 \001(\003"
+  "\022\024\n\014double_value\030\003 \001(\001\")\n\010Registry\022\035\n\003ja"
+  "r\030\001 \003(\0132\020.exec.shared.Jar\"/\n\003Jar\022\014\n\004name"
+  "\030\001 \001(\t\022\032\n\022function_signature\030\002 \003(\t\"W\n\013Sa"
+  "slMessage\022\021\n\tmechanism\030\001 \001(\t\022\014\n\004data\030\002 \001"
+  "(\014\022\'\n\006status\030\003 \001(\0162\027.exec.shared.SaslSta"
+  "tus*5\n\nRpcChannel\022\017\n\013BIT_CONTROL\020\000\022\014\n\010BI"
+  "T_DATA\020\001\022\010\n\004USER\020\002*V\n\tQueryType\022\007\n\003SQL\020\001"
+  "\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL\020\003\022\r\n\tEXECUTION"
+  "\020\004\022\026\n\022PREPARED_STATEMENT\020\005*\207\001\n\rFragmentS"
+  "tate\022\013\n\007SENDING\020\000\022\027\n\023AWAITING_ALLOCATION"
+  "\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISHED\020\003\022\r\n\tCANCELL"
+  "ED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCELLATION_REQUEST"
+  "ED\020\006*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\n"
+  "SASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014SA"
+  "SL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.apa"
+  "che.drill.exec.protoB\rUserBitSharedH\001"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_UserBitShared_2eproto_deps[3] = {
   &::descriptor_table_Coordination_2eproto,
@@ -882,7 +885,7 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_UserBitShared_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_UserBitShared_2eproto = {
-  false, false, 4412, descriptor_table_protodef_UserBitShared_2eproto, "UserBitShared.proto", 
+  false, false, 4437, descriptor_table_protodef_UserBitShared_2eproto, "UserBitShared.proto",
   &descriptor_table_UserBitShared_2eproto_once, descriptor_table_UserBitShared_2eproto_deps, 3, 22,
   schemas, file_default_instances, TableStruct_UserBitShared_2eproto::offsets,
   file_level_metadata_UserBitShared_2eproto, file_level_enum_descriptors_UserBitShared_2eproto, file_level_service_descriptors_UserBitShared_2eproto,
@@ -5502,7 +5505,8 @@ const ::PROTOBUF_NAMESPACE_ID::internal::LazyString QueryProfile::_i_give_permis
 const ::PROTOBUF_NAMESPACE_ID::internal::LazyString QueryProfile::_i_give_permission_to_break_this_code_default_queue_name_{{{"-", 1}}, {nullptr}};
 QueryProfile::QueryProfile(::PROTOBUF_NAMESPACE_ID::Arena* arena)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena),
-  fragment_profile_(arena) {
+  fragment_profile_(arena),
+  scanned_plugins_(arena) {
   SharedCtor();
   RegisterArenaDtor(arena);
   // @@protoc_insertion_point(arena_constructor:exec.shared.QueryProfile)
@@ -5510,7 +5514,8 @@ QueryProfile::QueryProfile(::PROTOBUF_NAMESPACE_ID::Arena* arena)
 QueryProfile::QueryProfile(const QueryProfile& from)
   : ::PROTOBUF_NAMESPACE_ID::Message(),
       _has_bits_(from._has_bits_),
-      fragment_profile_(from.fragment_profile_) {
+      fragment_profile_(from.fragment_profile_),
+      scanned_plugins_(from.scanned_plugins_) {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   query_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   if (from._internal_has_query()) {
@@ -5635,6 +5640,7 @@ void QueryProfile::Clear() {
   (void) cached_has_bits;
 
   fragment_profile_.Clear();
+  scanned_plugins_.Clear();
   cached_has_bits = _has_bits_[0];
   if (cached_has_bits & 0x000000ffu) {
     if (cached_has_bits & 0x00000001u) {
@@ -5924,6 +5930,22 @@ const char* QueryProfile::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_I
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
+      // repeated string scanned_plugins = 24;
+      case 24:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 194)) {
+          ptr -= 2;
+          do {
+            ptr += 2;
+            auto str = _internal_add_scanned_plugins();
+            ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+            #ifndef NDEBUG
+            ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "exec.shared.QueryProfile.scanned_plugins");
+            #endif  // !NDEBUG
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<194>(ptr));
+        } else goto handle_unusual;
+        continue;
       default: {
       handle_unusual:
         if ((tag == 0) || ((tag & 7) == 4)) {
@@ -6141,6 +6163,16 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(23, this->_internal_autolimit(), target);
   }
 
+  // repeated string scanned_plugins = 24;
+  for (int i = 0, n = this->_internal_scanned_plugins_size(); i < n; i++) {
+    const auto& s = this->_internal_scanned_plugins(i);
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
+      s.data(), static_cast<int>(s.length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
+      "exec.shared.QueryProfile.scanned_plugins");
+    target = stream->WriteString(24, s, target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -6162,6 +6194,14 @@ size_t QueryProfile::ByteSizeLong() const {
   for (const auto& msg : this->fragment_profile_) {
     total_size +=
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated string scanned_plugins = 24;
+  total_size += 2 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(scanned_plugins_.size());
+  for (int i = 0, n = scanned_plugins_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+      scanned_plugins_.Get(i));
   }
 
   cached_has_bits = _has_bits_[0];
@@ -6353,6 +6393,7 @@ void QueryProfile::MergeFrom(const QueryProfile& from) {
   (void) cached_has_bits;
 
   fragment_profile_.MergeFrom(from.fragment_profile_);
+  scanned_plugins_.MergeFrom(from.scanned_plugins_);
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 0x000000ffu) {
     if (cached_has_bits & 0x00000001u) {
@@ -6453,6 +6494,7 @@ void QueryProfile::InternalSwap(QueryProfile* other) {
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   swap(_has_bits_[0], other->_has_bits_[0]);
   fragment_profile_.InternalSwap(&other->fragment_profile_);
+  scanned_plugins_.InternalSwap(&other->scanned_plugins_);
   query_.Swap(&other->query_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   plan_.Swap(&other->plan_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   user_.Swap(&other->user_, nullptr, GetArena());

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -3177,6 +3177,7 @@ class QueryProfile PROTOBUF_FINAL :
 
   enum : int {
     kFragmentProfileFieldNumber = 11,
+    kScannedPluginsFieldNumber = 24,
     kQueryFieldNumber = 5,
     kPlanFieldNumber = 6,
     kUserFieldNumber = 12,
@@ -3217,6 +3218,30 @@ class QueryProfile PROTOBUF_FINAL :
   ::exec::shared::MajorFragmentProfile* add_fragment_profile();
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::exec::shared::MajorFragmentProfile >&
       fragment_profile() const;
+
+  // repeated string scanned_plugins = 24;
+  int scanned_plugins_size() const;
+  private:
+  int _internal_scanned_plugins_size() const;
+  public:
+  void clear_scanned_plugins();
+  const std::string& scanned_plugins(int index) const;
+  std::string* mutable_scanned_plugins(int index);
+  void set_scanned_plugins(int index, const std::string& value);
+  void set_scanned_plugins(int index, std::string&& value);
+  void set_scanned_plugins(int index, const char* value);
+  void set_scanned_plugins(int index, const char* value, size_t size);
+  std::string* add_scanned_plugins();
+  void add_scanned_plugins(const std::string& value);
+  void add_scanned_plugins(std::string&& value);
+  void add_scanned_plugins(const char* value);
+  void add_scanned_plugins(const char* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& scanned_plugins() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_scanned_plugins();
+  private:
+  const std::string& _internal_scanned_plugins(int index) const;
+  std::string* _internal_add_scanned_plugins();
+  public:
 
   // optional string query = 5;
   bool has_query() const;
@@ -3574,6 +3599,7 @@ class QueryProfile PROTOBUF_FINAL :
   ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::exec::shared::MajorFragmentProfile > fragment_profile_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> scanned_plugins_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr query_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr plan_;
   static const ::PROTOBUF_NAMESPACE_ID::internal::LazyString _i_give_permission_to_break_this_code_default_user_;
@@ -8747,6 +8773,80 @@ inline void QueryProfile::_internal_set_autolimit(::PROTOBUF_NAMESPACE_ID::int32
 inline void QueryProfile::set_autolimit(::PROTOBUF_NAMESPACE_ID::int32 value) {
   _internal_set_autolimit(value);
   // @@protoc_insertion_point(field_set:exec.shared.QueryProfile.autoLimit)
+}
+
+// repeated string scanned_plugins = 24;
+inline int QueryProfile::_internal_scanned_plugins_size() const {
+  return scanned_plugins_.size();
+}
+inline int QueryProfile::scanned_plugins_size() const {
+  return _internal_scanned_plugins_size();
+}
+inline void QueryProfile::clear_scanned_plugins() {
+  scanned_plugins_.Clear();
+}
+inline std::string* QueryProfile::add_scanned_plugins() {
+  // @@protoc_insertion_point(field_add_mutable:exec.shared.QueryProfile.scanned_plugins)
+  return _internal_add_scanned_plugins();
+}
+inline const std::string& QueryProfile::_internal_scanned_plugins(int index) const {
+  return scanned_plugins_.Get(index);
+}
+inline const std::string& QueryProfile::scanned_plugins(int index) const {
+  // @@protoc_insertion_point(field_get:exec.shared.QueryProfile.scanned_plugins)
+  return _internal_scanned_plugins(index);
+}
+inline std::string* QueryProfile::mutable_scanned_plugins(int index) {
+  // @@protoc_insertion_point(field_mutable:exec.shared.QueryProfile.scanned_plugins)
+  return scanned_plugins_.Mutable(index);
+}
+inline void QueryProfile::set_scanned_plugins(int index, const std::string& value) {
+  // @@protoc_insertion_point(field_set:exec.shared.QueryProfile.scanned_plugins)
+  scanned_plugins_.Mutable(index)->assign(value);
+}
+inline void QueryProfile::set_scanned_plugins(int index, std::string&& value) {
+  // @@protoc_insertion_point(field_set:exec.shared.QueryProfile.scanned_plugins)
+  scanned_plugins_.Mutable(index)->assign(std::move(value));
+}
+inline void QueryProfile::set_scanned_plugins(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  scanned_plugins_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:exec.shared.QueryProfile.scanned_plugins)
+}
+inline void QueryProfile::set_scanned_plugins(int index, const char* value, size_t size) {
+  scanned_plugins_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:exec.shared.QueryProfile.scanned_plugins)
+}
+inline std::string* QueryProfile::_internal_add_scanned_plugins() {
+  return scanned_plugins_.Add();
+}
+inline void QueryProfile::add_scanned_plugins(const std::string& value) {
+  scanned_plugins_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:exec.shared.QueryProfile.scanned_plugins)
+}
+inline void QueryProfile::add_scanned_plugins(std::string&& value) {
+  scanned_plugins_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:exec.shared.QueryProfile.scanned_plugins)
+}
+inline void QueryProfile::add_scanned_plugins(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  scanned_plugins_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:exec.shared.QueryProfile.scanned_plugins)
+}
+inline void QueryProfile::add_scanned_plugins(const char* value, size_t size) {
+  scanned_plugins_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:exec.shared.QueryProfile.scanned_plugins)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+QueryProfile::scanned_plugins() const {
+  // @@protoc_insertion_point(field_list:exec.shared.QueryProfile.scanned_plugins)
+  return scanned_plugins_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+QueryProfile::mutable_scanned_plugins() {
+  // @@protoc_insertion_point(field_mutable_list:exec.shared.QueryProfile.scanned_plugins)
+  return &scanned_plugins_;
 }
 
 // -------------------------------------------------------------------

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.ops;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +53,6 @@ import org.apache.drill.exec.store.PartitionExplorerImpl;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.SchemaConfig.SchemaConfigInfoProvider;
 import org.apache.drill.exec.store.SchemaTreeProvider;
-import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.util.Utilities;
@@ -89,7 +87,6 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   /** Stores constants and their holders by type */
   private final Map<String, Map<MinorType, ValueHolder>> constantValueHolderCache;
   private SqlStatementType stmtType;
-  private Collection<StoragePlugin> scannedPlugins;
 
   /*
    * Flag to indicate if close has been called, after calling close the first
@@ -417,16 +414,5 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
 
   public AliasRegistryProvider getAliasRegistryProvider() {
     return drillbitContext.getAliasRegistryProvider();
-  }
-
-  /**
-   * @return The collection of plugins scanned by the executing query.
-   */
-  public Collection<StoragePlugin> getScannedPlugins() {
-    return scannedPlugins != null ? scannedPlugins : Collections.emptySet();
-  }
-
-  public void setScannedPlugins(Collection<StoragePlugin> scannedPlugins) {
-    this.scannedPlugins = scannedPlugins;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.ops;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -422,7 +423,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    * @return The collection of plugins scanned by the executing query.
    */
   public Collection<StoragePlugin> getScannedPlugins() {
-    return scannedPlugins;
+    return scannedPlugins != null ? scannedPlugins : Collections.emptySet();
   }
 
   public void setScannedPlugins(Collection<StoragePlugin> scannedPlugins) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -53,6 +53,7 @@ import org.apache.drill.exec.store.PartitionExplorerImpl;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.SchemaConfig.SchemaConfigInfoProvider;
 import org.apache.drill.exec.store.SchemaTreeProvider;
+import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.util.Utilities;
@@ -87,6 +88,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   /** Stores constants and their holders by type */
   private final Map<String, Map<MinorType, ValueHolder>> constantValueHolderCache;
   private SqlStatementType stmtType;
+  private Collection<StoragePlugin> scannedPlugins;
 
   /*
    * Flag to indicate if close has been called, after calling close the first
@@ -414,5 +416,16 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
 
   public AliasRegistryProvider getAliasRegistryProvider() {
     return drillbitContext.getAliasRegistryProvider();
+  }
+
+  /**
+   * @return The collection of plugins scanned by the executing query.
+   */
+  public Collection<StoragePlugin> getScannedPlugins() {
+    return scannedPlugins;
+  }
+
+  public void setScannedPlugins(Collection<StoragePlugin> scannedPlugins) {
+    this.scannedPlugins = scannedPlugins;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
@@ -129,7 +129,7 @@ public class AnalyzeTableHandler extends DefaultSqlHandler {
     Prel prel = convertToPrel(drel, validatedRowType);
     logAndSetTextPlan("Drill Physical", prel, logger);
     PhysicalOperator pop = convertToPop(prel);
-    PhysicalPlan plan = convertToPlan(pop);
+    PhysicalPlan plan = convertToPlan(pop, relScan);
     log("Drill Plan", plan, logger);
 
     return plan;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateTableHandler.java
@@ -113,7 +113,7 @@ public class CreateTableHandler extends DefaultSqlHandler {
     Prel prel = convertToPrel(drel, newTblRelNode.getRowType(), sqlCreateTable.getPartitionColumns());
     logAndSetTextPlan("Drill Physical", prel, logger);
     PhysicalOperator pop = convertToPop(prel);
-    PhysicalPlan plan = convertToPlan(pop);
+    PhysicalPlan plan = convertToPlan(pop, queryRelNode);
     log("Drill Plan", plan, logger);
 
     String message = String.format("Creating %s table [%s].",

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ExplainHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ExplainHandler.java
@@ -71,7 +71,7 @@ public class ExplainHandler extends DefaultSqlHandler {
     Prel prel = convertToPrel(drel, validatedRowType);
     logAndSetTextPlan("Drill Physical", prel, logger);
     PhysicalOperator pop = convertToPop(prel);
-    PhysicalPlan plan = convertToPlan(pop);
+    PhysicalPlan plan = convertToPlan(pop, queryRelNode);
     log("Drill Plan", plan, logger);
     PhysicalExplain physicalResult = new PhysicalExplain(prel, plan, level, context);
     return DirectPlan.createDirectPlan(context, physicalResult);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreAnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreAnalyzeTableHandler.java
@@ -140,7 +140,7 @@ public class MetastoreAnalyzeTableHandler extends DefaultSqlHandler {
     Prel prel = convertToPrel(drel, validatedRowType);
     logAndSetTextPlan("Drill Physical", prel, logger);
     PhysicalOperator pop = convertToPop(prel);
-    PhysicalPlan plan = convertToPlan(pop);
+    PhysicalPlan plan = convertToPlan(pop, relScan);
     log("Drill Plan", plan, logger);
     return plan;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerConfig.java
@@ -19,9 +19,10 @@ package org.apache.drill.exec.planner.sql.handlers;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttleImpl;
@@ -43,7 +44,7 @@ public class SqlHandlerConfig {
 
   private final QueryContext context;
   private final SqlConverter converter;
-  private ConcurrentHashMap<RelNode, Collection<StoragePlugin>> scannedPluginCache = new ConcurrentHashMap<>();
+  private Map<RelNode, Collection<StoragePlugin>> scannedPluginCache = new HashMap<>();
 
   public SqlHandlerConfig(QueryContext context, SqlConverter converter) {
     this.context = context;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerConfig.java
@@ -17,10 +17,9 @@
  */
 package org.apache.drill.exec.planner.sql.handlers;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
+import java.util.TreeSet;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttleImpl;
@@ -57,6 +56,7 @@ public class SqlHandlerConfig {
     input.accept(pluginsCollector);
 
     Collection<StoragePlugin> plugins = pluginsCollector.getPlugins();
+    context.setScannedPlugins(plugins);
     return phase.getRules(context, plugins);
   }
 
@@ -65,7 +65,11 @@ public class SqlHandlerConfig {
   }
 
   public static class PluginsCollector extends RelShuttleImpl {
-    private final List<StoragePlugin> plugins = new ArrayList<>();
+    // A TreeSet that compares plugins by name to remove duplicates and sort
+    // alphabetically.
+    private final TreeSet<StoragePlugin> plugins = new TreeSet<>(
+      (sp1, sp2) -> sp1.getName().compareTo(sp2.getName())
+    );
     private final StoragePluginRegistry storagePlugins;
 
     public PluginsCollector(StoragePluginRegistry storagePlugins) {
@@ -104,7 +108,10 @@ public class SqlHandlerConfig {
       plugins.add(storagePlugin);
     }
 
-    public List<StoragePlugin> getPlugins() {
+    /**
+     * @return A deduplicated collection of storage plugins scanned by the query.
+     */
+    public Collection<StoragePlugin> getPlugins() {
       return plugins;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -420,6 +420,7 @@ public class Foreman implements Runnable {
     }
     if (textPlan != null) {
       queryManager.setPlanText(textPlan.value);
+      queryManager.setPlanProperties(plan.getProperties());
     }
     queryRM.visitPhysicalPlan(work);
     queryRM.setCost(plan.totalCost());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -384,6 +384,10 @@ public class QueryManager implements AutoCloseable {
       profileBuilder.setQuery(queryText);
     }
 
+    if (planProps != null && planProps.scannedPluginNames != null ) {
+      profileBuilder.addAllScannedPlugins(planProps.scannedPluginNames);
+    }
+
     int autoLimitRowCount = queryCtx.getOptions().getOption(ExecConstants.QUERY_MAX_ROWS).num_val.intValue();
     if (autoLimitRowCount > 0) {
       profileBuilder.setAutoLimit(autoLimitRowCount);
@@ -391,8 +395,6 @@ public class QueryManager implements AutoCloseable {
     }
 
     fragmentDataMap.forEach(new OuterIter(profileBuilder));
-
-    profileBuilder.addAllScannedPlugins(planProps.scannedPluginNames);
 
     return profileBuilder.build();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
@@ -389,7 +390,13 @@ public class QueryManager implements AutoCloseable {
     }
 
     fragmentDataMap.forEach(new OuterIter(profileBuilder));
-    //profileBuilder.setScannedPlugins(queryCtx.getScannedPlugins());
+
+    profileBuilder.addAllScannedPlugins(
+      queryCtx.getScannedPlugins()
+        .stream()
+        .map(sp -> sp.getName())
+        .collect(Collectors.toList())
+    );
 
     return profileBuilder.build();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -51,6 +51,7 @@ import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.control.Controller;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionList;
+import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import org.apache.drill.exec.work.EndpointListener;
@@ -391,12 +392,11 @@ public class QueryManager implements AutoCloseable {
 
     fragmentDataMap.forEach(new OuterIter(profileBuilder));
 
-    profileBuilder.addAllScannedPlugins(
-      queryCtx.getScannedPlugins()
-        .stream()
-        .map(sp -> sp.getName())
-        .collect(Collectors.toList())
-    );
+    List<String> scannedPlugins = queryCtx.getScannedPlugins()
+      .stream()
+      .map(StoragePlugin::getName)
+      .collect(Collectors.toList());
+    profileBuilder.addAllScannedPlugins(scannedPlugins);
 
     return profileBuilder.build();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.common.logical.PlanProperties;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.coord.store.TransientStore;
@@ -51,7 +51,6 @@ import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.control.Controller;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionList;
-import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import org.apache.drill.exec.work.EndpointListener;
@@ -90,6 +89,7 @@ public class QueryManager implements AutoCloseable {
 
   // the following mutable variables are used to capture ongoing query status
   private String planText;
+  private PlanProperties planProps;
   private long startTime = System.currentTimeMillis();
   private long endTime;
   private long planningEndTime;
@@ -392,11 +392,7 @@ public class QueryManager implements AutoCloseable {
 
     fragmentDataMap.forEach(new OuterIter(profileBuilder));
 
-    List<String> scannedPlugins = queryCtx.getScannedPlugins()
-      .stream()
-      .map(StoragePlugin::getName)
-      .collect(Collectors.toList());
-    profileBuilder.addAllScannedPlugins(scannedPlugins);
+    profileBuilder.addAllScannedPlugins(planProps.scannedPluginNames);
 
     return profileBuilder.build();
   }
@@ -442,6 +438,10 @@ public class QueryManager implements AutoCloseable {
 
   void setPlanText(final String planText) {
     this.planText = planText;
+  }
+
+  void setPlanProperties(PlanProperties planProps) {
+    this.planProps = planProps;
   }
 
   void markStartTime() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryProfiles.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryProfiles.java
@@ -19,11 +19,10 @@ package org.apache.drill.exec.server.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import okhttp3.*;
 import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.json.simple.JSONArray;
@@ -34,29 +33,18 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestQueryProfiles extends ClusterTest {
 
-  private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
   private static final int TIMEOUT = 3000; // for debugging
-  private static String[] SQL = new String[5];
+  private static final String GOOD_SQL = "SELECT * FROM cp.`employee.json` LIMIT 20";
+  private static final String BAD_SQL = "SELECT cast(first_name as int)  FROM cp.`employee.json` where LIMIT 20";
   private static int portNumber;
 
-  private final OkHttpClient httpClient = new OkHttpClient.Builder()
+  private static final OkHttpClient httpClient = new OkHttpClient.Builder()
       .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
       .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
       .readTimeout(TIMEOUT, TimeUnit.SECONDS).build();
-
-  private final ObjectMapper mapper = new ObjectMapper();
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -65,23 +53,13 @@ public class TestQueryProfiles extends ClusterTest {
         .configProperty(ExecConstants.HTTP_PORT_HUNT, true);
     startCluster(builder);
     portNumber = cluster.drillbit().getWebServerPort();
-  }
 
-  @Test
-  public void testAdorableQuery() throws IOException {
-    String sql = "SELECT * FROM cp.`employee.json` LIMIT 20";
-    SQL[0] = sql;
-    QueryWrapper query = new QueryWrapper(sql, QueryType.SQL.name(), "10", null, null, null);
-    assertEquals(200, runQuery(query));
-  }
-
-  @Test
-  public void testBadQuery() throws IOException {
-    String sql = "SELECT * FROM cp.`employee123.json` LIMIT 20";
-    SQL[1] = sql;
-    QueryWrapper query = new QueryWrapper(sql, QueryType.SQL.name(), null, null, null, null);
-    int code = runQuery(query);
-    assertEquals(200, code);
+    client.runSqlSilently(GOOD_SQL);
+    try {
+      client.runSqlSilently(BAD_SQL);
+    } catch (Exception ex) {
+      // "Error: SYSTEM ERROR: NumberFormatException: Sheri", as intended.
+    }
   }
 
   @Test
@@ -89,16 +67,16 @@ public class TestQueryProfiles extends ClusterTest {
     String url = String.format("http://localhost:%d/profiles/completed.json", portNumber);
     Request request = new Request.Builder().url(url).build();
     try (Response response = httpClient.newCall(request).execute()) {
-      String respon_body = response.body().string();
-      JSONObject json_data = (JSONObject) new JSONParser().parse(respon_body);
-      JSONArray finishedQueries = (JSONArray) json_data.get("finishedQueries");
+      String responseBody = response.body().string();
+      JSONObject jsonData = (JSONObject) new JSONParser().parse(responseBody);
+      JSONArray finishedQueries = (JSONArray) jsonData.get("finishedQueries");
       JSONObject firstData = (JSONObject) finishedQueries.get(0);
       JSONObject secondData = (JSONObject) finishedQueries.get(1);
 
       assertEquals(2, finishedQueries.size());
-      assertEquals(SQL[1], firstData.get("query").toString());
+      assertEquals(BAD_SQL, firstData.get("query").toString());
       assertEquals("Failed", firstData.get("state").toString());
-      assertEquals(SQL[0], secondData.get("query").toString());
+      assertEquals(GOOD_SQL, secondData.get("query").toString());
       assertEquals("Succeeded", secondData.get("state").toString());
     }
   }
@@ -108,18 +86,18 @@ public class TestQueryProfiles extends ClusterTest {
     String url = String.format("http://localhost:%d/profiles.json", portNumber);
     Request request = new Request.Builder().url(url).build();
     try (Response response = httpClient.newCall(request).execute()) {
-      String respon_body = response.body().string();
-      JSONObject json_data = (JSONObject) new JSONParser().parse(respon_body);
-      JSONArray finishedQueries = (JSONArray) json_data.get("finishedQueries");
+      String responseBody = response.body().string();
+      JSONObject jsonBody = (JSONObject) new JSONParser().parse(responseBody);
+      JSONArray finishedQueries = (JSONArray) jsonBody.get("finishedQueries");
       JSONObject firstData = (JSONObject) finishedQueries.get(0);
       JSONObject secondData = (JSONObject) finishedQueries.get(1);
 
-      assertEquals(5, json_data.size());
-      assertEquals("[]", json_data.get("runningQueries").toString());
+      assertEquals(5, jsonBody.size());
+      assertEquals("[]", jsonBody.get("runningQueries").toString());
       assertEquals(2, finishedQueries.size());
-      assertEquals(SQL[1], firstData.get("query").toString());
+      assertEquals(BAD_SQL, firstData.get("query").toString());
       assertEquals("Failed", firstData.get("state").toString());
-      assertEquals(SQL[0], secondData.get("query").toString());
+      assertEquals(GOOD_SQL, secondData.get("query").toString());
       assertEquals("Succeeded", secondData.get("state").toString());
     }
   }
@@ -129,20 +107,10 @@ public class TestQueryProfiles extends ClusterTest {
     String url = String.format("http://localhost:%d/profiles/running.json", portNumber);
     Request request = new Request.Builder().url(url).build();
     try (Response response = httpClient.newCall(request).execute()) {
-      String respon_body = response.body().string();
-      JSONObject json_data = (JSONObject) new JSONParser().parse(respon_body);
-      assertEquals(4, json_data.size());
-      assertEquals("[]", json_data.get("runningQueries").toString());
-    }
-  }
-
-  private int runQuery(QueryWrapper query) throws IOException {
-    ObjectWriter writer = mapper.writerFor(QueryWrapper.class);
-    String json = writer.writeValueAsString(query);
-    String url = String.format("http://localhost:%d/query.json", portNumber);
-    Request request = new Request.Builder().url(url).post(RequestBody.create(json, JSON_MEDIA_TYPE)).build();
-    try (Response response = httpClient.newCall(request).execute()) {
-      return response.code();
+      String responseBody = response.body().string();
+      JSONObject jsonData = (JSONObject) new JSONParser().parse(responseBody);
+      assertEquals(4, jsonData.size());
+      assertEquals("[]", jsonData.get("runningQueries").toString());
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryProfiles.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryProfiles.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
-import okhttp3.*;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;

--- a/logical/src/main/java/org/apache/drill/common/logical/PlanProperties.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/PlanProperties.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.common.logical;
 
+import java.util.List;
+
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.logical.PlanProperties.Generator.ResultMode;
 
@@ -40,6 +42,7 @@ public class PlanProperties {
    * (memory, etc.) or if this plan must still be computed.
    */
   public boolean hasResourcePlan;
+  public List<String> scannedPluginNames;
 
 //  @JsonInclude(Include.NON_NULL)
   public static class Generator {
@@ -62,7 +65,8 @@ public class PlanProperties {
                          @JsonProperty("mode") ResultMode resultMode,
                          @JsonProperty("options") JSONOptions options,
                          @JsonProperty("queue") int queue,
-                         @JsonProperty("hasResourcePlan") boolean hasResourcePlan
+                         @JsonProperty("hasResourcePlan") boolean hasResourcePlan,
+                         @JsonProperty("scannedPluginNames") List<String> scannedPluginNames
                          ) {
     this.version = version;
     this.queue = queue;
@@ -71,6 +75,7 @@ public class PlanProperties {
     this.resultMode = resultMode == null ? ResultMode.EXEC : resultMode;
     this.options = options;
     this.hasResourcePlan = hasResourcePlan;
+    this.scannedPluginNames = scannedPluginNames;
   }
 
   public static PlanPropertiesBuilder builder() {
@@ -85,6 +90,7 @@ public class PlanProperties {
     private JSONOptions options;
     private int queueNumber = 0;
     private boolean hasResourcePlan = false;
+    private List<String> scannedPluginNames;
 
     public PlanPropertiesBuilder type(PlanType type) {
       this.type = type;
@@ -126,8 +132,22 @@ public class PlanProperties {
       return this;
     }
 
+    public PlanPropertiesBuilder scannedPluginNames(List<String> scannedPluginNames) {
+      this.scannedPluginNames = scannedPluginNames;
+      return this;
+    }
+
     public PlanProperties build() {
-      return new PlanProperties(version, generator, type, mode, options, queueNumber, hasResourcePlan);
+      return new PlanProperties(
+        version,
+        generator,
+        type,
+        mode,
+        options,
+        queueNumber,
+        hasResourcePlan,
+        scannedPluginNames
+      );
     }
 
   }

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
@@ -1830,6 +1830,8 @@ public final class SchemaUserBitShared
                     output.writeString(22, message.getQueryId(), false);
                 if(message.hasAutoLimit())
                     output.writeInt32(23, message.getAutoLimit(), false);
+                for(String scannedPlugins : message.getScannedPluginsList())
+                    output.writeString(24, scannedPlugins, true);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserBitShared.QueryProfile message)
             {
@@ -1941,6 +1943,9 @@ public final class SchemaUserBitShared
                         case 23:
                             builder.setAutoLimit(input.readInt32());
                             break;
+                        case 24:
+                            builder.addScannedPlugins(input.readString());
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -2004,6 +2009,7 @@ public final class SchemaUserBitShared
                 case 21: return "queueName";
                 case 22: return "queryId";
                 case 23: return "autoLimit";
+                case 24: return "scannedPlugins";
                 default: return null;
             }
         }
@@ -2038,6 +2044,7 @@ public final class SchemaUserBitShared
             fieldMap.put("queueName", 21);
             fieldMap.put("queryId", 22);
             fieldMap.put("autoLimit", 23);
+            fieldMap.put("scannedPlugins", 24);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
@@ -16185,6 +16185,31 @@ public final class UserBitShared {
      * @return The autoLimit.
      */
     int getAutoLimit();
+
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @return A list containing the scannedPlugins.
+     */
+    java.util.List<java.lang.String>
+        getScannedPluginsList();
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @return The count of scannedPlugins.
+     */
+    int getScannedPluginsCount();
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @param index The index of the element to return.
+     * @return The scannedPlugins at the given index.
+     */
+    java.lang.String getScannedPlugins(int index);
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the scannedPlugins at the given index.
+     */
+    com.google.protobuf.ByteString
+        getScannedPluginsBytes(int index);
   }
   /**
    * Protobuf type {@code exec.shared.QueryProfile}
@@ -16212,6 +16237,7 @@ public final class UserBitShared {
       optionsJson_ = "";
       queueName_ = "-";
       queryId_ = "";
+      scannedPlugins_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -16404,6 +16430,15 @@ public final class UserBitShared {
               autoLimit_ = input.readInt32();
               break;
             }
+            case 194: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00800000) != 0)) {
+                scannedPlugins_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00800000;
+              }
+              scannedPlugins_.add(bs);
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -16421,6 +16456,9 @@ public final class UserBitShared {
       } finally {
         if (((mutable_bitField0_ & 0x00000400) != 0)) {
           fragmentProfile_ = java.util.Collections.unmodifiableList(fragmentProfile_);
+        }
+        if (((mutable_bitField0_ & 0x00800000) != 0)) {
+          scannedPlugins_ = scannedPlugins_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -17202,6 +17240,41 @@ public final class UserBitShared {
       return autoLimit_;
     }
 
+    public static final int SCANNED_PLUGINS_FIELD_NUMBER = 24;
+    private com.google.protobuf.LazyStringList scannedPlugins_;
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @return A list containing the scannedPlugins.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getScannedPluginsList() {
+      return scannedPlugins_;
+    }
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @return The count of scannedPlugins.
+     */
+    public int getScannedPluginsCount() {
+      return scannedPlugins_.size();
+    }
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @param index The index of the element to return.
+     * @return The scannedPlugins at the given index.
+     */
+    public java.lang.String getScannedPlugins(int index) {
+      return scannedPlugins_.get(index);
+    }
+    /**
+     * <code>repeated string scanned_plugins = 24;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the scannedPlugins at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getScannedPluginsBytes(int index) {
+      return scannedPlugins_.getByteString(index);
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -17284,6 +17357,9 @@ public final class UserBitShared {
       }
       if (((bitField0_ & 0x00200000) != 0)) {
         output.writeInt32(23, autoLimit_);
+      }
+      for (int i = 0; i < scannedPlugins_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 24, scannedPlugins_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -17375,6 +17451,14 @@ public final class UserBitShared {
       if (((bitField0_ & 0x00200000) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(23, autoLimit_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < scannedPlugins_.size(); i++) {
+          dataSize += computeStringSizeNoTag(scannedPlugins_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getScannedPluginsList().size();
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -17502,6 +17586,8 @@ public final class UserBitShared {
         if (getAutoLimit()
             != other.getAutoLimit()) return false;
       }
+      if (!getScannedPluginsList()
+          .equals(other.getScannedPluginsList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -17609,6 +17695,10 @@ public final class UserBitShared {
       if (hasAutoLimit()) {
         hash = (37 * hash) + AUTOLIMIT_FIELD_NUMBER;
         hash = (53 * hash) + getAutoLimit();
+      }
+      if (getScannedPluginsCount() > 0) {
+        hash = (37 * hash) + SCANNED_PLUGINS_FIELD_NUMBER;
+        hash = (53 * hash) + getScannedPluginsList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -17804,6 +17894,8 @@ public final class UserBitShared {
         bitField0_ = (bitField0_ & ~0x00200000);
         autoLimit_ = 0;
         bitField0_ = (bitField0_ & ~0x00400000);
+        scannedPlugins_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00800000);
         return this;
       }
 
@@ -17937,6 +18029,11 @@ public final class UserBitShared {
           result.autoLimit_ = autoLimit_;
           to_bitField0_ |= 0x00200000;
         }
+        if (((bitField0_ & 0x00800000) != 0)) {
+          scannedPlugins_ = scannedPlugins_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00800000);
+        }
+        result.scannedPlugins_ = scannedPlugins_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -18097,6 +18194,16 @@ public final class UserBitShared {
         }
         if (other.hasAutoLimit()) {
           setAutoLimit(other.getAutoLimit());
+        }
+        if (!other.scannedPlugins_.isEmpty()) {
+          if (scannedPlugins_.isEmpty()) {
+            scannedPlugins_ = other.scannedPlugins_;
+            bitField0_ = (bitField0_ & ~0x00800000);
+          } else {
+            ensureScannedPluginsIsMutable();
+            scannedPlugins_.addAll(other.scannedPlugins_);
+          }
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -19842,6 +19949,115 @@ public final class UserBitShared {
       public Builder clearAutoLimit() {
         bitField0_ = (bitField0_ & ~0x00400000);
         autoLimit_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList scannedPlugins_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureScannedPluginsIsMutable() {
+        if (!((bitField0_ & 0x00800000) != 0)) {
+          scannedPlugins_ = new com.google.protobuf.LazyStringArrayList(scannedPlugins_);
+          bitField0_ |= 0x00800000;
+         }
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @return A list containing the scannedPlugins.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getScannedPluginsList() {
+        return scannedPlugins_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @return The count of scannedPlugins.
+       */
+      public int getScannedPluginsCount() {
+        return scannedPlugins_.size();
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @param index The index of the element to return.
+       * @return The scannedPlugins at the given index.
+       */
+      public java.lang.String getScannedPlugins(int index) {
+        return scannedPlugins_.get(index);
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the scannedPlugins at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getScannedPluginsBytes(int index) {
+        return scannedPlugins_.getByteString(index);
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @param index The index to set the value at.
+       * @param value The scannedPlugins to set.
+       * @return This builder for chaining.
+       */
+      public Builder setScannedPlugins(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureScannedPluginsIsMutable();
+        scannedPlugins_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @param value The scannedPlugins to add.
+       * @return This builder for chaining.
+       */
+      public Builder addScannedPlugins(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureScannedPluginsIsMutable();
+        scannedPlugins_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @param values The scannedPlugins to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllScannedPlugins(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureScannedPluginsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, scannedPlugins_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearScannedPlugins() {
+        scannedPlugins_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00800000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string scanned_plugins = 24;</code>
+       * @param value The bytes of the scannedPlugins to add.
+       * @return This builder for chaining.
+       */
+      public Builder addScannedPluginsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureScannedPluginsIsMutable();
+        scannedPlugins_.add(value);
         onChanged();
         return this;
       }
@@ -28848,7 +29064,7 @@ public final class UserBitShared {
       "ult.QueryState\022\017\n\004user\030\004 \001(\t:\001-\022\'\n\007forem" +
       "an\030\005 \001(\0132\026.exec.DrillbitEndpoint\022\024\n\014opti" +
       "ons_json\030\006 \001(\t\022\022\n\ntotal_cost\030\007 \001(\001\022\025\n\nqu" +
-      "eue_name\030\010 \001(\t:\001-\"\306\004\n\014QueryProfile\022 \n\002id" +
+      "eue_name\030\010 \001(\t:\001-\"\337\004\n\014QueryProfile\022 \n\002id" +
       "\030\001 \001(\0132\024.exec.shared.QueryId\022$\n\004type\030\002 \001" +
       "(\0162\026.exec.shared.QueryType\022\r\n\005start\030\003 \001(" +
       "\003\022\013\n\003end\030\004 \001(\003\022\r\n\005query\030\005 \001(\t\022\014\n\004plan\030\006 " +
@@ -28863,45 +29079,45 @@ public final class UserBitShared {
       " \001(\t\022\017\n\007planEnd\030\022 \001(\003\022\024\n\014queueWaitEnd\030\023 " +
       "\001(\003\022\022\n\ntotal_cost\030\024 \001(\001\022\025\n\nqueue_name\030\025 " +
       "\001(\t:\001-\022\017\n\007queryId\030\026 \001(\t\022\021\n\tautoLimit\030\027 \001" +
-      "(\005\"t\n\024MajorFragmentProfile\022\031\n\021major_frag" +
-      "ment_id\030\001 \001(\005\022A\n\026minor_fragment_profile\030" +
-      "\002 \003(\0132!.exec.shared.MinorFragmentProfile" +
-      "\"\350\002\n\024MinorFragmentProfile\022)\n\005state\030\001 \001(\016" +
-      "2\032.exec.shared.FragmentState\022(\n\005error\030\002 " +
-      "\001(\0132\031.exec.shared.DrillPBError\022\031\n\021minor_" +
-      "fragment_id\030\003 \001(\005\0226\n\020operator_profile\030\004 " +
-      "\003(\0132\034.exec.shared.OperatorProfile\022\022\n\nsta" +
-      "rt_time\030\005 \001(\003\022\020\n\010end_time\030\006 \001(\003\022\023\n\013memor" +
-      "y_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(\003\022(\n" +
-      "\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpoint\022" +
-      "\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progress\030\013 " +
-      "\001(\003\"\237\002\n\017OperatorProfile\0221\n\rinput_profile" +
-      "\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023\n\013op" +
-      "erator_id\030\003 \001(\005\022\031\n\roperator_type\030\004 \001(\005B\002" +
-      "\030\001\022\023\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos" +
-      "\030\006 \001(\003\022#\n\033peak_local_memory_allocated\030\007 " +
-      "\001(\003\022(\n\006metric\030\010 \003(\0132\030.exec.shared.Metric" +
-      "Value\022\022\n\nwait_nanos\030\t \001(\003\022\032\n\022operator_ty" +
-      "pe_name\030\n \001(\t\"B\n\rStreamProfile\022\017\n\007record" +
-      "s\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007schemas\030\003 \001(" +
-      "\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nl" +
-      "ong_value\030\002 \001(\003\022\024\n\014double_value\030\003 \001(\001\")\n" +
-      "\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.shared.Jar" +
-      "\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022function_signat" +
-      "ure\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmechanism\030\001 " +
-      "\001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001(\0162\027.exec" +
-      ".shared.SaslStatus*5\n\nRpcChannel\022\017\n\013BIT_" +
-      "CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\tQue" +
-      "ryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL" +
-      "\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_STATEMENT\020" +
-      "\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000\022\027\n\023AWAI" +
-      "TING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISH" +
-      "ED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCE" +
-      "LLATION_REQUESTED\020\006*g\n\nSaslStatus\022\020\n\014SAS" +
-      "L_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_P" +
-      "ROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAIL" +
-      "ED\020\004B.\n\033org.apache.drill.exec.protoB\rUse" +
-      "rBitSharedH\001"
+      "(\005\022\027\n\017scanned_plugins\030\030 \003(\t\"t\n\024MajorFrag" +
+      "mentProfile\022\031\n\021major_fragment_id\030\001 \001(\005\022A" +
+      "\n\026minor_fragment_profile\030\002 \003(\0132!.exec.sh" +
+      "ared.MinorFragmentProfile\"\350\002\n\024MinorFragm" +
+      "entProfile\022)\n\005state\030\001 \001(\0162\032.exec.shared." +
+      "FragmentState\022(\n\005error\030\002 \001(\0132\031.exec.shar" +
+      "ed.DrillPBError\022\031\n\021minor_fragment_id\030\003 \001" +
+      "(\005\0226\n\020operator_profile\030\004 \003(\0132\034.exec.shar" +
+      "ed.OperatorProfile\022\022\n\nstart_time\030\005 \001(\003\022\020" +
+      "\n\010end_time\030\006 \001(\003\022\023\n\013memory_used\030\007 \001(\003\022\027\n" +
+      "\017max_memory_used\030\010 \001(\003\022(\n\010endpoint\030\t \001(\013" +
+      "2\026.exec.DrillbitEndpoint\022\023\n\013last_update\030" +
+      "\n \001(\003\022\025\n\rlast_progress\030\013 \001(\003\"\237\002\n\017Operato" +
+      "rProfile\0221\n\rinput_profile\030\001 \003(\0132\032.exec.s" +
+      "hared.StreamProfile\022\023\n\013operator_id\030\003 \001(\005" +
+      "\022\031\n\roperator_type\030\004 \001(\005B\002\030\001\022\023\n\013setup_nan" +
+      "os\030\005 \001(\003\022\025\n\rprocess_nanos\030\006 \001(\003\022#\n\033peak_" +
+      "local_memory_allocated\030\007 \001(\003\022(\n\006metric\030\010" +
+      " \003(\0132\030.exec.shared.MetricValue\022\022\n\nwait_n" +
+      "anos\030\t \001(\003\022\032\n\022operator_type_name\030\n \001(\t\"B" +
+      "\n\rStreamProfile\022\017\n\007records\030\001 \001(\003\022\017\n\007batc" +
+      "hes\030\002 \001(\003\022\017\n\007schemas\030\003 \001(\003\"J\n\013MetricValu" +
+      "e\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nlong_value\030\002 \001(\003" +
+      "\022\024\n\014double_value\030\003 \001(\001\")\n\010Registry\022\035\n\003ja" +
+      "r\030\001 \003(\0132\020.exec.shared.Jar\"/\n\003Jar\022\014\n\004name" +
+      "\030\001 \001(\t\022\032\n\022function_signature\030\002 \003(\t\"W\n\013Sa" +
+      "slMessage\022\021\n\tmechanism\030\001 \001(\t\022\014\n\004data\030\002 \001" +
+      "(\014\022\'\n\006status\030\003 \001(\0162\027.exec.shared.SaslSta" +
+      "tus*5\n\nRpcChannel\022\017\n\013BIT_CONTROL\020\000\022\014\n\010BI" +
+      "T_DATA\020\001\022\010\n\004USER\020\002*V\n\tQueryType\022\007\n\003SQL\020\001" +
+      "\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL\020\003\022\r\n\tEXECUTION" +
+      "\020\004\022\026\n\022PREPARED_STATEMENT\020\005*\207\001\n\rFragmentS" +
+      "tate\022\013\n\007SENDING\020\000\022\027\n\023AWAITING_ALLOCATION" +
+      "\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISHED\020\003\022\r\n\tCANCELL" +
+      "ED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCELLATION_REQUEST" +
+      "ED\020\006*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\n" +
+      "SASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014SA" +
+      "SL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.apa" +
+      "che.drill.exec.protoB\rUserBitSharedH\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -28993,7 +29209,7 @@ public final class UserBitShared {
     internal_static_exec_shared_QueryProfile_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_exec_shared_QueryProfile_descriptor,
-        new java.lang.String[] { "Id", "Type", "Start", "End", "Query", "Plan", "Foreman", "State", "TotalFragments", "FinishedFragments", "FragmentProfile", "User", "Error", "VerboseError", "ErrorId", "ErrorNode", "OptionsJson", "PlanEnd", "QueueWaitEnd", "TotalCost", "QueueName", "QueryId", "AutoLimit", });
+        new java.lang.String[] { "Id", "Type", "Start", "End", "Query", "Plan", "Foreman", "State", "TotalFragments", "FinishedFragments", "FragmentProfile", "User", "Error", "VerboseError", "ErrorId", "ErrorNode", "OptionsJson", "PlanEnd", "QueueWaitEnd", "TotalCost", "QueueName", "QueryId", "AutoLimit", "ScannedPlugins", });
     internal_static_exec_shared_MajorFragmentProfile_descriptor =
       getDescriptor().getMessageTypes().get(14);
     internal_static_exec_shared_MajorFragmentProfile_fieldAccessorTable = new

--- a/protocol/src/main/protobuf/UserBitShared.proto
+++ b/protocol/src/main/protobuf/UserBitShared.proto
@@ -256,6 +256,7 @@ message QueryProfile {
   optional string queue_name = 21 [default = "-"];
   optional string queryId = 22;
   optional int32 autoLimit = 23;
+  repeated string scanned_plugins = 24;
 }
 
 message MajorFragmentProfile {


### PR DESCRIPTION
# [DRILL-8322](https://issues.apache.org/jira/browse/DRILL-8322): Add a list of scanned plugin names to the query profile

## Description

A useful piece of information about a query is the set of plugins that it attempted to scan. While some such information is present in the physical plan text in the query profile, an easy to parse, sorted and deduplicated list of plugin names is not. This PR adds such a list.

Query profile fragment including the new scannedPlugins array
```
    "user": "alice",
    "optionsJson": "[ {\n  \"kind\" : \"BOOLEAN\",\n  \"accessibleScopes\" : \"ALL\",\n  \"name\" : \"metastore.enabled\",\n  \"bool_val\" : false,\n  \"scope\" : \"QUERY\"\n} ]",
    "planEnd": 1664464547555,
    "queueWaitEnd": 1664464547555,
    "totalCost": 260,
    "queueName": "Unknown",
    "queryId": "1cca495d-6dcd-4620-8027-0cf056e3b5bc",
    "scannedPlugins": [
        "cp",
        "dfs",
        "sys"
    ]
```

## Documentation
~~Add an entry to https://drill.apache.org/docs/query-profile-column-descriptions/~~

## Testing
View old query profiles from before this change in the web UI.
View new query profiles created after this change in web UI, check scannedPlugins array for

- SELECT against cp
- SELECT against dfs
- CTAS from cp to dfs
- SELECT against cp + dfs + sys

## Notes
I didn't turn up any unit testing of the contents of query profiles when I looked.
I haven't added anything to Profile detail page in the Drill web UI to present the new list of scanned plugins visually.