### PR TITLE
[MINOR UPDATE]: Upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -79,7 +77,7 @@
       Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated,
       for example parquet-hadoop-bundle and derby dependencies.
     -->
-    <hive.version>3.1.2</hive.version>
+    <hive.version>3.1.3</hive.version>
     <hadoop.version>3.2.4</hadoop.version>
     <hbase.version>2.4.9</hbase.version>
     <fmpp.version>1.0</fmpp.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 2.3.3-mapr-1808
- [CVE-2018-11777](https://www.oscs1024.com/hd/CVE-2018-11777)


### What did I do？
Upgrade org.apache.hive:hive-exec from 2.3.3-mapr-1808 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS