### PR TITLE
DRILL-8333: Resource leak when JsonLoader is built from a stream

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpUdfUtils.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/udfs/HttpUdfUtils.java
@@ -22,12 +22,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
-import org.apache.drill.exec.store.easy.json.loader.SingleElementIterator;
+import org.apache.drill.exec.store.easy.json.loader.ClosingStreamIterator;
 import org.apache.drill.exec.store.http.HttpApiConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.InputStream;
 
 public class HttpUdfUtils {
 
@@ -35,11 +33,11 @@ public class HttpUdfUtils {
 
   public static JsonLoaderImpl createJsonLoader(ResultSetLoader rsLoader,
                                                 OptionManager options,
-                                                SingleElementIterator<InputStream> stream) {
+                                                ClosingStreamIterator stream) {
     return createJsonLoader(null, rsLoader, options, stream);
   }
   public static JsonLoaderImpl createJsonLoader(HttpApiConfig endpointConfig, ResultSetLoader rsLoader,
-                                                OptionManager options, SingleElementIterator<InputStream> stream) {
+                                                OptionManager options, ClosingStreamIterator stream) {
     // Add JSON configuration from Storage plugin, if present.
     org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder jsonLoaderBuilder =
       new org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl.JsonLoaderBuilder()

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.Properties;
 import java.util.StringJoiner;
 
@@ -50,7 +49,7 @@ public class JsonMessageReader implements MessageReader {
 
   private static final Logger logger = LoggerFactory.getLogger(JsonMessageReader.class);
 
-  private final ClosingStreamIterator<InputStream> stream = new ClosingStreamIterator<>();
+  private final ClosingStreamIterator stream = new ClosingStreamIterator();
 
   private KafkaJsonLoader kafkaJsonLoader;
   private ResultSetLoader resultSetLoader;

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/decoders/JsonMessageReader.java
@@ -26,7 +26,7 @@ import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.store.easy.json.loader.JsonLoaderOptions;
-import org.apache.drill.exec.store.easy.json.loader.SingleElementIterator;
+import org.apache.drill.exec.store.easy.json.loader.ClosingStreamIterator;
 import org.apache.drill.exec.store.easy.json.parser.TokenIterator;
 import org.apache.drill.exec.store.kafka.KafkaStoragePlugin;
 import org.apache.drill.exec.store.kafka.MetaDataField;
@@ -50,7 +50,7 @@ public class JsonMessageReader implements MessageReader {
 
   private static final Logger logger = LoggerFactory.getLogger(JsonMessageReader.class);
 
-  private final SingleElementIterator<InputStream> stream = new SingleElementIterator<>();
+  private final ClosingStreamIterator<InputStream> stream = new ClosingStreamIterator<>();
 
   private KafkaJsonLoader kafkaJsonLoader;
   private ResultSetLoader resultSetLoader;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/ClosingStreamIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/ClosingStreamIterator.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.exec.store.easy.json.loader;
 
+import java.io.InputStream;
+
+import org.apache.drill.common.AutoCloseables;
+
 import java.util.Iterator;
 
 /**
@@ -24,22 +28,27 @@ import java.util.Iterator;
  *
  * @param <T> type of the value
  */
-public class SingleElementIterator<T> implements Iterator<T> {
-    private T value;
+public class ClosingStreamIterator implements Iterator<InputStream> {
+    private InputStream value, last;
 
     @Override
     public boolean hasNext() {
-      return value != null;
+      if (value == null) {
+        AutoCloseables.closeSilently(last);
+        return false;
+      }
+      return true;
     }
 
     @Override
-    public T next() {
-      T value = this.value;
+    public InputStream next() {
+      this.last = this.value;
       this.value = null;
-      return value;
+      return this.last;
     }
 
-    public void setValue(T value) {
+    public void setValue(InputStream value) {
+      AutoCloseables.closeSilently(this.value);
       this.value = value;
     }
   }


### PR DESCRIPTION
# [DRILL-8333](https://issues.apache.org/jira/browse/DRILL-8333): Resource leak when JsonLoader is built from a stream

## Description

The JsonLoader can be built to parse from a stream, as it is by the HTTP storage plugin. Given the lifecycles of the objects involved, it is the loader that should be responsible for closing any streams that it is constructed from once JSON parsing is complete and the loader itself is closed.

## Documentation
N/A

## Testing
Monitor fd leakage using the lsof program on Linux while querying an HTTP plugin directly or through HTTP UDFs.
