### PR TITLE
DRILL-8349: GoogleSheets Not Registering Schemas with Non Default Name

### DIFF
--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/schema/GoogleSheetsSchemaFactory.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/schema/GoogleSheetsSchemaFactory.java
@@ -22,13 +22,12 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.exec.store.AbstractSchemaFactory;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.googlesheets.GoogleSheetsStoragePlugin;
-import org.apache.drill.exec.store.googlesheets.GoogleSheetsStoragePluginConfig;
 
 public class GoogleSheetsSchemaFactory extends AbstractSchemaFactory {
   private final GoogleSheetsStoragePlugin plugin;
 
   public GoogleSheetsSchemaFactory(GoogleSheetsStoragePlugin plugin) {
-    super(GoogleSheetsStoragePluginConfig.NAME);
+    super(plugin.getName());
     this.plugin = plugin;
   }
 


### PR DESCRIPTION
# [DRILL-8349](https://issues.apache.org/jira/browse/DRILL-8349):  GoogleSheets Not Registering Schemas with Non Default Name

## Description
GoogleSheets plugin fails to register plugin instances with names other than `GoogleSheets`. 

## Documentation
No user facing changes.

## Testing
Tested manually and ran existing unit tests.