### PR TITLE
DRILL-8341: Add Scanned Plugin List to Sys Profiles Table

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileInfoIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileInfoIterator.java
@@ -90,6 +90,8 @@ public class ProfileInfoIterator extends ProfileIterator {
             computeDuration(profile.getPlanEnd(), assumedQueueEndTime),
             computeDuration(assumedQueueEndTime, profile.getEnd()),
             profile.getState().name(),
+            profile.getScannedPluginsCount(),
+            profile.getScannedPluginsList().toString(),
             profile.getQuery()
          );
       }
@@ -129,11 +131,13 @@ public class ProfileInfoIterator extends ProfileIterator {
     public final long executeTime;
     public final long totalTime;
     public final String state;
+    public final int pluginCount;
+    public final String pluginList;
     public final String query;
 
     public ProfileInfo(String query_id, Timestamp time, String foreman, long fragmentCount, String username,
         String queueName, long planDuration, long queueWaitDuration, long executeDuration,
-        String state, String query) {
+        String state, int pluginCount, String pluginList, String query) {
       this.queryId = query_id;
       this.startTime = time;
       this.foreman = foreman;
@@ -145,13 +149,15 @@ public class ProfileInfoIterator extends ProfileIterator {
       this.executeTime = executeDuration;
       this.totalTime = this.planTime + this.queueTime + this.executeTime;
       this.query = query;
+      this.pluginCount = pluginCount;
+      this.pluginList = pluginList;
       this.state = state;
     }
 
     private ProfileInfo() {
       this(UNKNOWN_VALUE, new Timestamp(0), UNKNOWN_VALUE, 0L,
           UNKNOWN_VALUE, UNKNOWN_VALUE, 0L, 0L,
-          0L, UNKNOWN_VALUE, UNKNOWN_VALUE);
+          0L, UNKNOWN_VALUE, 0, UNKNOWN_VALUE, UNKNOWN_VALUE);
     }
 
     /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileInfoIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileInfoIterator.java
@@ -131,13 +131,13 @@ public class ProfileInfoIterator extends ProfileIterator {
     public final long executeTime;
     public final long totalTime;
     public final String state;
-    public final int pluginCount;
+    public final long pluginCount;
     public final String pluginList;
     public final String query;
 
     public ProfileInfo(String query_id, Timestamp time, String foreman, long fragmentCount, String username,
         String queueName, long planDuration, long queueWaitDuration, long executeDuration,
-        String state, int pluginCount, String pluginList, String query) {
+        String state, long pluginCount, String pluginList, String query) {
       this.queryId = query_id;
       this.startTime = time;
       this.foreman = foreman;
@@ -157,7 +157,7 @@ public class ProfileInfoIterator extends ProfileIterator {
     private ProfileInfo() {
       this(UNKNOWN_VALUE, new Timestamp(0), UNKNOWN_VALUE, 0L,
           UNKNOWN_VALUE, UNKNOWN_VALUE, 0L, 0L,
-          0L, UNKNOWN_VALUE, 0, UNKNOWN_VALUE, UNKNOWN_VALUE);
+          0L, UNKNOWN_VALUE, 0L, UNKNOWN_VALUE, UNKNOWN_VALUE);
     }
 
     /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -242,7 +242,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(170, columns.size());
+    assertEquals(172, columns.size());
     // too many records to verify the output.
   }
 


### PR DESCRIPTION
# [DRILL-8341](https://issues.apache.org/jira/browse/DRILL-8341): Add Scanned Plugin List to Sys Profiles Table

## Description
In [DRILL-8322](https://issues.apache.org/jira/browse/DRILL-8322), @jnturton added the list of scanned plugins to the query profiles.  This information is extremely useful in query analysis.  This minor PR adds this same information to the sys.profiles table.

## Documentation
Adds two fields to the `sys.profiles` table: 
*  `pluginCount`: Returns the number of plugins scanned in the query
* `pluginList`: Returns the actual plugins.  Note this is a JSON String, not an actual list. 

## Testing
Tested manually.

```
apache drill> select pluginCount, pluginList, query from sys.profiles limit 2;
+-------------+------------+------------------------------------+
| pluginCount | pluginList |               query                |
+-------------+------------+------------------------------------+
| 1           | [sys]      | select * from sys.profiles limit 2 |
| 0           | []         | show files in dfs.test             |
+-------------+------------+------------------------------------+
```

