### PR TITLE
fix(sec): upgrade com.drewnoakes:metadata-extractor to 2.18.0

### DIFF
--- a/contrib/format-image/pom.xml
+++ b/contrib/format-image/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.drewnoakes</groupId>
       <artifactId>metadata-extractor</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.drewnoakes:metadata-extractor 2.17.0
- [CVE-2022-24614](https://www.oscs1024.com/hd/CVE-2022-24614)


### What did I do？
Upgrade com.drewnoakes:metadata-extractor from 2.17.0 to 2.18.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS