### PR TITLE
DRILL-8324: sizeof refactor

### DIFF
--- a/contrib/storage-opentsdb/pom.xml
+++ b/contrib/storage-opentsdb/pom.xml
@@ -75,11 +75,6 @@
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.madhukaraphatak</groupId>
-            <artifactId>java-sizeof_2.11</artifactId>
-            <version>0.1</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/OpenTSDBGroupScan.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/OpenTSDBGroupScan.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import com.madhukaraphatak.sizeof.SizeEstimator;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
@@ -293,6 +293,8 @@ class SizeEstimator {
       return ((int[]) obj)[index];
     } else if (obj instanceof short[]) {
       return ((short[])obj)[index];
+    } else if (obj instanceof long[]) {
+      return ((long[])obj)[index];
     } else if (obj instanceof boolean[]) {
       return ((boolean[]) obj)[index];
     } else if (obj instanceof float[]) {
@@ -314,6 +316,8 @@ class SizeEstimator {
       return ((int[]) obj).length;
     } else if (obj instanceof short[]) {
       return ((short[])obj).length;
+    } else if (obj instanceof long[]) {
+      return ((long[])obj).length;
     } else if (obj instanceof boolean[]) {
       return ((boolean[]) obj).length;
     } else if (obj instanceof float[]) {

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
@@ -50,7 +50,7 @@ class SizeEstimator {
   private static class SearchState {
 
     private final IdentityHashMap<Object, Object> visited;
-    final LinkedList<Object> stack = new LinkedList<>();
+    private final LinkedList<Object> stack = new LinkedList<>();
     long size = 0L;
 
     SearchState(IdentityHashMap<Object, Object> visited) {
@@ -224,7 +224,7 @@ class SizeEstimator {
         for (Field field : classInfo.pointerFields) {
           try {
             state.enqueue(field.get(obj));
-          } catch (IllegalAccessException e) {
+          } catch (Exception e) {
             //skip this field
           }
         }
@@ -287,6 +287,20 @@ class SizeEstimator {
   private static Object arrayApply(final Object obj, final int index) {
     if (obj instanceof Object[]) {
       return ((Object[])obj)[index];
+    } else if (obj instanceof byte[]) {
+      return ((byte[]) obj)[index];
+    } else if (obj instanceof int[]) {
+      return ((int[]) obj)[index];
+    } else if (obj instanceof short[]) {
+      return ((short[])obj)[index];
+    } else if (obj instanceof boolean[]) {
+      return ((boolean[]) obj)[index];
+    } else if (obj instanceof float[]) {
+      return ((float[]) obj)[index];
+    } else if (obj instanceof double[]) {
+      return ((double[]) obj)[index];
+    } else if (obj instanceof char[]) {
+      return ((char[]) obj)[index];
     }
     throw new IllegalArgumentException("illegal input for arrayApply " + obj);
   }
@@ -294,6 +308,20 @@ class SizeEstimator {
   private static int arrayLength(final Object obj) {
     if (obj instanceof Object[]) {
       return ((Object[])obj).length;
+    } else if (obj instanceof byte[]) {
+      return ((byte[]) obj).length;
+    } else if (obj instanceof int[]) {
+      return ((int[]) obj).length;
+    } else if (obj instanceof short[]) {
+      return ((short[])obj).length;
+    } else if (obj instanceof boolean[]) {
+      return ((boolean[]) obj).length;
+    } else if (obj instanceof float[]) {
+      return ((float[]) obj).length;
+    } else if (obj instanceof double[]) {
+      return ((double[])obj).length;
+    } else if (obj instanceof char[]) {
+      return ((char[]) obj).length;
     }
     throw new IllegalArgumentException("illegal input for arrayLength " + obj);
   }

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Random;
 
 // based on https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+// which itself is based on https://www.infoworld.com/article/2077408/sizeof-for-java.html
 class SizeEstimator {
 
   private static final Logger logger = LoggerFactory.getLogger(SizeEstimator.class);
@@ -270,7 +271,7 @@ class SizeEstimator {
   private static long sampleArray(final Object array, final SearchState state, final Random rand,
                                   final HashSet<Integer> drawn, final int length) {
     long size = 0L;
-    for (int i = 0; i <= ARRAY_SAMPLE_SIZE; i++) {
+    for (int i = 0; i < ARRAY_SAMPLE_SIZE; i++) {
       int index;
       do {
         index = rand.nextInt(length);

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.openTSDB;
+
+import org.apache.drill.exec.store.openTSDB.schema.OpenTSDBSchemaFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MBeanServer;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+
+class SizeEstimator {
+
+  private static final Logger logger = LoggerFactory.getLogger(SizeEstimator.class);
+
+  /**
+   * The state of an ongoing size estimation. Contains a stack of objects to visit as well as an
+   * IdentityHashMap of visited objects, and provides utility methods for enqueueing new objects
+   * to visit.
+   */
+  private static class SearchState {
+
+    private final IdentityHashMap<Object, Object> visited;
+    final LinkedList<Object> stack = new LinkedList<>();
+    long size = 0L;
+
+    SearchState(IdentityHashMap<Object, Object> visited) {
+      this.visited = visited;
+    }
+
+    void enqueue(Object obj) {
+      if (obj != null && !visited.containsKey(obj)) {
+        visited.put(obj, null);
+        stack.add(obj);
+      }
+    }
+
+    boolean isFinished() {
+      return stack.isEmpty();
+    }
+
+    Object dequeue() {
+      Object elem = stack.removeLast();
+      return elem;
+    }
+  }
+
+  /**
+   * Cached information about each class. We remember two things: the "shell size" of the class
+   * (size of all non-static fields plus the java.lang.Object size), and any fields that are
+   * pointers to objects.
+   */
+  private static class ClassInfo {
+    private final long shellSize;
+    private final List<Field> pointerFields;
+
+    ClassInfo(final long shellSize, final List<Field> pointerFields) {
+      this.shellSize = shellSize;
+      this.pointerFields = pointerFields;
+    }
+
+    long getShellSize() {
+      return shellSize;
+    }
+
+    List<Field> getPointerFields() {
+      return pointerFields;
+    }
+  }
+
+  // Sizes of primitive types
+  private static final int BYTE_SIZE    = 1;
+  private static final int BOOLEAN_SIZE = 1;
+  private static final int CHAR_SIZE    = 2;
+  private static final int SHORT_SIZE   = 2;
+  private static final int INT_SIZE     = 4;
+  private static final int LONG_SIZE    = 8;
+  private static final int FLOAT_SIZE   = 4;
+  private static final int DOUBLE_SIZE  = 8;
+
+  // Alignment boundary for objects
+  // TODO: Is this arch dependent ?
+  private static final int ALIGN_SIZE = 8;
+
+  // A cache of ClassInfo objects for each class
+  private static final ConcurrentHashMap<Class<?>, ClassInfo> classInfos = new ConcurrentHashMap<>();
+
+  // Object and pointer sizes are arch dependent
+  private static boolean is64bit = false;
+
+  // Size of an object reference
+  // Based on https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
+  private static boolean isCompressedOops = false;
+  private static int pointerSize = 4;
+
+  // Minimum size of a java.lang.Object
+  private static int objectSize = 8;
+
+  static {
+    // Sets object size, pointer size based on architecture and CompressedOops settings
+    // from the JVM.
+    is64bit = System.getProperty("os.arch").contains("64");
+    isCompressedOops = getIsCompressedOops();
+
+    objectSize = !is64bit ? 8 : (!isCompressedOops ? 16 : 12);
+    pointerSize = (is64bit && !isCompressedOops) ? 8 : 4;
+    classInfos.clear();
+    classInfos.put(Object.class, new ClassInfo(objectSize, Collections.emptyList()));
+  }
+
+  private static boolean getIsCompressedOops() {
+    // This is only used by tests to override the detection of compressed oops. The test
+    // actually uses a system property instead of a SparkConf, so we'll stick with that.
+    if (System.getProperty("spark.test.useCompressedOops") != null) {
+      return Boolean.getBoolean("spark.test.useCompressedOops");
+    }
+
+    try {
+      final String hotSpotMBeanName = "com.sun.management:type=HotSpotDiagnostic";
+      final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+      // NOTE: This should throw an exception in non-Sun JVMs
+      final Class<?> hotSpotMBeanClass = Class.forName("com.sun.management.HotSpotDiagnosticMXBean");
+      final Method getVMMethod = hotSpotMBeanClass.getDeclaredMethod("getVMOption",
+        Class.forName("java.lang.String"));
+
+      final Object bean = ManagementFactory.newPlatformMXBeanProxy(server,
+        hotSpotMBeanName, hotSpotMBeanClass);
+      // TODO: We could use reflection on the VMOption returned ?
+      return getVMMethod.invoke(bean, "UseCompressedOops").toString().contains("true");
+    } catch(Exception e) {
+      // Guess whether they've enabled UseCompressedOops based on whether maxMemory < 32 GB
+      final boolean guess = Runtime.getRuntime().maxMemory() < (32L*1024*1024*1024);
+      logger.warn("Failed to check whether UseCompressedOops is set; assuming {}", guess);
+      return guess;
+    }
+  }
+
+  private long primitiveSize(Class<?> cls) {
+    if (cls == byte.class) {
+      return BYTE_SIZE;
+    } else if (cls == boolean.class) {
+      return BOOLEAN_SIZE;
+    } else if (cls == char.class) {
+      return CHAR_SIZE;
+    } else if (cls == short.class) {
+      return SHORT_SIZE;
+    } else if (cls == int.class) {
+      return INT_SIZE;
+    } else if (cls == long.class) {
+      return LONG_SIZE;
+    } else if (cls == float.class) {
+      return FLOAT_SIZE;
+    } else if (cls == double.class) {
+      return DOUBLE_SIZE;
+    } else {
+      throw new IllegalArgumentException(
+        "Non-primitive class " + cls + " passed to primitiveSize()");
+    }
+  }
+
+  private long alignSize(long size) {
+    final long rem = size % ALIGN_SIZE;
+    return (rem == 0) ? size : (size + ALIGN_SIZE - rem);
+  }
+}

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/SizeEstimator.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.store.openTSDB;
 
-import com.google.common.collect.MapMaker;
+import org.apache.drill.shaded.guava.com.google.common.collect.MapMaker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +69,7 @@ class SizeEstimator {
     }
 
     Object dequeue() {
-      Object elem = stack.removeLast();
-      return elem;
+      return stack.removeLast();
     }
   }
 
@@ -121,11 +120,8 @@ class SizeEstimator {
   private static final Map<Class<?>, ClassInfo> classInfos = new MapMaker().weakKeys().makeMap();
 
   // Object and pointer sizes are arch dependent
-  private static boolean is64bit = false;
+  private static final boolean is64bit;
 
-  // Size of an object reference
-  // Based on https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
-  private static boolean isCompressedOops = false;
   private static int pointerSize = 4;
 
   // Minimum size of a java.lang.Object
@@ -141,7 +137,9 @@ class SizeEstimator {
     // from the JVM.
     final String arch = System.getProperty("os.arch");
     is64bit = arch.contains("64") || arch.contains("s390x");
-    isCompressedOops = getIsCompressedOops();
+    // Size of an object reference
+    // Based on https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
+    final boolean isCompressedOops = getIsCompressedOops();
 
     objectSize = !is64bit ? 8 : (!isCompressedOops ? 16 : 12);
     pointerSize = (is64bit && !isCompressedOops) ? 8 : 4;
@@ -219,7 +217,7 @@ class SizeEstimator {
     } else {
       final Long calculatedSize = knownSize(obj);
       if (calculatedSize != null) {
-        state.size += calculatedSize.longValue();
+        state.size += calculatedSize;
       } else {
         final ClassInfo classInfo = getClassInfo(cls);
         state.size += alignSize(classInfo.shellSize);
@@ -273,7 +271,7 @@ class SizeEstimator {
                                   final HashSet<Integer> drawn, final int length) {
     long size = 0L;
     for (int i = 0; i <= ARRAY_SAMPLE_SIZE; i++) {
-      int index = 0;
+      int index;
       do {
         index = rand.nextInt(length);
       } while (drawn.contains(index));

--- a/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestDataHolder.java
+++ b/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestDataHolder.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.store.openTSDB;
+package org.apache.drill.exec.store.openTSDB;
 
 public class TestDataHolder {
 

--- a/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestOpenTSDBPlugin.java
+++ b/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestOpenTSDBPlugin.java
@@ -15,13 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.store.openTSDB;
+package org.apache.drill.exec.store.openTSDB;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
-import org.apache.drill.exec.store.openTSDB.OpenTSDBStoragePluginConfig;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
@@ -36,20 +35,20 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.apache.drill.store.openTSDB.TestDataHolder.DOWNSAMPLE_REQUEST_WITH_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.DOWNSAMPLE_REQUEST_WTIHOUT_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.END_PARAM_REQUEST_WITH_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.END_PARAM_REQUEST_WTIHOUT_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.POST_REQUEST_WITHOUT_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.POST_REQUEST_WITH_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.REQUEST_TO_NONEXISTENT_METRIC;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_GET_TABLE_NAME_REQUEST;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_GET_TABLE_REQUEST;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_DOWNSAMPLE_REQUEST_WITHOUT_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_DOWNSAMPLE_REQUEST_WITH_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_END_REQUEST_WITHOUT_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_END_REQUEST_WITH_TAGS;
-import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_REQUEST_WITH_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.DOWNSAMPLE_REQUEST_WITH_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.DOWNSAMPLE_REQUEST_WTIHOUT_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.END_PARAM_REQUEST_WITH_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.END_PARAM_REQUEST_WTIHOUT_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.POST_REQUEST_WITHOUT_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.POST_REQUEST_WITH_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.REQUEST_TO_NONEXISTENT_METRIC;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_GET_TABLE_NAME_REQUEST;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_GET_TABLE_REQUEST;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_DOWNSAMPLE_REQUEST_WITHOUT_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_DOWNSAMPLE_REQUEST_WITH_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_END_REQUEST_WITHOUT_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_END_REQUEST_WITH_TAGS;
+import static org.apache.drill.exec.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_REQUEST_WITH_TAGS;
 import static org.junit.Assert.assertEquals;
 
 public class TestOpenTSDBPlugin extends ClusterTest {

--- a/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestSizeEstimator.java
+++ b/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestSizeEstimator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.openTSDB;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class TestSizeEstimator {
+
+  private static class TestMetricDTO {
+    private final String metric;
+    private final Map<String, String> tags;
+    private final List<String> aggregateTags;
+    private final Map<String, String> dps;
+
+    TestMetricDTO(String metric, Map<String, String> tags, List<String> aggregateTags, Map<String, String> dps) {
+      this.metric = metric;
+      this.tags = tags;
+      this.aggregateTags = aggregateTags;
+      this.dps = dps;
+    }
+  }
+
+  @Test
+  public void testMetricDTO() {
+    Map<String, String> tags = new HashMap<>();
+    Map<String, String> dps = new HashMap<>();
+    tags.put("t1", "v1");
+    dps.put("dp1", "dpv1");
+    List<String> aggregateTags = new ArrayList<>();
+    TestMetricDTO dto = new TestMetricDTO("metric1", tags, aggregateTags, dps);
+    long size = SizeEstimator.estimate(dto);
+    assertTrue(size > 500);
+    assertTrue(size < 1000);
+  }
+}

--- a/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestSizeEstimator.java
+++ b/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestSizeEstimator.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestSizeEstimator {
@@ -54,4 +55,20 @@ public class TestSizeEstimator {
     assertTrue(size > 500);
     assertTrue(size < 1000);
   }
+
+  @Test
+  public void testArrays() {
+    assertEquals(32, SizeEstimator.estimate(new byte[10]));
+    assertEquals(40, SizeEstimator.estimate(new char[10]));
+    assertEquals(40, SizeEstimator.estimate(new short[10]));
+    assertEquals(56, SizeEstimator.estimate(new int[10]));
+    assertEquals(96, SizeEstimator.estimate(new long[10]));
+    assertEquals(56, SizeEstimator.estimate(new float[10]));
+    assertEquals(96, SizeEstimator.estimate(new double[10]));
+    assertEquals(4016, SizeEstimator.estimate(new int[1000]));
+    assertEquals(8016, SizeEstimator.estimate(new long[1000]));
+    assertEquals(56, SizeEstimator.estimate(new String[10]));
+    assertEquals(56, SizeEstimator.estimate(new Object[10]));
+  }
+
 }

--- a/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestSizeEstimator.java
+++ b/contrib/storage-opentsdb/src/test/java/org/apache/drill/exec/store/openTSDB/TestSizeEstimator.java
@@ -44,19 +44,6 @@ public class TestSizeEstimator {
   }
 
   @Test
-  public void testMetricDTO() {
-    Map<String, String> tags = new HashMap<>();
-    Map<String, String> dps = new HashMap<>();
-    tags.put("t1", "v1");
-    dps.put("dp1", "dpv1");
-    List<String> aggregateTags = new ArrayList<>();
-    TestMetricDTO dto = new TestMetricDTO("metric1", tags, aggregateTags, dps);
-    long size = SizeEstimator.estimate(dto);
-    assertTrue(size > 500);
-    assertTrue(size < 1000);
-  }
-
-  @Test
   public void testArrays() {
     assertEquals(32, SizeEstimator.estimate(new byte[10]));
     assertEquals(40, SizeEstimator.estimate(new char[10]));
@@ -69,6 +56,32 @@ public class TestSizeEstimator {
     assertEquals(8016, SizeEstimator.estimate(new long[1000]));
     assertEquals(56, SizeEstimator.estimate(new String[10]));
     assertEquals(56, SizeEstimator.estimate(new Object[10]));
+  }
+
+  @Test
+  public void testList() {
+    ArrayList<Long> list = new ArrayList<>();
+    for(int i = 0; i < 10; i++) {
+      list.add(Long.valueOf(i));
+    }
+    assertEquals(320, SizeEstimator.estimate(list));
+    for(int i = 0; i < 10; i++) {
+      list.add(Long.valueOf(i));
+    }
+    assertEquals(368, SizeEstimator.estimate(list));
+  }
+
+  @Test
+  public void testMetricDTO() {
+    Map<String, String> tags = new HashMap<>();
+    Map<String, String> dps = new HashMap<>();
+    tags.put("t1", "v1");
+    dps.put("dp1", "dpv1");
+    List<String> aggregateTags = new ArrayList<>();
+    TestMetricDTO dto = new TestMetricDTO("metric1", tags, aggregateTags, dps);
+    long size = SizeEstimator.estimate(dto);
+    assertTrue("size less then expected: " + size, size > 550);
+    assertTrue("size greater then expected: " + size, size < 800);
   }
 
 }


### PR DESCRIPTION
## Description

Remove use of java-sizeof jar. It is an old copy of Spark code. I have ported the latest Spark code to Java and inlined it.

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
