### PR TITLE
fix(sec): upgrade io.netty:netty-common to 4.1.77.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <jna.version>5.8.0</jna.version>
     <commons.compress.version>1.21</commons.compress.version>
     <hikari.version>4.0.3</hikari.version>
-    <netty.version>4.1.73.Final</netty.version>
+    <netty.version>4.1.77.Final</netty.version>
     <httpclient.version>4.5.13</httpclient.version>
     <libthrift.version>0.14.0</libthrift.version>
     <derby.version>10.14.2.0</derby.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-common 4.1.73.Final
- [CVE-2022-24823](https://www.oscs1024.com/hd/CVE-2022-24823)


### What did I do？
Upgrade io.netty:netty-common from 4.1.73.Final to 4.1.77.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS