### PR TITLE
DRILL-8345: Fix Eclipse compatibility in the Maven resources plugin config

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/udf/dynamic/JarBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/udf/dynamic/JarBuilder.java
@@ -31,6 +31,13 @@ import static org.junit.Assert.assertEquals;
 public class JarBuilder {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JarBuilder.class);
+  // This use of maven.multiModuleProjectDirectory cannot be changed to one of
+  // session.executionRootDirectory as has been done in /pom.xml for the sake
+  // Eclipse/m2e compatibility. Running the test class TestDynamicUDFSupport
+  // using mvn:surefire from exec/java-exec/ reveals the issues that arise if
+  // said change is attempted in this class. However, there is no need for it
+  // here since the way that maven.multiModuleProjectDirectory is used is already
+  // compatible with Eclipse/m2e.
   private static final String MAVEN_MULTI_MODULE_PROJECT_DIRECTORY = "maven.multiModuleProjectDirectory";
 
   private final MavenCli cli;
@@ -93,4 +100,3 @@ public class JarBuilder {
   }
 
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -603,8 +603,7 @@
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
               <resources>
                 <resource>
-                  <!--suppress UnresolvedMavenProperty -->
-                  <directory>${maven.multiModuleProjectDirectory}</directory>
+                  <directory>${session.executionRootDirectory}</directory>
                   <includes>
                     <include>git.properties</include>
                   </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,7 @@
           <configuration>
             <aggregate>true</aggregate>
             <!--suppress UnresolvedMavenProperty -->
-            <header>${maven.multiModuleProjectDirectory}/header</header>
+            <header>${session.executionRootDirectory}/header</header>
             <excludes>
               <exclude>**/clientlib/y2038/*.c</exclude> <!-- All the files here should have MIT License -->
               <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->


### PR DESCRIPTION
# [DRILL-8345](https://issues.apache.org/jira/browse/DRILL-8345): Fix Eclipse compatibility in the Maven resources plugin config

## Description

The Maven resources plugin config in /pom.xml makes use of the undocumented variable maven.multiModuleProjectDirectory to copy /git.properties to target/classes in every sub-module. This variable breaks the project build in Eclipse 2022-03, even when a .mvn directory is present at the project root, and was probably never meant for use by the public. Replacing it with the session.executionRootDirectory Maven variable fixes the build in Eclipse and retains the intended copying of git.properties during builds.


## Documentation
N/A

## Testing

1. Import the Drill Maven project from scratch into Eclipse 2022-03 and run a unit test
2. Import the Drill Maven project from scratch into IDEA 2021.2.4 and run a unit test
3. Delete all but the root git.properties then build the project using mvn and check that a git.properties is present in target/classes of all modules.
4. Test TestDynamicUDFSupport based on maven.multiModuleProjectDirectory in Eclipse (see code comment in this PR).
5. Run `mvn license:check` to test session.executionRootDirectory in the Maven license plugin.
