### PR TITLE
DRILL-8321: Change kafka_2.13 dependency scope to test

### DIFF
--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -81,6 +81,7 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.13</artifactId>
       <version>${kafka.version}</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/MessageIterator.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/MessageIterator.java
@@ -28,13 +28,13 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
 
-import kafka.common.KafkaException;
 
 public class MessageIterator implements Iterator<ConsumerRecord<byte[], byte[]>>, AutoCloseable {
 


### PR DESCRIPTION
# [DRILL-8321](https://issues.apache.org/jira/browse/DRILL-8321): Change kafka_2.13 dependency scope to test 

## Description
Move `org.apache.kafka.kafka_2.13` to test dependency scope. It prevents conflict between Scala versions of `org.apache.kafka.kafka_2.13` (Scala 2.13) and `com.madhukaraphatak.java-sizeof_2.11` (Scala 2.11). Solves such exceptions that could appear during Drill-On-Yarn startup:
```
Caused by: java.util.ServiceConfigurationError: com.fasterxml.jackson.databind.Module: Provider com.fasterxml.jackson.module.scala.DefaultScalaModule could not be instantiated
...
Caused by: java.lang.NoSuchMethodError: 'scala.collection.immutable.Seq$ scala.package$.Seq()'
```

Also, it cleans Drill's classpath from unnecessary dependencies.

Probably `org.apache.kafka.kafka_2.13` was added to compile scope by mistake. 

## Documentation
No changes.

## Testing
Unit tests pass successfully. Tried to connect to Kafka and read a topic - everything works fine.
