### PR TITLE
DRILL-8340: Add Additional Date Manipulation Functions

### DIFF
--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateConversionUtils.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateConversionUtils.java
@@ -28,7 +28,7 @@ import java.time.DayOfWeek;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
-public class NearestDateUtils {
+public class DateConversionUtils {
   /**
    * Specifies the time grouping to be used with the nearest date function
    */
@@ -48,7 +48,7 @@ public class NearestDateUtils {
     SECOND
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(NearestDateUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(DateConversionUtils.class);
 
   /**
    * This function takes a Java LocalDateTime object, and an interval string and returns

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -22,7 +22,6 @@ import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.Output;
 import org.apache.drill.exec.expr.annotations.Param;
-import org.apache.drill.exec.expr.holders.DateHolder;
 import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.expr.holders.TimeStampHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
@@ -192,7 +191,9 @@ public class DateFunctions {
     public void eval() {
       String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputHolder.start, inputHolder.end, inputHolder.buffer);
       java.time.LocalDateTime dt = org.apache.drill.exec.udfs.DateUtilFunctions.getTimestampFromString(input);
-      out.value = dt.toEpochSecond(java.time.ZoneOffset.UTC) * 1000;
+      if (dt != null) {
+        out.value = dt.toEpochSecond(java.time.ZoneOffset.UTC) * 1000;
+      }
     }
   }
 }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -173,27 +173,6 @@ public class DateFunctions {
     }
   }
 
-  @FunctionTemplate(names = {"yearweek","year_week"},
-    scope = FunctionTemplate.FunctionScope.SIMPLE,
-    nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
-  public static class YearWeekFromDateFunction implements DrillSimpleFunc {
-    @Param
-    DateHolder inputHolder;
-
-    @Output
-    IntHolder out;
-
-    @Override
-    public void setup() {
-      // noop
-    }
-
-    @Override
-    public void eval() {
-      out.value = org.apache.drill.exec.udfs.DateUtilFunctions.getYearWeek(inputHolder.value);
-    }
-  }
-
   @FunctionTemplate(names = {"to_timestamp"},
     scope = FunctionTemplate.FunctionScope.SIMPLE,
     nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -194,7 +194,7 @@ public class DateFunctions {
     }
   }
 
-  @FunctionTemplate(names = {"time_stamp", "timestamp"},
+  @FunctionTemplate(names = {"to_timestamp"},
     scope = FunctionTemplate.FunctionScope.SIMPLE,
     nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class TimestampFunction implements DrillSimpleFunc {

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -177,6 +177,11 @@ public class DateFunctions {
     scope = FunctionTemplate.FunctionScope.SIMPLE,
     nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class TimestampFunction implements DrillSimpleFunc {
+    /**
+     * This version of the TO_TIMESTAMP function converts strings into timestamps
+     * without the need for a format string.  The function will attempt to determine
+     * the date format automatically.  If it cannot, the function will return null.
+     */
     @Param
     VarCharHolder inputHolder;
 

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -27,6 +27,8 @@ import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.expr.holders.TimeStampHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
+import java.time.ZoneOffset;
+
 
 public class DateFunctions {
 
@@ -191,6 +193,29 @@ public class DateFunctions {
     @Override
     public void eval() {
       out.value = org.apache.drill.exec.udfs.DateUtilFunctions.getYearWeek(inputHolder.value);
+    }
+  }
+
+  @FunctionTemplate(names = {"time_stamp"},
+    scope = FunctionTemplate.FunctionScope.SIMPLE,
+    nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+  public static class TimestampFunction implements DrillSimpleFunc {
+    @Param
+    VarCharHolder inputHolder;
+
+    @Output
+    TimeStampHolder out;
+
+    @Override
+    public void setup() {
+      // noop
+    }
+
+    @Override
+    public void eval() {
+      String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputHolder.start, inputHolder.end, inputHolder.buffer);
+      java.time.LocalDateTime dt = org.apache.drill.exec.udfs.DateUtilFunctions.getTimestampFromString(input);
+      out.value = dt.toEpochSecond(java.time.ZoneOffset.UTC) * 1000;
     }
   }
 }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -23,6 +23,7 @@ import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.Output;
 import org.apache.drill.exec.expr.annotations.Param;
 import org.apache.drill.exec.expr.holders.IntHolder;
+import org.apache.drill.exec.expr.holders.NullableTimeStampHolder;
 import org.apache.drill.exec.expr.holders.TimeStampHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
@@ -180,7 +181,7 @@ public class DateFunctions {
     VarCharHolder inputHolder;
 
     @Output
-    TimeStampHolder out;
+    NullableTimeStampHolder out;
 
     @Override
     public void setup() {
@@ -193,6 +194,9 @@ public class DateFunctions {
       java.time.LocalDateTime dt = org.apache.drill.exec.udfs.DateUtilFunctions.getTimestampFromString(input);
       if (dt != null) {
         out.value = dt.toEpochSecond(java.time.ZoneOffset.UTC) * 1000;
+        out.isSet = 1;
+      } else {
+        out.isSet = 0;
       }
     }
   }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateFunctions.java
@@ -27,8 +27,6 @@ import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.expr.holders.TimeStampHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
-import java.time.ZoneOffset;
-
 
 public class DateFunctions {
 
@@ -58,7 +56,7 @@ public class DateFunctions {
    * 15SECOND
    * SECOND
    */
-  @FunctionTemplate(name = "nearestDate",
+  @FunctionTemplate(names = {"nearestDate","nearest_date"},
           scope = FunctionTemplate.FunctionScope.SIMPLE,
           nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class NearestDateFunction implements DrillSimpleFunc {
@@ -113,7 +111,7 @@ public class DateFunctions {
    * 15SECOND
    * SECOND
    */
-  @FunctionTemplate(name = "nearestDate",
+  @FunctionTemplate(names = {"nearestDate","nearest_date"},
           scope = FunctionTemplate.FunctionScope.SIMPLE,
           nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class NearestDateFunctionWithString implements DrillSimpleFunc {
@@ -196,7 +194,7 @@ public class DateFunctions {
     }
   }
 
-  @FunctionTemplate(names = {"time_stamp"},
+  @FunctionTemplate(names = {"time_stamp", "timestamp"},
     scope = FunctionTemplate.FunctionScope.SIMPLE,
     nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class TimestampFunction implements DrillSimpleFunc {

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
@@ -155,7 +155,7 @@ public class DateUtilFunctions {
       minute = Integer.parseInt(timestampMatcher.group(5));
       second = Integer.parseInt(timestampMatcher.group(6));
       if (StringUtils.isNotEmpty(timestampMatcher.group(7))) {
-        nanos = Integer.parseInt(timestampMatcher.group(7));
+        nanos = Integer.parseInt(timestampMatcher.group(7)) * 1000000;
       }
     }
     return LocalDateTime.of(year,month,day,hour,minute,second,nanos);

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
@@ -22,12 +22,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Timestamp;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Timestamp;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DateUtilFunctions {
+  private static final Logger logger = LoggerFactory.getLogger(DateUtilFunctions.class);
+  // Date Matcher Regexes
+  // yyyy-mm-dd
+  private static final Pattern DB_DATE = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})$");
+
+  // Matches various dates which use slashes
+  private static final Pattern DATE_SLASH = Pattern.compile("^(\\d{1,2})/(\\d{1,2})/(\\d{4})$");
+
+  // Year first with slashes
+  private static final Pattern LEADING_SLASH_DATE = Pattern.compile("^(\\d{4})/(\\d{1,2})/" +
+    "(\\d{1,2})$");
+
+  private static final Pattern TIMESTAMP_PATTERN = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})" +
+    "(?:T|\\s)(\\d{1,2}):(\\d{1,2}):(\\d{1,2})\\.?(\\d*)");
+
+  /** Parses common date strings and returns a {@link LocalDate} of that string.
+   * If the method is unable to parse the string, an error will be logged.
+   * Supports the following formats:
+   *
+   * <ul>
+   *   <li>yyyy-MM-dd</li>
+   *   <li>MM/dd/yyyy</li>
+   *   <li>M/d/yyyy</li>
+   *   <li>yyyy/MM/dd</li>
+   * </ul>
+   *
+   * @param inputString An input string containing a date.
+   * @return A {@link LocalDate} of the input string.
+   */
+  public static LocalDate getDateFromString(String inputString) {
+    return getDateFromString(inputString, false);
+  }
+
+  /** Parses common date strings and returns a {@link LocalDate} of that string.
+   * If the method is unable to parse the string, an error will be logged.
+   * Supports the following formats:
+   *
+   * <ul>
+   *   <li>yyyy-MM-dd</li>
+   *   <li>MM/dd/yyyy</li>
+   *   <li>dd/MM/yyyy</li>
+   *   <li>M/d/yyyy</li>
+   *   <li>yyyy/MM/dd</li>
+   * </ul>
+   *
+   * @param inputString An input string containing a date.
+   * @param leadingDay True if the format has the day first.
+   * @return A {@link LocalDate} of the input string.
+   */
+  public static LocalDate getDateFromString(String inputString, boolean leadingDay) {
+    int year = 1970;
+    int month = 1;
+    int day = 1;
+    if (StringUtils.isEmpty(inputString)) {
+      return LocalDate.of(year,month,day);
+    }
+
+    // Clean up input string:
+    inputString = inputString.trim();
+    Matcher dateMatcher;
+    if (DB_DATE.matcher(inputString).matches()) {
+      dateMatcher = DB_DATE.matcher(inputString);
+      dateMatcher.find();
+      year = Integer.parseInt(dateMatcher.group(1));
+      month = Integer.parseInt(dateMatcher.group(2));
+      day = Integer.parseInt(dateMatcher.group(3));
+    } else if (DATE_SLASH.matcher(inputString).matches()) {
+      dateMatcher = DATE_SLASH.matcher(inputString);
+      dateMatcher.find();
+      year = Integer.parseInt(dateMatcher.group(3));
+      if (leadingDay) {
+        month = Integer.parseInt(dateMatcher.group(2));
+        day = Integer.parseInt(dateMatcher.group(1));
+      } else {
+        month = Integer.parseInt(dateMatcher.group(1));
+        day = Integer.parseInt(dateMatcher.group(2));
+      }
+    } else if (LEADING_SLASH_DATE.matcher(inputString).matches()) {
+      dateMatcher = LEADING_SLASH_DATE.matcher(inputString);
+      dateMatcher.find();
+      year = Integer.parseInt(dateMatcher.group(1));
+      month = Integer.parseInt(dateMatcher.group(2));
+      day = Integer.parseInt(dateMatcher.group(3));
+    } else {
+      logger.warn("Unable to parse date {}.", inputString);
+    }
+    try {
+      LocalDate result = LocalDate.of(year,month,day);
+      return result;
+    } catch (DateTimeException e) {
+      return LocalDate.of(1970,1,1);
+    }
+  }
+
+  public static LocalDateTime getTimestampFromString(String inputString) {
+    int year = 1970;
+    int month = 1;
+    int day = 1;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+    int nanos = 0;
+    if (StringUtils.isEmpty(inputString)) {
+      return LocalDateTime.of(year,month,day,hour,minute,second,nanos);
+    }
+    // Clean up input string:
+    inputString = inputString.trim();
+
+    if (inputString.length() <= 10) {
+      LocalDate localDate = getDateFromString(inputString);
+      LocalTime localTime = LocalTime.of(0,0,0);
+      return LocalDateTime.of(localDate, localTime);
+    }
+
+    Matcher timestampMatcher = TIMESTAMP_PATTERN.matcher(inputString);
+    if (timestampMatcher.find()) {
+      year = Integer.parseInt(timestampMatcher.group(1));
+      month = Integer.parseInt(timestampMatcher.group(2));
+      day = Integer.parseInt(timestampMatcher.group(3));
+      hour = Integer.parseInt(timestampMatcher.group(4));
+      minute = Integer.parseInt(timestampMatcher.group(5));
+      second = Integer.parseInt(timestampMatcher.group(6));
+      if (StringUtils.isNotEmpty(timestampMatcher.group(7))) {
+        nanos = Integer.parseInt(timestampMatcher.group(7));
+      }
+    }
+    return LocalDateTime.of(year,month,day,hour,minute,second,nanos);
+  }
+
+  public static int getYearWeek(long inputDate) {
+    Timestamp timestamp = new Timestamp(inputDate);
+
+    LocalDate localDate = timestamp.toInstant()
+      .atZone(ZoneId.of("UTC"))
+      .toLocalDate();
+
+    int week = localDate.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+    int year = localDate.getYear();
+    return (year * 100) + week;
+  }
+}

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
@@ -135,6 +135,10 @@ public class DateUtilFunctions {
 
     if (inputString.length() <= 10) {
       LocalDate localDate = getDateFromString(inputString);
+      if (localDate == null) {
+        logger.warn("Unable to parse date {}.", inputString);
+        return null;
+      }
       LocalTime localTime = LocalTime.of(0,0,0);
       return LocalDateTime.of(localDate, localTime);
     }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DateUtilFunctions.java
@@ -77,16 +77,17 @@ public class DateUtilFunctions {
    *   <li>yyyy/MM/dd</li>
    * </ul>
    *
+   * If the matcher is unable to convert the string, the function returns null.
    * @param inputString An input string containing a date.
    * @param leadingDay True if the format has the day first.
    * @return A {@link LocalDate} of the input string.
    */
   public static LocalDate getDateFromString(String inputString, boolean leadingDay) {
-    int year = 1970;
-    int month = 1;
-    int day = 1;
+    int year;
+    int month;
+    int day;
     if (StringUtils.isEmpty(inputString)) {
-      return LocalDate.of(year,month,day);
+      return null;
     }
 
     // Clean up input string:
@@ -117,25 +118,19 @@ public class DateUtilFunctions {
       day = Integer.parseInt(dateMatcher.group(3));
     } else {
       logger.warn("Unable to parse date {}.", inputString);
+      return null;
     }
     try {
-      LocalDate result = LocalDate.of(year,month,day);
-      return result;
+      return LocalDate.of(year,month,day);
     } catch (DateTimeException e) {
-      return LocalDate.of(1970,1,1);
+      logger.warn("Unable to parse date {}.", inputString);
+      return null;
     }
   }
 
   public static LocalDateTime getTimestampFromString(String inputString) {
-    int year = 1970;
-    int month = 1;
-    int day = 1;
-    int hour = 0;
-    int minute = 0;
-    int second = 0;
-    int nanos = 0;
     if (StringUtils.isEmpty(inputString)) {
-      return LocalDateTime.of(year,month,day,hour,minute,second,nanos);
+      return null;
     }
     // Clean up input string:
     inputString = inputString.trim();
@@ -148,28 +143,20 @@ public class DateUtilFunctions {
 
     Matcher timestampMatcher = TIMESTAMP_PATTERN.matcher(inputString);
     if (timestampMatcher.find()) {
-      year = Integer.parseInt(timestampMatcher.group(1));
-      month = Integer.parseInt(timestampMatcher.group(2));
-      day = Integer.parseInt(timestampMatcher.group(3));
-      hour = Integer.parseInt(timestampMatcher.group(4));
-      minute = Integer.parseInt(timestampMatcher.group(5));
-      second = Integer.parseInt(timestampMatcher.group(6));
+      int year = Integer.parseInt(timestampMatcher.group(1));
+      int month = Integer.parseInt(timestampMatcher.group(2));
+      int day = Integer.parseInt(timestampMatcher.group(3));
+      int hour = Integer.parseInt(timestampMatcher.group(4));
+      int minute = Integer.parseInt(timestampMatcher.group(5));
+      int second = Integer.parseInt(timestampMatcher.group(6));
+      int nanos = 0;
       if (StringUtils.isNotEmpty(timestampMatcher.group(7))) {
         nanos = Integer.parseInt(timestampMatcher.group(7)) * 1000000;
       }
+      return LocalDateTime.of(year,month,day,hour,minute,second,nanos);
+    } else {
+      logger.warn("Unable to parse date {}.", inputString);
+      return null;
     }
-    return LocalDateTime.of(year,month,day,hour,minute,second,nanos);
-  }
-
-  public static int getYearWeek(long inputDate) {
-    Timestamp timestamp = new Timestamp(inputDate);
-
-    LocalDate localDate = timestamp.toInstant()
-      .atZone(ZoneId.of("UTC"))
-      .toLocalDate();
-
-    int week = localDate.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
-    int year = localDate.getYear();
-    return (year * 100) + week;
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateFunctions.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
-public class TestNearestDateFunctions extends ClusterTest {
+public class TestDateFunctions extends ClusterTest {
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -213,8 +213,8 @@ public class TestNearestDateFunctions extends ClusterTest {
   public void testTimestamp() throws Exception {
     LocalDateTime ts1 = LocalDateTime.of(2020,2,4,0,0,0);
     LocalDateTime ts2 = LocalDateTime.of(2012,6,12,12,12,45);
-    String query = "SELECT time_stamp('2020-02-04') AS ts1," +
-      "time_stamp('2012-06-12T12:12:45.123Z') AS ts2 FROM (VALUES(1))";
+    String query = "SELECT to_timestamp('2020-02-04') AS ts1," +
+      "to_timestamp('2012-06-12T12:12:45.123Z') AS ts2 FROM (VALUES(1))";
     testBuilder()
       .sqlQuery(query)
       .unOrdered()

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateFunctions.java
@@ -214,12 +214,13 @@ public class TestDateFunctions extends ClusterTest {
     LocalDateTime ts1 = LocalDateTime.of(2020,2,4,0,0,0);
     LocalDateTime ts2 = LocalDateTime.of(2012,6,12,12,12,45);
     String query = "SELECT to_timestamp('2020-02-04') AS ts1," +
-      "to_timestamp('2012-06-12T12:12:45.123Z') AS ts2 FROM (VALUES(1))";
+      "to_timestamp('2012-06-12T12:12:45.123Z') AS ts2, to_timestamp('AAAAHHHHH') " +
+      "AS ts3 FROM (VALUES(1))";
     testBuilder()
       .sqlQuery(query)
       .unOrdered()
-      .baselineColumns("ts1", "ts2")
-      .baselineValues(ts1, ts2)
+      .baselineColumns("ts1", "ts2", "ts3")
+      .baselineValues(ts1, ts2, null)
       .go();
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateUtils.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestDateUtils {
+
+  @Test
+  public void testDateFromString() {
+    LocalDate testDate = LocalDate.of(2022, 3,14);
+    LocalDate badDate = LocalDate.of(1970, 1, 1);
+    assertEquals(testDate, DateUtilFunctions.getDateFromString("2022-03-14"));
+    assertEquals(testDate, DateUtilFunctions.getDateFromString("3/14/2022"));
+    assertEquals(testDate, DateUtilFunctions.getDateFromString("14/03/2022", true));
+    assertEquals(testDate, DateUtilFunctions.getDateFromString("2022/3/14"));
+
+    // Test bad dates
+    assertEquals(badDate, DateUtilFunctions.getDateFromString(null));
+    assertEquals(badDate, DateUtilFunctions.getDateFromString("1975-13-56"));
+    assertEquals(badDate, DateUtilFunctions.getDateFromString("1975-1s"));
+  }
+
+  @Test
+  public void testTimestampFromString() {
+    LocalDateTime testNoSecondFragments = LocalDateTime.of(2022,4,19,17,3,46);
+    LocalDateTime test1Digit = LocalDateTime.of(2022,4,19,17,3,46, 1);
+    LocalDateTime test2Digit = LocalDateTime.of(2022,4,19,17,3,46, 13);
+    LocalDateTime test3Digit = LocalDateTime.of(2022,4,19,17,3,46, 342);
+
+    LocalDateTime badDate = LocalDateTime.of(1970,1,1, 0, 0, 0);
+
+    assertEquals(testNoSecondFragments,
+      DateUtilFunctions.getTimestampFromString("2022-04-19 17:03:46"));
+    assertEquals(testNoSecondFragments,
+      DateUtilFunctions.getTimestampFromString("2022-04-19T17:03:46"));
+    assertEquals(testNoSecondFragments,
+      DateUtilFunctions.getTimestampFromString("2022-04-19T17:03:46.000Z"));
+    assertEquals(test1Digit,
+      DateUtilFunctions.getTimestampFromString("2022-04-19T17:03:46.1Z"));
+    assertEquals(test1Digit,
+      DateUtilFunctions.getTimestampFromString("2022-04-19T17:03:46.001Z"));
+    assertEquals(test2Digit,
+      DateUtilFunctions.getTimestampFromString("2022-04-19T17:03:46.13Z"));
+    assertEquals(test2Digit,
+      DateUtilFunctions.getTimestampFromString("2022-04-19T17:03:46.013Z"));
+    assertEquals(test3Digit,
+      DateUtilFunctions.getTimestampFromString("2022-04-19 17:03:46.342Z"));
+
+    // Test bad dates
+    assertEquals(badDate,
+      DateUtilFunctions.getTimestampFromString(null));
+    assertEquals(badDate,
+      DateUtilFunctions.getTimestampFromString(""));
+  }
+}

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateUtils.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateUtils.java
@@ -24,22 +24,22 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TestDateUtils {
 
   @Test
   public void testDateFromString() {
     LocalDate testDate = LocalDate.of(2022, 3,14);
-    LocalDate badDate = LocalDate.of(1970, 1, 1);
     assertEquals(testDate, DateUtilFunctions.getDateFromString("2022-03-14"));
     assertEquals(testDate, DateUtilFunctions.getDateFromString("3/14/2022"));
     assertEquals(testDate, DateUtilFunctions.getDateFromString("14/03/2022", true));
     assertEquals(testDate, DateUtilFunctions.getDateFromString("2022/3/14"));
 
     // Test bad dates
-    assertEquals(badDate, DateUtilFunctions.getDateFromString(null));
-    assertEquals(badDate, DateUtilFunctions.getDateFromString("1975-13-56"));
-    assertEquals(badDate, DateUtilFunctions.getDateFromString("1975-1s"));
+    assertNull(DateUtilFunctions.getDateFromString(null));
+    assertNull(DateUtilFunctions.getDateFromString("1975-13-56"));
+    assertNull(DateUtilFunctions.getDateFromString("1975-1s"));
   }
 
   @Test
@@ -48,8 +48,6 @@ public class TestDateUtils {
     LocalDateTime test1Digit = LocalDateTime.of(2022,4,19,17,3,46, 1000000);
     LocalDateTime test2Digit = LocalDateTime.of(2022,4,19,17,3,46, 13000000);
     LocalDateTime test3Digit = LocalDateTime.of(2022,4,19,17,3,46, 342000000);
-
-    LocalDateTime badDate = LocalDateTime.of(1970,1,1, 0, 0, 0);
 
     assertEquals(testNoSecondFragments,
       DateUtilFunctions.getTimestampFromString("2022-04-19 17:03:46"));
@@ -69,9 +67,7 @@ public class TestDateUtils {
       DateUtilFunctions.getTimestampFromString("2022-04-19 17:03:46.342Z"));
 
     // Test bad dates
-    assertEquals(badDate,
-      DateUtilFunctions.getTimestampFromString(null));
-    assertEquals(badDate,
-      DateUtilFunctions.getTimestampFromString(""));
+    assertNull(DateUtilFunctions.getTimestampFromString(null));
+    assertNull(DateUtilFunctions.getTimestampFromString(""));
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateUtils.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDateUtils.java
@@ -45,9 +45,9 @@ public class TestDateUtils {
   @Test
   public void testTimestampFromString() {
     LocalDateTime testNoSecondFragments = LocalDateTime.of(2022,4,19,17,3,46);
-    LocalDateTime test1Digit = LocalDateTime.of(2022,4,19,17,3,46, 1);
-    LocalDateTime test2Digit = LocalDateTime.of(2022,4,19,17,3,46, 13);
-    LocalDateTime test3Digit = LocalDateTime.of(2022,4,19,17,3,46, 342);
+    LocalDateTime test1Digit = LocalDateTime.of(2022,4,19,17,3,46, 1000000);
+    LocalDateTime test2Digit = LocalDateTime.of(2022,4,19,17,3,46, 13000000);
+    LocalDateTime test3Digit = LocalDateTime.of(2022,4,19,17,3,46, 342000000);
 
     LocalDateTime badDate = LocalDateTime.of(1970,1,1, 0, 0, 0);
 

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestNearestDateFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestNearestDateFunctions.java
@@ -208,4 +208,18 @@ public class TestNearestDateFunctions extends ClusterTest {
       .baselineValues(201216, 201203, 202050)
       .go();
   }
+
+  @Test
+  public void testTimestamp() throws Exception {
+    LocalDateTime ts1 = LocalDateTime.of(2020,2,4,0,0,0);
+    LocalDateTime ts2 = LocalDateTime.of(2012,6,12,12,12,45);
+    String query = "SELECT time_stamp('2020-02-04') AS ts1," +
+      "time_stamp('2012-06-12T12:12:45.123Z') AS ts2 FROM (VALUES(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("ts1", "ts2")
+      .baselineValues(ts1, ts2)
+      .go();
+  }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestNearestDateFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestNearestDateFunctions.java
@@ -149,7 +149,7 @@ public class TestNearestDateFunctions extends ClusterTest {
       run(query);
       fail();
     } catch (DrillRuntimeException e) {
-      assertTrue(e.getMessage().contains("[BAD_DATE] is not a valid time statement. Expecting: " + Arrays.asList(NearestDateUtils.TimeInterval.values())));
+      assertTrue(e.getMessage().contains("[BAD_DATE] is not a valid time statement. Expecting: " + Arrays.asList(DateConversionUtils.TimeInterval.values())));
     }
   }
 
@@ -193,5 +193,19 @@ public class TestNearestDateFunctions extends ClusterTest {
             q3, q3, q3,
             q4, q4, q4)
         .go();
+  }
+
+  @Test
+  public void testYearWeek() throws Exception {
+    String query = "SELECT yearweek('2012-04-19') as yw, yearweek(CAST('2012-01-19' AS DATE)) AS " +
+      "yw1, year_week(CAST('2020-12-12' AS TIMESTAMP)) AS yw2" +
+      " FROM (VALUES(1))";
+
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("yw", "yw1", "yw2")
+      .baselineValues(201216, 201203, 202050)
+      .go();
   }
 }

--- a/exec/java-exec/src/main/codegen/data/ExtractTypes.tdd
+++ b/exec/java-exec/src/main/codegen/data/ExtractTypes.tdd
@@ -17,6 +17,7 @@
 #
 
 {
-  toTypes: [Second, Minute, Hour, Day, Week, Month, Quarter, Year],
+  toTypes: [Second, Minute, Hour, Day, Week, Dow, DayOfWeek, Month, Quarter, Doy, DayOfYear, Year,
+  Epoch],
   fromTypes: [Date, Time, TimeStamp, Interval, IntervalDay, IntervalYear]
 }

--- a/exec/java-exec/src/main/codegen/data/ExtractTypes.tdd
+++ b/exec/java-exec/src/main/codegen/data/ExtractTypes.tdd
@@ -17,6 +17,6 @@
 #
 
 {
-  toTypes: [Second, Minute, Hour, Day, Week, Month, Year],
+  toTypes: [Second, Minute, Hour, Day, Week, Month, Quarter, Year],
   fromTypes: [Date, Time, TimeStamp, Interval, IntervalDay, IntervalYear]
 }

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
@@ -39,7 +39,8 @@ public class ${className} {
 <#list extract.toTypes as toUnit>
 <#if fromUnit == "Date" || fromUnit == "Time" || fromUnit == "TimeStamp">
 <#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Quarter" || toUnit == "Month"
-  || toUnit == "Week" || toUnit == "Day"))>
+  || toUnit == "Week" || toUnit == "Day" || toUnit == "Epoch"  || toUnit == "Epoch"
+  || toUnit == "Doy"  || toUnit == "Dow"))>
   @FunctionTemplate(name = "extract${toUnit}", scope = FunctionTemplate.FunctionScope.SIMPLE,
       nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class ${toUnit}From${fromUnit} implements DrillSimpleFunc {
@@ -68,6 +69,10 @@ public class ${className} {
       out.value = dateTime.getHourOfDay();
     <#elseif toUnit = "Day">
       out.value = dateTime.getDayOfMonth();
+    <#elseif toUnit = "Dow">
+      out.value = dateTime.getDayOfWeek();
+    <#elseif toUnit = "Doy">
+      out.value = dateTime.getDayOfYear();
     <#elseif toUnit = "Week">
       out.value = dateTime.getWeekOfWeekyear();
     <#elseif toUnit = "Month">
@@ -76,6 +81,8 @@ public class ${className} {
       out.value = ((int) dateTime.getMonthOfYear() / 4) + 1;
     <#elseif toUnit = "Year">
       out.value = dateTime.getYear();
+    <#elseif toUnit = "Epoch">
+      out.value = dateTime.getMillis();
     </#if>
     }
   }

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
@@ -38,7 +38,8 @@ public class ${className} {
 <#list extract.fromTypes as fromUnit>
 <#list extract.toTypes as toUnit>
 <#if fromUnit == "Date" || fromUnit == "Time" || fromUnit == "TimeStamp">
-<#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Month" || toUnit == "Week" || toUnit == "Day"))>
+<#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Quarter" || toUnit == "Month"
+  || toUnit == "Week" || toUnit == "Day"))>
   @FunctionTemplate(name = "extract${toUnit}", scope = FunctionTemplate.FunctionScope.SIMPLE,
       nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class ${toUnit}From${fromUnit} implements DrillSimpleFunc {
@@ -71,6 +72,8 @@ public class ${className} {
       out.value = dateTime.getWeekOfWeekyear();
     <#elseif toUnit = "Month">
       out.value = dateTime.getMonthOfYear();
+    <#elseif toUnit = "Quarter">
+      out.value = ((int) dateTime.getMonthOfYear() / 4) + 1;
     <#elseif toUnit = "Year">
       out.value = dateTime.getYear();
     </#if>
@@ -95,6 +98,8 @@ public class ${className} {
   <#if fromUnit == "Interval">
     <#if toUnit == "Year">
       out.value = (in.months / org.apache.drill.exec.vector.DateUtilities.yearsToMonths);
+    <#elseif toUnit == "Quarter">
+      out.value = (in.months / org.apache.drill.exec.vector.DateUtilities.yearsToQuarter);
     <#elseif toUnit == "Month">
       out.value = (in.months % org.apache.drill.exec.vector.DateUtilities.yearsToMonths);
     <#elseif toUnit == "Week">
@@ -114,6 +119,8 @@ public class ${className} {
     <#if toUnit == "Year" || toUnit == "Month">
       out.value = 0;
     <#elseif toUnit == "Week">
+      out.value = 0;
+    <#elseif toUnit == "Quarter">
       out.value = 0;
     <#elseif toUnit == "Day">
       out.value = in.days;

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
@@ -39,8 +39,8 @@ public class ${className} {
 <#list extract.toTypes as toUnit>
 <#if fromUnit == "Date" || fromUnit == "Time" || fromUnit == "TimeStamp">
 <#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Quarter" || toUnit == "Month"
-  || toUnit == "Week" || toUnit == "Day" || toUnit == "Epoch"  || toUnit == "Epoch"
-  || toUnit == "Doy"  || toUnit == "Dow"))>
+  || toUnit == "Week" || toUnit == "Day" || toUnit == "Epoch"
+  || toUnit == "Doy" || toUnit == "DayOfYear"  || toUnit == "Dow" || toUnit == "DayOfWeek))>
   @FunctionTemplate(name = "extract${toUnit}", scope = FunctionTemplate.FunctionScope.SIMPLE,
       nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class ${toUnit}From${fromUnit} implements DrillSimpleFunc {

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/Extract.java
@@ -40,7 +40,7 @@ public class ${className} {
 <#if fromUnit == "Date" || fromUnit == "Time" || fromUnit == "TimeStamp">
 <#if !(fromUnit == "Time" && (toUnit == "Year" || toUnit == "Quarter" || toUnit == "Month"
   || toUnit == "Week" || toUnit == "Day" || toUnit == "Epoch"
-  || toUnit == "Doy" || toUnit == "DayOfYear"  || toUnit == "Dow" || toUnit == "DayOfWeek))>
+  || toUnit == "Doy" || toUnit == "DayOfYear"  || toUnit == "Dow" || toUnit == "DayOfWeek"))>
   @FunctionTemplate(name = "extract${toUnit}", scope = FunctionTemplate.FunctionScope.SIMPLE,
       nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class ${toUnit}From${fromUnit} implements DrillSimpleFunc {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -575,6 +575,7 @@ public class DrillOptiq {
 
           switch (timeUnit) {
             case YEAR:
+            case QUARTER:
             case MONTH:
             case WEEK:
             case DAY:
@@ -585,7 +586,8 @@ public class DrillOptiq {
               functionName += functionPostfix;
               return FunctionCallFactory.createExpression(functionName, args.subList(1, 2));
             default:
-              throw new UnsupportedOperationException("extract function supports the following time units: YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND");
+              throw new UnsupportedOperationException("extract function supports the following " +
+                "time units: YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND");
           }
         }
         case "timestampdiff": {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -570,8 +570,15 @@ public class DrillOptiq {
 
           // Get the unit of time to be extracted
           String timeUnitStr = ((ValueExpressions.QuotedString) args.get(0)).value;
-
-          TimeUnit timeUnit = TimeUnit.valueOf(timeUnitStr);
+          TimeUnit timeUnit;
+          // Clean up day of XXX
+          if (timeUnitStr.contentEquals("DAYOFWEEK")) {
+            timeUnit = TimeUnit.DOW;
+          } else if (timeUnitStr.contentEquals("DAYOFYEAR")) {
+            timeUnit = TimeUnit.DOY;
+          } else {
+            timeUnit = TimeUnit.valueOf(timeUnitStr);
+          }
 
           switch (timeUnit) {
             case YEAR:
@@ -579,6 +586,9 @@ public class DrillOptiq {
             case MONTH:
             case WEEK:
             case DAY:
+            case DOW:
+            case DOY:
+            case EPOCH:
             case HOUR:
             case MINUTE:
             case SECOND:
@@ -587,7 +597,8 @@ public class DrillOptiq {
               return FunctionCallFactory.createExpression(functionName, args.subList(1, 2));
             default:
               throw new UnsupportedOperationException("extract function supports the following " +
-                "time units: YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND");
+                "time units: YEAR, QUARTER, MONTH, WEEK, DAY, DAYOFWEEK, DAYOFYEAR, EPOCH, HOUR, " +
+                "MINUTE, SECOND");
           }
         }
         case "timestampdiff": {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
@@ -949,6 +949,7 @@ public class TypeInferenceUtils {
     TimeUnit timeUnit = TimeUnit.valueOf(timeUnitStr);
     switch (timeUnit) {
       case YEAR:
+      case QUARTER:
       case MONTH:
       case WEEK:
       case DAY:
@@ -960,7 +961,8 @@ public class TypeInferenceUtils {
       default:
         throw UserException
             .functionError()
-            .message("extract function supports the following time units: YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND")
+            .message("extract function supports the following time units: YEAR, QUARTER, MONTH, " +
+              "WEEK, DAY, HOUR, MINUTE, SECOND")
             .build(logger);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
@@ -946,12 +946,25 @@ public class TypeInferenceUtils {
    * For Extract and date_part functions, infer the return types based on timeUnit
    */
   public static SqlTypeName getSqlTypeNameForTimeUnit(String timeUnitStr) {
-    TimeUnit timeUnit = TimeUnit.valueOf(timeUnitStr);
+    TimeUnit timeUnit;
+
+    // Clean up day of XXX
+    if (timeUnitStr.contentEquals("DAYOFWEEK")) {
+      timeUnit = TimeUnit.DOW;
+    } else if (timeUnitStr.contentEquals("DAYOFYEAR")) {
+      timeUnit = TimeUnit.DOY;
+    } else {
+      timeUnit = TimeUnit.valueOf(timeUnitStr);
+    }
+
     switch (timeUnit) {
       case YEAR:
       case QUARTER:
       case MONTH:
       case WEEK:
+      case EPOCH:
+      case DOY:
+      case DOW:
       case DAY:
       case HOUR:
       case MINUTE:
@@ -962,7 +975,7 @@ public class TypeInferenceUtils {
         throw UserException
             .functionError()
             .message("extract function supports the following time units: YEAR, QUARTER, MONTH, " +
-              "WEEK, DAY, HOUR, MINUTE, SECOND")
+              "WEEK, DAY, DAYOFWEEK, DAYOFYEAR, EPOCH, HOUR, MINUTE, SECOND")
             .build(logger);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewDateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewDateFunctions.java
@@ -142,6 +142,17 @@ public class TestNewDateFunctions extends BaseTestQuery {
   }
 
   @Test
+  public void testExtractQuarter() throws Exception {
+    testBuilder()
+      .sqlQuery("SELECT EXTRACT(QUARTER FROM hire_date) AS col FROM cp.`employee.json` WHERE " +
+        "last_name='Nowmer'")
+      .unOrdered()
+      .baselineColumns("col")
+      .baselineValues(4L)
+      .go();
+  }
+
+  @Test
   public void testLocalTimestamp() throws Exception {
     testBuilder()
         .sqlQuery("select extract(day from localtimestamp) = extract(day from current_date) as col from cp.`employee.json` limit 1")

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/DateUtilities.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/DateUtilities.java
@@ -36,6 +36,7 @@ import org.joda.time.Period;
 public class DateUtilities {
 
   public static final int yearsToMonths = 12;
+  public static final int yearsToQuarter = 4;
   public static final int daysToWeeks = 7;
   public static final int hoursToMillis = 60 * 60 * 1000;
   public static final int minutesToMillis = 60 * 1000;


### PR DESCRIPTION
# [DRILL-8340](https://issues.apache.org/jira/browse/DRILL-8340): Add Additional Date Manipulation Functions

## Description
See below.

## Documentation
This PR adds several utility functions to facilitate working with dates and times.  These are modeled after the date/time functionality in MySQL.  Due to the new casting updates, these functions will work with strings, dates or timestamps without the need to explicitly cast the input to a temporal type.

Specifically this adds:
* `DAYOFWEEK(<date>)`: Returns the day of the week 1-7 per SQL standard.
* `DAYOFYEAR(<date>)`: Returns the day of the year. 
* `TO_TIMESTAMP(<date string>)`:  Converts most anything that looks like a date string into a timestamp.
* `QUARTER(<date>)`:  Returns the quarter of the date/time.

Additionally, `DAYOFWEEK`, `DAYOFYEAR`, `QUARTER`, and `EPOCH`  are now available in the `EXTRACT` function.  

## Testing
Added unit tests.