### PR TITLE
DRILL-8335: Add Ability to Query GoogleSheets Tabs by Index

### DIFF
--- a/contrib/storage-googlesheets/README.md
+++ b/contrib/storage-googlesheets/README.md
@@ -92,6 +92,15 @@ FROM <plugin name>.<sheet ID>.<tab name>
 ```
 Note that you must specify the tab name to successfully query Google Sheets.
 
+### Accessing Tabs by Index
+If you don't know the names of the available tabs in your GoogleSheets document, you can query the sheets by index using the `tab[n]` format.  Indexing starts at zero and every Sheets document must have at least one sheet.  Note that this must be enclosed in backticks.
+
+```sql
+SELECT * 
+FROM googlesheets.<sheet id>.`tab[0]`
+```
+
+
 ### Metadata
 You can obtain a list of available sheets by querying the `INFORMATION_SCHEMA` as shown below.  Assuming that you have a connection to Google Sheets called `googlesheets`:
 

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/DrillDataStore.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/DrillDataStore.java
@@ -60,7 +60,12 @@ public class DrillDataStore<V extends Serializable> extends AbstractMemoryDataSt
     logger.debug("Saving credentials to token table");
     String accessToken = new String(keyValueMap.get(tokenTable.ACCESS_TOKEN_KEY), StandardCharsets.UTF_8);
     String refreshToken = new String(keyValueMap.get(tokenTable.REFRESH_TOKEN_KEY), StandardCharsets.UTF_8);
-    String expiresIn = new String(keyValueMap.get(tokenTable.EXPIRES_IN_KEY), StandardCharsets.UTF_8);
+
+    String expiresIn = "";
+    // Avoids an NPE if the expires_in field is not set.
+    if (keyValueMap.containsKey(tokenTable.EXPIRES_IN_KEY)) {
+      expiresIn = new String(keyValueMap.get(tokenTable.EXPIRES_IN_KEY), StandardCharsets.UTF_8);
+    }
     tokenTable.setAccessToken(accessToken);
     tokenTable.setRefreshToken(refreshToken);
     tokenTable.setExpiresIn(expiresIn);


### PR DESCRIPTION
# [DRILL-8335](https://issues.apache.org/jira/browse/DRILL-8335): Add Ability to Query GoogleSheets Tabs by Index

## Description
This PR adds the ability to query Google Sheets tabs by index rather than by name.   

## Documentation
Updated docs.

### Accessing Tabs by Index
If you don't know the names of the available tabs in your GoogleSheets document, you can query the sheets by index using the `tab[n]` format.  Indexing starts at zero and every Sheets document must have at least one sheet.  Note that this must be enclosed in backticks.

```sql
SELECT * 
FROM googlesheets.<sheet id>.`tab[0]`
```


## Testing
Added additional unit tests.