### PR TITLE
DRILL-8337: Upgrade Hive libs to 3.1.3 due to sonatype-2019-0400

### DIFF
--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -73,6 +73,10 @@
           <artifactId>log4j-1.2-api</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.airlift</groupId>
           <artifactId>aircompressor</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,11 @@
     <logback.version>1.2.11</logback.version>
     <mockito.version>3.11.2</mockito.version>
     <!--
-      Currently, Hive storage plugin only supports Apache Hive 3.1.2 or vendor specific variants of the
+      Currently, Hive storage plugin only supports Apache Hive 3.1.3 or vendor specific variants of the
       Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated,
       for example parquet-hadoop-bundle and derby dependencies.
     -->
-    <hive.version>3.1.2</hive.version>
+    <hive.version>3.1.3</hive.version>
     <hadoop.version>3.2.4</hadoop.version>
     <hbase.version>2.4.9</hbase.version>
     <fmpp.version>1.0</fmpp.version>


### PR DESCRIPTION
# [DRILL-8337](https://issues.apache.org/jira/browse/DRILL-8337): Upgrade Hive libs to 3.1.3 due to sonatype-2019-0400

## Description

https://ds-3p.sonatype.com/assets/index.html#/vulnerabilities/sonatype-2019-0400

## Documentation
N/A

## Testing
Hive plugin unit tests.
