### PR TITLE
[MINOR UPDATE]: Upgrade org.freemarker:freemarker to 2.3.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <hadoop.version>3.2.4</hadoop.version>
     <hbase.version>2.4.9</hbase.version>
     <fmpp.version>1.0</fmpp.version>
-    <freemarker.version>2.3.28</freemarker.version>
+    <freemarker.version>2.3.30</freemarker.version>
     <javassist.version>3.28.0-GA</javassist.version>
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.freemarker:freemarker 2.3.28
- [MPS-2022-12438](https://www.oscs1024.com/hd/MPS-2022-12438)


### What did I do？
Upgrade org.freemarker:freemarker from 2.3.28 to 2.3.30 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS