### PR TITLE
DRILL-8330:  Convert ESRI Shape File Reader to EVF2

### DIFF
--- a/contrib/format-esri/pom.xml
+++ b/contrib/format-esri/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.esri.geometry</groupId>
       <artifactId>esri-geometry-api</artifactId>
-      <version>2.2.3</version>
+      <version>2.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.jamel.dbf</groupId>


### PR DESCRIPTION
# [DRILL-8330](https://issues.apache.org/jira/browse/DRILL-8330): Convert ESRI Shape File Reader to EVF2

## Description
Converts the ESRI Shape File Reader to EVF V2.  

## Documentation
No user facing changes.

## Testing
Ran existing unit tests.