### PR TITLE
DRILL-8342: Add Automatic Retry for Rate Limited APIs

### DIFF
--- a/contrib/storage-http/Pagination.md
+++ b/contrib/storage-http/Pagination.md
@@ -1,12 +1,18 @@
 # Auto Pagination in Drill
-Remote APIs frequently implement some sort of pagination as a way of limiting results.  However, if you are performing bulk data analysis, it is necessary to reassemble the 
+Remote APIs frequently implement some sort of pagination as a way of limiting results.  However, if you are performing bulk data analysis, it is necessary to reassemble the
 data into one larger dataset.  Drill's auto-pagination features allow this to happen in the background, so that the user will get clean data back.
 
-To use a paginator, you simply have to configure the paginator in the connection for the particular API.  
+To use a paginator, you simply have to configure the paginator in the connection for the particular API.
 
 ## Words of Caution
 While extremely powerful, the auto-pagination feature has the potential to run afoul of APIs rate limits and even potentially DDoS an API. Please use with extreme care.
 
+## Rate Limits
+When using automatic pagination, you may encounter APIs that have burst limits or other limits
+as to the maximum number of requests in a minute or other amount of time.  Drill allows you to
+set a `retryDelay` parameter which is the number of milliseconds that Drill should wait before
+resending the request.  This defaults to 1 second.  This option is set in the configuration for
+the HTTP plugin. 
 
 ## Offset Pagination
 Offset Pagination uses commands similar to SQL which has a `LIMIT` and an `OFFSET`.  With an offset paginator, let's say you want 200 records and the  page size is 50 records, the offset paginator will break up your query into 4 requests as shown below:
