### PR TITLE
DRILL-8329: Close HTTP Caching Resources

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -165,9 +165,12 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
       // Paranoia: ensure stream is closed if anything goes wrong.
       // After this, the JSON loader will close the stream.
       AutoCloseables.closeSilently(inStream);
+      AutoCloseables.closeSilently(http);
       throw t;
     }
 
+    // Close the http client
+    http.close();
     return true;
   }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
@@ -126,6 +126,8 @@ public class HttpCSVBatchReader extends HttpBatchReader {
     rowWriter = resultLoader.writer();
     populateWriterArray();
 
+    // Close cache resources
+    http.close();
     return true;
   }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
@@ -115,6 +115,9 @@ public class HttpXMLBatchReader extends HttpBatchReader {
         .addContext(errorContext)
         .build(logger);
     }
+
+    // Close cache resources
+    http.close();
     return true;
   }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -98,7 +98,7 @@ import java.util.stream.Collectors;
  * method is the getInputStream() method which accepts a url and opens an
  * InputStream with that URL's contents.
  */
-public class SimpleHttp {
+public class SimpleHttp implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(SimpleHttp.class);
   private static final int DEFAULT_TIMEOUT = 1;
   private static final Pattern URL_PARAM_REGEX = Pattern.compile("\\{(\\w+)(?:=(\\w*))?}");
@@ -969,6 +969,19 @@ public class SimpleHttp {
     // Execute the request
     Response response = client.newCall(request).execute();
     return response.body();
+  }
+
+  @Override
+  public void close() {
+    Cache cache;
+    try {
+      cache = client.cache();
+      if (cache != null) {
+        cache.close();
+      }
+    } catch (IOException e) {
+      logger.warn("Error closing cache. {}", e.getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
# [DRILL-8329](https://issues.apache.org/jira/browse/DRILL-8329): Close HTTP Caching Resources


## Description
The HTTP plugin has the ability to cache API responses.  However, the storage plugin was not closing the connection to the file cache.  This minor PR fixes that. 

## Documentation
No user facing changes.

## Testing
Ran existing unit tests.