### PR TITLE
DRILL-8328: HTTP UDF Not Resolving Storage Aliases

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -126,6 +126,9 @@ public class HttpHelperFunctions {
     DrillbitContext drillbitContext;
 
     @Inject
+    org.apache.drill.exec.ops.ContextInformation contextInformation;
+
+    @Inject
     ResultSetLoader rsLoader;
 
     @Workspace
@@ -153,12 +156,12 @@ public class HttpHelperFunctions {
       String pluginName = parts[0], endpointName = parts[1];
 
       plugin = org.apache.drill.exec.store.http.util.SimpleHttp.getStoragePlugin(
-        drillbitContext,
+        drillbitContext, contextInformation,
         pluginName
       );
 
       endpointConfig = org.apache.drill.exec.store.http.util.SimpleHttp.getEndpointConfig(
-        endpointName,
+        endpointName, drillbitContext, contextInformation,
         plugin.getConfig()
       );
       stream = new org.apache.drill.exec.store.easy.json.loader.SingleElementIterator<>();

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -155,13 +155,10 @@ public class HttpHelperFunctions {
       }
       String pluginName = parts[0], endpointName = parts[1];
 
-      plugin = org.apache.drill.exec.store.http.util.SimpleHttp.getStoragePlugin(
-        drillbitContext, contextInformation,
-        pluginName
-      );
+      plugin = org.apache.drill.exec.store.http.util.SimpleHttp.getStoragePlugin(pluginName, drillbitContext);
 
       endpointConfig = org.apache.drill.exec.store.http.util.SimpleHttp.getEndpointConfig(
-        endpointName, drillbitContext, contextInformation,
+        endpointName,
         plugin.getConfig()
       );
       stream = new org.apache.drill.exec.store.easy.json.loader.SingleElementIterator<>();

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpHelperFunctions.java
@@ -126,9 +126,6 @@ public class HttpHelperFunctions {
     DrillbitContext drillbitContext;
 
     @Inject
-    org.apache.drill.exec.ops.ContextInformation contextInformation;
-
-    @Inject
     ResultSetLoader rsLoader;
 
     @Workspace

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers;
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.oauth.PersistentTokenTable;
-import org.apache.drill.exec.ops.ContextInformation;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -837,8 +836,6 @@ public class SimpleHttp implements AutoCloseable {
    * This function is used to obtain the configuration information for a given API in the HTTP UDF.
    * If aliasing is enabled, this function will resolve aliases for connections.
    * @param endpoint The name of the endpoint.  Should be a {@link String}
-   * @param context The {@link DrillbitContext} from the current query.
-   * @param info {@link ContextInformation} from the current query.
    * @param pluginConfig The {@link HttpStoragePluginConfig} the configuration from the plugin
    * @return The {@link HttpApiConfig} corresponding with the endpoint.
    */
@@ -886,23 +883,6 @@ public class SimpleHttp implements AutoCloseable {
         .message("Could not access plugin " + pluginName)
         .build(logger);
     }
-  }
-
-  public static String addBackTicksToAliasName(String plugin, String identifier) {
-    plugin = plugin.trim();
-    if (! plugin.startsWith(identifier)) {
-      plugin = identifier + plugin;
-    }
-    if (! plugin.endsWith(identifier)) {
-      plugin = plugin + identifier;
-    }
-    return plugin;
-  }
-
-  public static String removeBackTicksFromPluginName(String plugin, String identifier) {
-    plugin = plugin.trim();
-    plugin = plugin.replaceAll(identifier, "");
-    return plugin;
   }
 
   /**

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
@@ -63,14 +63,12 @@ public class TestHttpUDFWithAliases extends ClusterTest {
   private static AliasRegistry storageAliasesRegistry;
   private static AliasRegistry tableAliasesRegistry;
   private static final int MOCK_SERVER_PORT = 47778;
-  private static String TEST_JSON_RESPONSE;
   private static String TEST_JSON_PAGE1;
-  private static String DUMMY_URL = "http://localhost:" + MOCK_SERVER_PORT;
+  private static final String DUMMY_URL = "http://localhost:" + MOCK_SERVER_PORT;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
 
-    TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/simple.json"), Charsets.UTF_8).read();
     TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
 
     cluster = ClusterFixture.bareBuilder(dirTestWatcher)

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.http;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.common.logical.StoragePluginConfig.AuthMode;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.util.DrillFileUtils;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
+import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+import org.apache.drill.shaded.guava.com.google.common.io.Files;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_GROUP;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.PROCESS_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_2_PASSWORD;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleMap;
+import static org.junit.Assert.assertEquals;
+
+public class TestHttpUDFWithAliases extends ClusterTest {
+
+  private static AliasRegistry storageAliasesRegistry;
+  private static AliasRegistry tableAliasesRegistry;
+  private static final int MOCK_SERVER_PORT = 47778;
+  private static String TEST_JSON_RESPONSE;
+  private static String TEST_JSON_PAGE1;
+  private static String DUMMY_URL = "http://localhost:" + MOCK_SERVER_PORT;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+
+    TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/simple.json"), Charsets.UTF_8).read();
+    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
+
+    cluster = ClusterFixture.bareBuilder(dirTestWatcher)
+      .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)
+      .configProperty(ExecConstants.IMPERSONATION_ENABLED, true)
+      .configProperty(ExecConstants.USER_AUTHENTICATOR_IMPL, UserAuthenticatorTestImpl.TYPE)
+      .configProperty(DrillProperties.USER, PROCESS_USER)
+      .configProperty(DrillProperties.PASSWORD, PROCESS_USER_PASSWORD)
+      .build();
+
+    ClientFixture admin = cluster.clientBuilder()
+      .property(DrillProperties.USER, PROCESS_USER)
+      .property(DrillProperties.PASSWORD, PROCESS_USER_PASSWORD)
+      .build();
+
+    admin.alterSystem(ExecConstants.ADMIN_USERS_KEY, ADMIN_USER + "," + PROCESS_USER);
+    admin.alterSystem(ExecConstants.ADMIN_USER_GROUPS_KEY, ADMIN_GROUP);
+
+    client = cluster.clientBuilder()
+      .property(DrillProperties.USER, ADMIN_USER)
+      .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+      .build();
+    storageAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getStorageAliasesRegistry();
+    tableAliasesRegistry = cluster.drillbit().getContext().getAliasRegistryProvider().getTableAliasesRegistry();
+
+    TupleMetadata simpleSchema = new SchemaBuilder()
+      .addNullable("col_1", MinorType.FLOAT8)
+      .addNullable("col_2", MinorType.FLOAT8)
+      .addNullable("col_3", MinorType.FLOAT8)
+      .build();
+
+    HttpJsonOptions jsonOptions = new HttpJsonOptions.HttpJsonOptionsBuilder()
+      .schema(simpleSchema)
+      .build();
+
+    HttpApiConfig basicJson = HttpApiConfig.builder()
+      .url(String.format("%s/json", DUMMY_URL))
+      .method("get")
+      .jsonOptions(jsonOptions)
+      .requireTail(false)
+      .inputType("json")
+      .build();
+
+    Map<String, HttpApiConfig> configs = new HashMap<>();
+    configs.put("basicJson", basicJson);
+
+    HttpStoragePluginConfig mockStorageConfigWithWorkspace =
+      new HttpStoragePluginConfig(false, configs, 200, "globaluser", "globalpass", "",
+        80, "", "", "", null, new PlainCredentialsProvider(ImmutableMap.of(
+        UsernamePasswordCredentials.USERNAME, "globaluser",
+        UsernamePasswordCredentials.PASSWORD, "globalpass")), AuthMode.SHARED_USER.name());
+    mockStorageConfigWithWorkspace.setEnabled(true);
+    cluster.defineStoragePlugin("local", mockStorageConfigWithWorkspace);
+  }
+
+  @Test
+  public void testSeveralRowsAndRequestsAndPublicStorageAlias() throws Exception {
+    storageAliasesRegistry.createPublicAliases();
+    storageAliasesRegistry.getPublicAliases().put("`foobar`", "`local`", false);
+
+    String sql = "SELECT http_request('foobar.basicJson', `col1`) as data FROM cp.`/data/p4.json`";
+    try (MockWebServer server = startServer()) {
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+
+      RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+      assertEquals(2, results.rowCount());
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("data")
+        .addNullable("col_1", MinorType.FLOAT8)
+        .addNullable("col_2", MinorType.FLOAT8)
+        .addNullable("col_3", MinorType.FLOAT8)
+        .resumeSchema()
+        .build();
+
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+        .addRow(singleMap(mapValue(1.0, 2.0, 3.0)))
+        .addRow(singleMap(mapValue(4.0, 5.0, 6.0)))
+        .build();
+
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      storageAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testSeveralRowsAndRequestsAndUserStorageAlias() throws Exception {
+    String sql = "SELECT http_request('foobar.basicJson', `col1`) as data FROM cp.`/data/p4.json`";
+    try (MockWebServer server = startServer()) {
+
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      storageAliasesRegistry.createUserAliases(TEST_USER_2);
+      storageAliasesRegistry.getUserAliases(TEST_USER_2).put("`foobar`", "`local`", false);
+
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+
+      RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+      assertEquals(2, results.rowCount());
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("data")
+        .addNullable("col_1", MinorType.FLOAT8)
+        .addNullable("col_2", MinorType.FLOAT8)
+        .addNullable("col_3", MinorType.FLOAT8)
+        .resumeSchema()
+        .build();
+
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+        .addRow(singleMap(mapValue(1.0, 2.0, 3.0)))
+        .addRow(singleMap(mapValue(4.0, 5.0, 6.0)))
+        .build();
+
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      storageAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  @Test
+  public void testSeveralRowsAndRequestsAndPublicTableAlias() throws Exception {
+    tableAliasesRegistry.createPublicAliases();
+    tableAliasesRegistry.getPublicAliases().put("`foobar`", "`basicJson`", false);
+
+    String sql = "SELECT http_request('local.foobar', `col1`) as data FROM cp.`/data/p4.json`";
+    try (MockWebServer server = startServer()) {
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+
+      RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+      assertEquals(2, results.rowCount());
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("data")
+        .addNullable("col_1", MinorType.FLOAT8)
+        .addNullable("col_2", MinorType.FLOAT8)
+        .addNullable("col_3", MinorType.FLOAT8)
+        .resumeSchema()
+        .build();
+
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+        .addRow(singleMap(mapValue(1.0, 2.0, 3.0)))
+        .addRow(singleMap(mapValue(4.0, 5.0, 6.0)))
+        .build();
+
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      tableAliasesRegistry.deletePublicAliases();
+    }
+  }
+
+  @Test
+  public void testSeveralRowsAndRequestsAndUserTableAlias() throws Exception {
+    String sql = "SELECT http_request('local.foobar', `col1`) as data FROM cp.`/data/p4.json`";
+    try (MockWebServer server = startServer()) {
+
+      ClientFixture client = cluster.clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_2)
+        .property(DrillProperties.PASSWORD, TEST_USER_2_PASSWORD)
+        .build();
+
+      tableAliasesRegistry.createUserAliases(TEST_USER_2);
+      tableAliasesRegistry.getUserAliases(TEST_USER_2).put("`foobar`", "`basicJson`", false);
+
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+      server.enqueue(new MockResponse().setResponseCode(200).setBody(TEST_JSON_PAGE1));
+
+      RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+      assertEquals(2, results.rowCount());
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("data")
+        .addNullable("col_1", MinorType.FLOAT8)
+        .addNullable("col_2", MinorType.FLOAT8)
+        .addNullable("col_3", MinorType.FLOAT8)
+        .resumeSchema()
+        .build();
+
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+        .addRow(singleMap(mapValue(1.0, 2.0, 3.0)))
+        .addRow(singleMap(mapValue(4.0, 5.0, 6.0)))
+        .build();
+
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      tableAliasesRegistry.deleteUserAliases(TEST_USER_2);
+    }
+  }
+
+  public static MockWebServer startServer() throws IOException {
+    MockWebServer server = new MockWebServer();
+    server.start(MOCK_SERVER_PORT);
+    return server;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -102,7 +102,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     this.skipProfileWrite = false;
     queryOptions = new QueryOptionManager(session.getOptions());
     executionControls = new ExecutionControls(queryOptions, drillbitContext.getEndpoint());
-    plannerSettings = new PlannerSettings(queryOptions, getFunctionRegistry(), this);
+    plannerSettings = new PlannerSettings(queryOptions, getFunctionRegistry(), session.getCredentials().getUserName(), drillbitContext.getAliasRegistryProvider());
     plannerSettings.setNumEndPoints(drillbitContext.getBits().size());
 
     // If we do not need to support dynamic UDFs for this query, just use static operator table

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -102,7 +102,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     this.skipProfileWrite = false;
     queryOptions = new QueryOptionManager(session.getOptions());
     executionControls = new ExecutionControls(queryOptions, drillbitContext.getEndpoint());
-    plannerSettings = new PlannerSettings(queryOptions, getFunctionRegistry());
+    plannerSettings = new PlannerSettings(queryOptions, getFunctionRegistry(), this);
     plannerSettings.setNumEndPoints(drillbitContext.getBits().size());
 
     // If we do not need to support dynamic UDFs for this query, just use static operator table

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -767,7 +767,7 @@ public class DrillOptiq {
 
       return FunctionCallFactory.createExpression(functionName, args);
     }
-    
+
     private LogicalExpression handleDateTruncFunction(final List<LogicalExpression> args) {
       // Assert that the first argument to extract is a QuotedString
       assert args.get(0) instanceof ValueExpressions.QuotedString;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -767,6 +767,7 @@ public class DrillOptiq {
 
       return FunctionCallFactory.createExpression(functionName, args);
     }
+    
     private LogicalExpression handleDateTruncFunction(final List<LogicalExpression> args) {
       // Assert that the first argument to extract is a QuotedString
       assert args.get(0) instanceof ValueExpressions.QuotedString;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -50,6 +50,8 @@ import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.alias.AliasRegistry;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.planner.StarColumnHelper;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -713,9 +715,87 @@ public class DrillOptiq {
         case "date_trunc": {
           return handleDateTruncFunction(args);
         }
+        case "httprequest":
+        case "http_request": {
+          final String QUOTING_IDENTIFIER = context.getPlannerSettings().getOptions().getOption(PlannerSettings.QUOTING_IDENTIFIERS_KEY).string_val;
+
+          // This code resolves aliases in the http_request function.
+          String completeRawPluginName = ((QuotedString) args.get(0)).value;
+          String username = context.getPlannerSettings().getQueryContext().getQueryUserName();
+          AliasRegistryProvider aliasRegistryProvider = context.getPlannerSettings().getQueryContext().getAliasRegistryProvider();
+          AliasRegistry storageAliasRegistry = aliasRegistryProvider.getStorageAliasesRegistry();
+          AliasRegistry tableAliasRegistry = aliasRegistryProvider.getTableAliasesRegistry();
+
+          // Split into plugin and endpoint
+          String[] parts = completeRawPluginName.split("\\.");
+          if (parts.length < 2) {
+            throw new org.apache.drill.common.exceptions.DrillRuntimeException(
+              "You must call this function with a connection name and endpoint."
+            );
+          }
+
+          String rawPluginName = addBackTicksToAliasName(parts[0], QUOTING_IDENTIFIER);
+          String rawEndpoint = addBackTicksToAliasName(parts[1], QUOTING_IDENTIFIER);
+
+
+          // Now resolve plugin name
+          String actualPluginName = storageAliasRegistry.getUserAliases(username).get(rawPluginName);
+          if (StringUtils.isEmpty(actualPluginName)) {
+            // Now check if there is a public alias for the plugin
+            actualPluginName = storageAliasRegistry.getPublicAliases().get(rawPluginName);
+            // If it is still empty, assign it the original name,
+            if (StringUtils.isEmpty(actualPluginName)) {
+              actualPluginName = rawPluginName;
+            }
+          }
+
+          // Finally remove backticks
+          actualPluginName = removeBackTicksFromPluginName(actualPluginName, QUOTING_IDENTIFIER);
+
+          // Now do the same for the endpoint name
+          String actualEndpointName = tableAliasRegistry.getUserAliases(username).get(rawEndpoint);
+          if (StringUtils.isEmpty(actualEndpointName)) {
+            // Now check if there is a public alias for the plugin
+            actualEndpointName = tableAliasRegistry.getPublicAliases().get(rawEndpoint);
+            // If it is still empty, assign it the original name,
+            if (StringUtils.isEmpty(actualEndpointName)) {
+              actualEndpointName = rawEndpoint;
+            }
+          }
+
+          // Now remove backticks
+          actualEndpointName = removeBackTicksFromPluginName(actualEndpointName, QUOTING_IDENTIFIER);
+
+          String finalPluginName = actualPluginName + "." + actualEndpointName;
+          QuotedString q = new QuotedString(finalPluginName, finalPluginName.length(), ExpressionPosition.UNKNOWN);
+
+          // Add args to new arg lists
+          List<LogicalExpression> requestArgs = new ArrayList<>();
+          requestArgs.add(q);
+          requestArgs.addAll(args.subList(1, args.size()));
+
+          return FunctionCallFactory.createExpression(functionName, requestArgs);
+        }
       }
 
       return FunctionCallFactory.createExpression(functionName, args);
+    }
+
+    public static String addBackTicksToAliasName(String plugin, String identifier) {
+      plugin = plugin.trim();
+      if (! plugin.startsWith(identifier)) {
+        plugin = identifier + plugin;
+      }
+      if (! plugin.endsWith(identifier)) {
+        plugin = plugin + identifier;
+      }
+      return plugin;
+    }
+
+    public static String removeBackTicksFromPluginName(String plugin, String identifier) {
+      plugin = plugin.trim();
+      plugin = plugin.replaceAll(identifier, "");
+      return plugin;
     }
 
     private LogicalExpression handleDateTruncFunction(final List<LogicalExpression> args) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -767,24 +767,7 @@ public class DrillOptiq {
 
       return FunctionCallFactory.createExpression(functionName, args);
     }
-
-    public static String addBackTicksToAliasName(String plugin, String identifier) {
-      plugin = plugin.trim();
-      if (! plugin.startsWith(identifier)) {
-        plugin = identifier + plugin;
-      }
-      if (! plugin.endsWith(identifier)) {
-        plugin = plugin + identifier;
-      }
-      return plugin;
-    }
-
-    public static String removeBackTicksFromPluginName(String plugin, String identifier) {
-      plugin = plugin.trim();
-      plugin = plugin.replaceAll(identifier, "");
-      return plugin;
-    }
-
+    
     private LogicalExpression handleDateTruncFunction(final List<LogicalExpression> args) {
       // Assert that the first argument to extract is a QuotedString
       assert args.get(0) instanceof ValueExpressions.QuotedString;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -767,7 +767,6 @@ public class DrillOptiq {
 
       return FunctionCallFactory.createExpression(functionName, args);
     }
-    
     private LogicalExpression handleDateTruncFunction(final List<LogicalExpression> args) {
       // Assert that the first argument to extract is a QuotedString
       assert args.get(0) instanceof ValueExpressions.QuotedString;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -21,6 +21,7 @@ import org.apache.calcite.avatica.util.Quoting;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValidator;
 import org.apache.drill.exec.server.options.OptionValidator.OptionDescription;
@@ -242,10 +243,17 @@ public class PlannerSettings implements Context{
 
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
+  public QueryContext queryContext = null;
 
-  public PlannerSettings(OptionManager options, FunctionImplementationRegistry functionImplementationRegistry){
+  @Override
+  public boolean equals(Object obj) {
+    return super.equals(obj);
+  }
+
+  public PlannerSettings(OptionManager options, FunctionImplementationRegistry functionImplementationRegistry, QueryContext queryContext){
     this.options = options;
     this.functionImplementationRegistry = functionImplementationRegistry;
+    this.queryContext = queryContext;
   }
 
   public OptionManager getOptions() {
@@ -372,6 +380,9 @@ public class PlannerSettings implements Context{
 
   public long getPlanningMemoryLimit() {
     return options.getOption(PLANNER_MEMORY_LIMIT.getOptionName()).num_val;
+  }
+  public QueryContext getQueryContext() {
+    return this.queryContext;
   }
 
   public static long getInitialPlanningMemorySize() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -22,7 +22,6 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValidator;
 import org.apache.drill.exec.server.options.OptionValidator.OptionDescription;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -243,8 +243,8 @@ public class PlannerSettings implements Context{
 
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
-  private final String queryUser;
-  private final AliasRegistryProvider aliasRegistryProvider;
+  public String queryUser = null;
+  public AliasRegistryProvider aliasRegistryProvider = null;
 
 
   public PlannerSettings(OptionManager options,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -243,8 +243,8 @@ public class PlannerSettings implements Context{
 
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
-  public String queryUser = null;
-  public AliasRegistryProvider aliasRegistryProvider = null;
+  private final String queryUser;
+  private final AliasRegistryProvider aliasRegistryProvider;
 
 
   public PlannerSettings(OptionManager options,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.planner.physical;
 import org.apache.calcite.avatica.util.Quoting;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.server.options.OptionManager;
@@ -243,17 +244,18 @@ public class PlannerSettings implements Context{
 
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
-  public QueryContext queryContext = null;
+  private final String queryUser;
+  private final AliasRegistryProvider aliasRegistryProvider;
 
-  @Override
-  public boolean equals(Object obj) {
-    return super.equals(obj);
-  }
 
-  public PlannerSettings(OptionManager options, FunctionImplementationRegistry functionImplementationRegistry, QueryContext queryContext){
+  public PlannerSettings(OptionManager options,
+                         FunctionImplementationRegistry functionImplementationRegistry,
+                         String queryUser,
+                         AliasRegistryProvider aliasRegistryProvider){
     this.options = options;
     this.functionImplementationRegistry = functionImplementationRegistry;
-    this.queryContext = queryContext;
+    this.queryUser = queryUser;
+    this.aliasRegistryProvider = aliasRegistryProvider;
   }
 
   public OptionManager getOptions() {
@@ -381,8 +383,12 @@ public class PlannerSettings implements Context{
   public long getPlanningMemoryLimit() {
     return options.getOption(PLANNER_MEMORY_LIMIT.getOptionName()).num_val;
   }
-  public QueryContext getQueryContext() {
-    return this.queryContext;
+  public String getQueryUser() {
+    return this.queryUser;
+  }
+
+  public AliasRegistryProvider getAliasRegistryProvider() {
+    return this.aliasRegistryProvider;
   }
 
   public static long getInitialPlanningMemorySize() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
@@ -121,7 +121,7 @@ public class ServerMetaProvider {
       final GetServerMetaResp.Builder respBuilder = GetServerMetaResp.newBuilder();
       try {
         final ServerMeta.Builder metaBuilder = ServerMeta.newBuilder(DEFAULT);
-        PlannerSettings plannerSettings = new PlannerSettings(session.getOptions(), context.getFunctionImplementationRegistry());
+        PlannerSettings plannerSettings = new PlannerSettings(session.getOptions(), context.getFunctionImplementationRegistry(), null);
 
         SqlParser.Config config = SqlParser.Config.DEFAULT
           .withIdentifierMaxLength((int) plannerSettings.getIdentifierMaxLength())

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
@@ -121,7 +121,7 @@ public class ServerMetaProvider {
       final GetServerMetaResp.Builder respBuilder = GetServerMetaResp.newBuilder();
       try {
         final ServerMeta.Builder metaBuilder = ServerMeta.newBuilder(DEFAULT);
-        PlannerSettings plannerSettings = new PlannerSettings(session.getOptions(), context.getFunctionImplementationRegistry(), null);
+        PlannerSettings plannerSettings = new PlannerSettings(session.getOptions(), context.getFunctionImplementationRegistry(), session.getCredentials().getUserName(), context.getAliasRegistryProvider());
 
         SqlParser.Config config = SqlParser.Config.DEFAULT
           .withIdentifierMaxLength((int) plannerSettings.getIdentifierMaxLength())

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -119,7 +119,7 @@ public class PlanningBase extends ExecTest {
         UserSession.Builder.newBuilder().withOptionManager(sessionOptions).setSupportComplexTypes(true).build());
     when(context.getCurrentEndpoint()).thenReturn(DrillbitEndpoint.getDefaultInstance());
     when(context.getActiveEndpoints()).thenReturn(ImmutableList.of(DrillbitEndpoint.getDefaultInstance()));
-    when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry, context));
+    when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry, context.getQueryUserName(), context.getAliasRegistryProvider()));
     when(context.getOptions()).thenReturn(queryOptions);
     when(context.getConfig()).thenReturn(config);
     when(context.getDrillOperatorTable()).thenReturn(table);

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -119,7 +119,7 @@ public class PlanningBase extends ExecTest {
         UserSession.Builder.newBuilder().withOptionManager(sessionOptions).setSupportComplexTypes(true).build());
     when(context.getCurrentEndpoint()).thenReturn(DrillbitEndpoint.getDefaultInstance());
     when(context.getActiveEndpoints()).thenReturn(ImmutableList.of(DrillbitEndpoint.getDefaultInstance()));
-    when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry, context.getQueryUserName(), context.getAliasRegistryProvider()));
+    when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry, null, null));
     when(context.getOptions()).thenReturn(queryOptions);
     when(context.getConfig()).thenReturn(config);
     when(context.getDrillOperatorTable()).thenReturn(table);

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -119,7 +119,7 @@ public class PlanningBase extends ExecTest {
         UserSession.Builder.newBuilder().withOptionManager(sessionOptions).setSupportComplexTypes(true).build());
     when(context.getCurrentEndpoint()).thenReturn(DrillbitEndpoint.getDefaultInstance());
     when(context.getActiveEndpoints()).thenReturn(ImmutableList.of(DrillbitEndpoint.getDefaultInstance()));
-    when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry));
+    when(context.getPlannerSettings()).thenReturn(new PlannerSettings(queryOptions, functionRegistry, context));
     when(context.getOptions()).thenReturn(queryOptions);
     when(context.getConfig()).thenReturn(config);
     when(context.getDrillOperatorTable()).thenReturn(table);


### PR DESCRIPTION
# [DRILL-8328](https://issues.apache.org/jira/browse/DRILL-8328): HTTP UDF Not Resolving Storage Aliases

## Description
This PR fixes a bug with the `http_request` UDF.    Previously, the UDF was not resolving aliases.  This PR fixes that and allows the UDF to resolve aliases if enabled.  It maintains the priority of user alias over public alias. 

## Documentation
No user facing documentation needed.

## Testing
Added unit tests.  