@@ -17,7 +23,7 @@ Offset Pagination uses commands similar to SQL which has a `LIMIT` and an `OFFSE
 * myapi.com?limit=50&offset=150
 
 ### Configuring Offset Pagination
-To configure an offset paginator, simply add the following to the configuration for your connection. 
+To configure an offset paginator, simply add the following to the configuration for your connection.
 
 ```json
 "paginator": {
@@ -29,7 +35,7 @@ To configure an offset paginator, simply add the following to the configuration 
 ```
 
 ## Page Pagination
-Page pagination is very similar to offset pagination except instead of using an `OFFSET` it uses a page number. 
+Page pagination is very similar to offset pagination except instead of using an `OFFSET` it uses a page number.
 
 ```json
  "paginator": {
@@ -42,9 +48,9 @@ Page pagination is very similar to offset pagination except instead of using an 
 In either case, the `pageSize` parameter should be set to the maximum page size allowable by the API.  This will minimize the number of requests Drill is making.
 
 ## Index / KeySet Pagination
-Index or KeySet pagination is when the API itself returns values to generate the next page. 
+Index or KeySet pagination is when the API itself returns values to generate the next page.
 
-Consider an API that returned data like this: 
+Consider an API that returned data like this:
 
 ```json
 {
@@ -69,4 +75,4 @@ There are three possible parameters:
 * `nextPageParam`: The parameter name which returns a complete URL of the next page.
 
 
-** Note: Index / Keyset Pagination is only implemented for APIs that return JSON ** 
+** Note: Index / Keyset Pagination is only implemented for APIs that return JSON **

--- a/contrib/storage-http/Pagination.md
+++ b/contrib/storage-http/Pagination.md
@@ -12,7 +12,7 @@ When using automatic pagination, you may encounter APIs that have burst limits o
 as to the maximum number of requests in a minute or other amount of time.  Drill allows you to
 set a `retryDelay` parameter which is the number of milliseconds that Drill should wait before
 resending the request.  This defaults to 1 second.  This option is set in the configuration for
-the HTTP plugin. 
+the HTTP plugin.
 
 ## Offset Pagination
 Offset Pagination uses commands similar to SQL which has a `LIMIT` and an `OFFSET`.  With an offset paginator, let's say you want 200 records and the  page size is 50 records, the offset paginator will break up your query into 4 requests as shown below:

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
@@ -58,13 +58,13 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
    * Timeout in {@link TimeUnit#SECONDS}.
    */
   public final int timeout;
-  public final int rateLimit;
+  public final int retryDelay;
 
   @JsonCreator
   public HttpStoragePluginConfig(@JsonProperty("cacheResults") Boolean cacheResults,
                                  @JsonProperty("connections") Map<String, HttpApiConfig> connections,
                                  @JsonProperty("timeout") Integer timeout,
-                                 @JsonProperty("rateLimit") Integer rateLimit,
+                                 @JsonProperty("retryDelay") Integer retryDelay,
                                  @JsonProperty("username") String username,
                                  @JsonProperty("password") String password,
                                  @JsonProperty("proxyHost") String proxyHost,
@@ -89,7 +89,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
         AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER),
       oAuthConfig);
     this.cacheResults = cacheResults != null && cacheResults;
-    this.rateLimit = (rateLimit == null || rateLimit < 0) ? DEFAULT_RATE_LIMIT : rateLimit;
+    this.retryDelay = (retryDelay == null || retryDelay < 0) ? DEFAULT_RATE_LIMIT : retryDelay;
 
     this.connections = CaseInsensitiveMap.newHashMap();
     if (connections != null) {
@@ -127,7 +127,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     this.proxyPort = that.proxyPort;
     this.proxyType = that.proxyType;
     this.oAuthConfig = that.oAuthConfig;
-    this.rateLimit = that.rateLimit;
+    this.retryDelay = that.retryDelay;
   }
 
   /**
@@ -146,7 +146,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     this.proxyPort = that.proxyPort;
     this.proxyType = that.proxyType;
     this.oAuthConfig = that.oAuthConfig;
-    this.rateLimit = that.rateLimit;
+    this.retryDelay = that.retryDelay;
   }
 
   private static String normalize(String value) {
@@ -166,8 +166,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     return new HttpStoragePluginConfig(
       cacheResults,
       configFor(connectionName),
-      timeout,
-      rateLimit,
+      timeout, retryDelay,
       username(),
       password(),
       proxyHost,
@@ -198,7 +197,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     return Objects.equals(connections, thatConfig.connections) &&
       Objects.equals(cacheResults, thatConfig.cacheResults) &&
       Objects.equals(proxyHost, thatConfig.proxyHost) &&
-      Objects.equals(rateLimit, thatConfig.rateLimit) &&
+      Objects.equals(retryDelay, thatConfig.retryDelay) &&
       Objects.equals(proxyPort, thatConfig.proxyPort) &&
       Objects.equals(proxyType, thatConfig.proxyType) &&
       Objects.equals(oAuthConfig, thatConfig.oAuthConfig) &&
@@ -212,7 +211,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
       .field("connections", connections)
       .field("cacheResults", cacheResults)
       .field("timeout", timeout)
-      .field("rateLimit", rateLimit)
+      .field("retryDelay", retryDelay)
       .field("proxyHost", proxyHost)
       .field("proxyPort", proxyPort)
       .field("credentialsProvider", credentialsProvider)
@@ -224,7 +223,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hash(connections, cacheResults, timeout, rateLimit,
+    return Objects.hash(connections, cacheResults, timeout, retryDelay,
         proxyHost, proxyPort, proxyType, oAuthConfig, credentialsProvider, authMode);
   }
 
@@ -237,9 +236,9 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
   @JsonProperty("timeout")
   public int timeout() { return timeout;}
 
-  @JsonProperty("rateLimit")
-  public int rateLimit() {
-    return rateLimit;
+  @JsonProperty("retryDelay")
+  public int retryDelay() {
+    return retryDelay;
   }
 
    @JsonProperty("proxyHost")

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 @JsonTypeName(HttpStoragePluginConfig.NAME)
 public class HttpStoragePluginConfig extends StoragePluginConfig {
   private static final Logger logger = LoggerFactory.getLogger(HttpStoragePluginConfig.class);
+  protected static final int DEFAULT_RATE_LIMIT = 1000;
   public static final String NAME = "http";
 
   public final Map<String, HttpApiConfig> connections;
@@ -55,11 +56,13 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
    * Timeout in {@link TimeUnit#SECONDS}.
    */
   public final int timeout;
+  public final int rateLimit;
 
   @JsonCreator
   public HttpStoragePluginConfig(@JsonProperty("cacheResults") Boolean cacheResults,
                                  @JsonProperty("connections") Map<String, HttpApiConfig> connections,
                                  @JsonProperty("timeout") Integer timeout,
+                                 @JsonProperty("rateLimit") Integer rateLimit,
                                  @JsonProperty("username") String username,
                                  @JsonProperty("password") String password,
                                  @JsonProperty("proxyHost") String proxyHost,
@@ -84,6 +87,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
         AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER),
       oAuthConfig);
     this.cacheResults = cacheResults != null && cacheResults;
+    this.rateLimit = rateLimit == null ? DEFAULT_RATE_LIMIT : rateLimit;
 
     this.connections = CaseInsensitiveMap.newHashMap();
     if (connections != null) {
@@ -121,6 +125,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     this.proxyPort = that.proxyPort;
     this.proxyType = that.proxyType;
     this.oAuthConfig = that.oAuthConfig;
+    this.rateLimit = that.rateLimit;
   }
 
   /**
@@ -139,6 +144,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     this.proxyPort = that.proxyPort;
     this.proxyType = that.proxyType;
     this.oAuthConfig = that.oAuthConfig;
+    this.rateLimit = that.rateLimit;
   }
 
   private static String normalize(String value) {
@@ -159,6 +165,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
       cacheResults,
       configFor(connectionName),
       timeout,
+      rateLimit,
       username(),
       password(),
       proxyHost,
@@ -189,6 +196,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
     return Objects.equals(connections, thatConfig.connections) &&
       Objects.equals(cacheResults, thatConfig.cacheResults) &&
       Objects.equals(proxyHost, thatConfig.proxyHost) &&
+      Objects.equals(rateLimit, thatConfig.rateLimit) &&
       Objects.equals(proxyPort, thatConfig.proxyPort) &&
       Objects.equals(proxyType, thatConfig.proxyType) &&
       Objects.equals(oAuthConfig, thatConfig.oAuthConfig) &&
@@ -202,6 +210,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
       .field("connections", connections)
       .field("cacheResults", cacheResults)
       .field("timeout", timeout)
+      .field("rateLimit", rateLimit)
       .field("proxyHost", proxyHost)
       .field("proxyPort", proxyPort)
       .field("credentialsProvider", credentialsProvider)
@@ -213,7 +222,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hash(connections, cacheResults, timeout,
+    return Objects.hash(connections, cacheResults, timeout, rateLimit,
         proxyHost, proxyPort, proxyType, oAuthConfig, credentialsProvider, authMode);
   }
 
@@ -225,6 +234,11 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
 
   @JsonProperty("timeout")
   public int timeout() { return timeout;}
+
+  @JsonProperty("rateLimit")
+  public int rateLimit() {
+    return rateLimit;
+  }
 
    @JsonProperty("proxyHost")
   public String proxyHost() { return proxyHost; }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePluginConfig.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.http;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.logical.OAuthConfig;
@@ -42,9 +43,10 @@ import java.util.concurrent.TimeUnit;
 
 
 @JsonTypeName(HttpStoragePluginConfig.NAME)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class HttpStoragePluginConfig extends StoragePluginConfig {
   private static final Logger logger = LoggerFactory.getLogger(HttpStoragePluginConfig.class);
-  protected static final int DEFAULT_RATE_LIMIT = 1000;
+  private static final int DEFAULT_RATE_LIMIT = 1000;
   public static final String NAME = "http";
 
   public final Map<String, HttpApiConfig> connections;
@@ -87,7 +89,7 @@ public class HttpStoragePluginConfig extends StoragePluginConfig {
         AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER),
       oAuthConfig);
     this.cacheResults = cacheResults != null && cacheResults;
-    this.rateLimit = rateLimit == null ? DEFAULT_RATE_LIMIT : rateLimit;
+    this.rateLimit = (rateLimit == null || rateLimit < 0) ? DEFAULT_RATE_LIMIT : rateLimit;
 
     this.connections = CaseInsensitiveMap.newHashMap();
     if (connections != null) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -141,7 +141,7 @@ public class SimpleHttp implements AutoCloseable {
     this.filters = scanDefn.filters();
     this.url = url;
     this.tempDir = tempDir;
-    this.rateLimit = scanDefn.tableSpec().config().rateLimit();
+    this.rateLimit = scanDefn.tableSpec().config().retryDelay();
     this.proxyConfig = proxyConfig;
     this.errorContext = errorContext;
     this.tokenTable = scanDefn.tableSpec().getTokenTable();
@@ -1084,7 +1084,7 @@ public class SimpleHttp implements AutoCloseable {
       this.tokenTable = scanDefn.tableSpec().getTokenTable();
       this.filters = scanDefn.filters();
       this.username = scanDefn.getUserName();
-      this.rateLimit = scanDefn.tableSpec().config().rateLimit();
+      this.rateLimit = scanDefn.tableSpec().config().retryDelay();
       return this;
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -250,7 +250,6 @@ public class SimpleHttp implements AutoCloseable {
     builder.connectionPool(new ConnectionPool(0, 1, TimeUnit.SECONDS));
 
     // Code to skip SSL Certificate validation
-    // Sourced from https://stackoverflow.com/questions/60110848/how-to-disable-ssl-verification
     if (! apiConfig.verifySSLCert()) {
       try {
         TrustManager[] trustAllCerts = getAllTrustingTrustManager();
@@ -1029,9 +1028,8 @@ public class SimpleHttp implements AutoCloseable {
 
   /**
    * This interceptor is used in pagination situations or elsewhere when APIs have burst throttling. The rate limit interceptor
-   * will wait a configurable number of milliseconds and retry queries if it encounters a 429 response code.
-   *
-   * Code sourced from https://stackoverflow.com/questions/35364823/okhttp-api-rate-limit
+   * will wait a configurable number of milliseconds and retry queries if it encounters a 429
+   * response code.
    */
   public static class RateLimitInterceptor implements Interceptor {
     private final int millis;

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -138,7 +138,8 @@ public class TestHttpPlugin extends ClusterTest {
     configs.put("pokemon", pokemonConfig);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-        new HttpStoragePluginConfig(false, configs, 10, null, null, "", 80, "", "", "", null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER, AuthMode.SHARED_USER.name());
+        new HttpStoragePluginConfig(false, configs, 10, 1000, null, null, "", 80, "", "", "", null, PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER,
+          AuthMode.SHARED_USER.name());
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("live", mockStorageConfigWithWorkspace);
   }
@@ -355,7 +356,7 @@ public class TestHttpPlugin extends ClusterTest {
     configs.put("malformedJson", mockJsonWithMalformedData);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-        new HttpStoragePluginConfig(false, configs, 2, "globaluser", "globalpass", "",
+        new HttpStoragePluginConfig(false, configs, 2, 1000, "globaluser", "globalpass", "",
           80, "", "", "", null, new PlainCredentialsProvider(ImmutableMap.of(
           UsernamePasswordCredentials.USERNAME, "globaluser",
           UsernamePasswordCredentials.PASSWORD, "globalpass")), AuthMode.SHARED_USER.name());

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
@@ -117,7 +117,7 @@ public class TestHttpUDFFunctions extends ClusterTest {
     configs.put("basicJson", basicJson);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 200, "globaluser", "globalpass", "",
+      new HttpStoragePluginConfig(false, configs, 200, 1000, "globaluser", "globalpass", "",
         80, "", "", "", null, new PlainCredentialsProvider(ImmutableMap.of(
         UsernamePasswordCredentials.USERNAME, "globaluser",
         UsernamePasswordCredentials.PASSWORD, "globalpass")), AuthMode.SHARED_USER.name());

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
@@ -116,7 +116,7 @@ public class TestHttpUDFWithAliases extends ClusterTest {
     configs.put("basicJson", basicJson);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 200, "globaluser", "globalpass", "",
+      new HttpStoragePluginConfig(false, configs, 200, 1000, "globaluser", "globalpass", "",
         80, "", "", "", null, new PlainCredentialsProvider(ImmutableMap.of(
         UsernamePasswordCredentials.USERNAME, "globaluser",
         UsernamePasswordCredentials.PASSWORD, "globalpass")), AuthMode.SHARED_USER.name());

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
@@ -111,7 +111,7 @@ public class TestOAuthProcess extends ClusterTest {
 
     // Add storage plugin for test OAuth
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, TIMEOUT, null, null, "", 80, "", "", "",
+      new HttpStoragePluginConfig(false, configs, TIMEOUT, 1000, null, null, "", 80, "", "", "",
         oAuthConfig, credentialsProvider, AuthMode.SHARED_USER.name());
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("localOauth", mockStorageConfigWithWorkspace);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthTokenUpdate.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthTokenUpdate.java
@@ -91,7 +91,7 @@ public class TestOAuthTokenUpdate extends ClusterTest {
 
     // Add storage plugin for test OAuth
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, TIMEOUT,null, null, "", 80, "", "", "",
+      new HttpStoragePluginConfig(false, configs, TIMEOUT, 1000, null, null, "", 80, "", "", "",
         oAuthConfig, credentialsProvider, AuthMode.SHARED_USER.name());
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("localOauth", mockStorageConfigWithWorkspace);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -132,7 +132,7 @@ public class TestPagination extends ClusterTest {
     configs.put("github", githubConfig);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 10, null, null, "", 80, "", "", "", null,
+      new HttpStoragePluginConfig(false, configs, 10, 1000, null, null, "", 80, "", "", "", null,
         PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER, AuthMode.SHARED_USER.name());
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("live", mockStorageConfigWithWorkspace);
@@ -268,7 +268,7 @@ public class TestPagination extends ClusterTest {
     configs.put("xml_paginator_url_params", mockXmlConfigWithPaginatorAndUrlParams);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 2, null, null, "", 80, "", "", "", null,
+      new HttpStoragePluginConfig(false, configs, 2,1000, null, null, "", 80, "", "", "", null,
         PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER, AuthMode.SHARED_USER.name());
     mockStorageConfigWithWorkspace.setEnabled(true);
     cluster.defineStoragePlugin("local", mockStorageConfigWithWorkspace);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -316,6 +316,8 @@ public class TestPagination extends ClusterTest {
 
   @Test
   public void simpleJSONPaginatorQueryWith429() throws Exception {
+    // This test simulates an http request that hits a burst limit.   In this situation,
+    // Drill will wait and retry the request.
     String sql = "SELECT * FROM `local`.`json_paginator` LIMIT 4";
     try (MockWebServer server = startServer()) {
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestProvidedSchema.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestProvidedSchema.java
@@ -160,7 +160,7 @@ public class TestProvidedSchema extends ClusterTest {
     configs.put("noSchema", noSchema);
 
     HttpStoragePluginConfig mockStorageConfigWithWorkspace =
-      new HttpStoragePluginConfig(false, configs, 2, "globaluser", "globalpass", "",
+      new HttpStoragePluginConfig(false, configs, 2, 1000, "globaluser", "globalpass", "",
         80, "", "", "", null, new PlainCredentialsProvider(ImmutableMap.of(
         UsernamePasswordCredentials.USERNAME, "globaluser",
         UsernamePasswordCredentials.PASSWORD, "globalpass")), AuthMode.SHARED_USER.name());

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
@@ -133,11 +133,11 @@ public class TestUserTranslationInHttpPlugin extends ClusterTest {
 
     PlainCredentialsProvider credentialsProvider = new PlainCredentialsProvider(TEST_USER_2, credentials);
 
-    HttpStoragePluginConfig mockStorageConfigWithWorkspace = new HttpStoragePluginConfig(false, configs, 2, null, null, "", 80, "", "", "", null, credentialsProvider,
+    HttpStoragePluginConfig mockStorageConfigWithWorkspace = new HttpStoragePluginConfig(false, configs, 2, 1000, null, null, "", 80, "", "", "", null, credentialsProvider,
       AuthMode.USER_TRANSLATION.name());
     mockStorageConfigWithWorkspace.setEnabled(true);
 
-    HttpStoragePluginConfig mockOAuthPlugin = new HttpStoragePluginConfig(false, configs, 2, null, null, "", 80, "", "", "", oAuthConfig, oauthCredentialProvider,
+    HttpStoragePluginConfig mockOAuthPlugin = new HttpStoragePluginConfig(false, configs, 2, 1000, null, null, "", 80, "", "", "", oAuthConfig, oauthCredentialProvider,
       AuthMode.USER_TRANSLATION.name());
     mockOAuthPlugin.setEnabled(true);
 


### PR DESCRIPTION
# [DRILL-8342](https://issues.apache.org/jira/browse/DRILL-8342): Add Automatic Retry for Rate Limited APIs

## Description
Many APIs have a burst limit for number of requests.  This PR adds a retry capability to the HTTP Storage Plugin, whereby if a 429 response code is received, Drill will wait a configurable amount of time, and retry the request once. 
To prevent runaway pagination, this retry will only happen once per request. 
This PR adds a new configuration option called retryDelay which is the number of milliseconds that Drill should wait between retrys.

## Documentation
When using automatic pagination, you may encounter APIs that have burst limits or other limits as to the maximum number of requests in a minute or other amount of time.  Drill allows you to set a `retryDelay` parameter which is the number of milliseconds that Drill should wait before resending the request.  This defaults to 1 second.  This option is set in the configuration for the HTTP plugin.

## Testing
Added unit test.