### PR TITLE
[MINOR UPDATE]: Upgrade org.apache.kafka:kafka_2.13 to 2.8.2

### DIFF
--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Storage : Kafka</name>
 
   <properties>
-    <kafka.version>2.8.0</kafka.version>
+    <kafka.version>2.8.2</kafka.version>
     <kafka.TestSuite>**/TestKafkaSuit.class</kafka.TestSuite>
   </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.13 2.8.0
- [CVE-2022-34917](https://nvd.nist.gov/vuln/detail/CVE-2022-34917)


### What did I do？
Upgrade org.apache.kafka:kafka_2.13 from 2.8.0 to 2.8.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS