### PR TITLE
DRILL-8323: upgrade commons-text to 1.10.0 

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>4.0.2</version>
+      <version>4.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestStringDistanceFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestStringDistanceFunctions.java
@@ -59,7 +59,7 @@ public class TestStringDistanceFunctions extends ClusterTest {
     double result = queryBuilder()
         .sql("select jaccard_distance( 'Big car', 'red car' ) as distance FROM (VALUES(1))")
         .singletonDouble();
-    assertEquals(0.56, result, 0.0);
+    assertEquals(0.5555555555555556, result, 0.0);
   }
 
   @Test
@@ -67,7 +67,7 @@ public class TestStringDistanceFunctions extends ClusterTest {
     double result = queryBuilder()
         .sql("select jaro_distance( 'Big car', 'red car' ) as distance FROM (VALUES(1))")
         .singletonDouble();
-    assertEquals(0.7142857142857143, result, 0.0);
+    assertEquals(0.2857142857142857, result, 0.0);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <maven.min.version>3.6.3</maven.min.version>
     <commons.net.version>3.6</commons.net.version>
     <commons.validator.version>1.6</commons.validator.version>
-    <commons.text.version>1.6</commons.text.version>
+    <commons.text.version>1.10.0</commons.text.version>
     <protobuf.version>3.16.1</protobuf.version>
     <protostuff.version>1.7.1</protostuff.version>
     <codemodel.version>2.6</codemodel.version>


### PR DESCRIPTION
(and excel-streaming-reader that has a transitive dependency on it)

## Description

Some important bugs fixed in latest version

Fixes include https://issues.apache.org/jira/browse/TEXT-191 and this affects one of the Drill tests - I fixed the test to match the new correct result from commons-text 1.10.0