### PR TITLE
DRILL-8348: Cannot delete disabled storage plugins

### DIFF
--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsStoragePlugin.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsStoragePlugin.java
@@ -70,7 +70,7 @@ public class GoogleSheetsStoragePlugin extends AbstractStoragePlugin {
   public GoogleSheetsStoragePlugin(GoogleSheetsStoragePluginConfig configuration, DrillbitContext context, String name) {
     super(context, name);
     this.config = configuration;
-    this.tokenProvider = context.getoAuthTokenProvider();
+    this.tokenProvider = context.getOauthTokenProvider();
     this.schemaFactory = new GoogleSheetsSchemaFactory(this);
   }
 
@@ -182,7 +182,7 @@ public class GoogleSheetsStoragePlugin extends AbstractStoragePlugin {
    */
   @VisibleForTesting
   public void initializeTokenTableForTesting() {
-    OAuthTokenProvider tokenProvider = context.getoAuthTokenProvider();
+    OAuthTokenProvider tokenProvider = context.getOauthTokenProvider();
     tokenRegistry = tokenProvider.getOauthTokenRegistry(null);
   }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePlugin.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePlugin.java
@@ -75,7 +75,7 @@ public class HttpStoragePlugin extends AbstractStoragePlugin {
 
   @VisibleForTesting
   public void initializeOauthTokenTable(String username) {
-    OAuthTokenProvider tokenProvider = context.getoAuthTokenProvider();
+    OAuthTokenProvider tokenProvider = context.getOauthTokenProvider();
     tokenRegistry = tokenProvider.getOauthTokenRegistry(username);
     tokenRegistry.createTokenTable(getName());
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/oauth/OAuthTokenProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/oauth/OAuthTokenProvider.java
@@ -22,7 +22,7 @@ import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.server.DrillbitContext;
 
 /**
- * Class for managing oauth tokens.  Storage plugins will have to manage obtaining the plugins, but
+ * Class for managing oauth tokens.  Storage plugins will have to manage obtaining the tokens, but
  * these classes handle the storage of access and refresh tokens.
  */
 public class OAuthTokenProvider implements AutoCloseable {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/oauth/PersistentTokenRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/oauth/PersistentTokenRegistry.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 
 /**
  * Implementation of {@link TokenRegistry} that persists token tables
- * to the pre-configured persistent store.
+ * to the preconfigured persistent store.
  */
 public class PersistentTokenRegistry implements TokenRegistry {
   private final PersistentStore<PersistentTokenTable> store;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/oauth/TokenRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/oauth/TokenRegistry.java
@@ -34,8 +34,8 @@ public interface TokenRegistry extends AutoCloseable {
   PersistentTokenTable getTokenTable(String name);
 
   /**
-   * Deletes aliases table for specified {@code userName}.
-   * @param pluginName name of the user whose aliases table should be removed
+   * Deletes the token table for specified {@code pluginName}.
+   * @param pluginName name of the plugin whose token table should be removed
    */
   void deleteTokenTable(String pluginName);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -224,7 +224,7 @@ public class DrillbitContext implements AutoCloseable {
     return aliasRegistryProvider;
   }
 
-  public OAuthTokenProvider getoAuthTokenProvider() { return oAuthTokenProvider; }
+  public OAuthTokenProvider getOauthTokenProvider() { return oAuthTokenProvider; }
 
   public EventLoopGroup getBitLoopGroup() {
     return context.getControlLoopGroup();
@@ -317,7 +317,7 @@ public class DrillbitContext implements AutoCloseable {
     getCompiler().close();
     getMetastoreRegistry().close();
     getAliasRegistryProvider().close();
-    getoAuthTokenProvider().close();
+    getOauthTokenProvider().close();
   }
 
   public ResourceManager getResourceManager() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/OAuthRequests.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/OAuthRequests.java
@@ -63,7 +63,7 @@ public class OAuthRequests {
                                            SecurityContext sc) {
     try {
       DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
-      OAuthTokenProvider tokenProvider = context.getoAuthTokenProvider();
+      OAuthTokenProvider tokenProvider = context.getOauthTokenProvider();
       PersistentTokenTable tokenTable = tokenProvider.getOauthTokenRegistry(getQueryUser(storage.getPlugin(name).getConfig(), authEnabled, sc)).getTokenTable(name);
 
       // Set the access token
@@ -85,7 +85,7 @@ public class OAuthRequests {
                                             SecurityContext sc) {
     try {
       DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
-      OAuthTokenProvider tokenProvider = context.getoAuthTokenProvider();
+      OAuthTokenProvider tokenProvider = context.getOauthTokenProvider();
       PersistentTokenTable tokenTable = tokenProvider.getOauthTokenRegistry(
         getQueryUser(storage.getPlugin(name).getConfig(), authEnabled, sc)).getTokenTable(name);
 
@@ -107,7 +107,7 @@ public class OAuthRequests {
                                            UserAuthEnabled authEnabled, SecurityContext sc) {
     try {
       DrillbitContext context = ((AbstractStoragePlugin) storage.getPlugin(name)).getContext();
-      OAuthTokenProvider tokenProvider = context.getoAuthTokenProvider();
+      OAuthTokenProvider tokenProvider = context.getOauthTokenProvider();
       PersistentTokenTable tokenTable = tokenProvider
         .getOauthTokenRegistry(getQueryUser(storage.getPlugin(name).getConfig(), authEnabled, sc))
         .getTokenTable(name);
@@ -145,7 +145,7 @@ public class OAuthRequests {
       // If USER_TRANSLATION is enabled, Drill will create a token table for each user.
       TokenRegistry tokenRegistry = ((AbstractStoragePlugin) storage.getPlugin(name))
         .getContext()
-        .getoAuthTokenProvider()
+        .getOauthTokenProvider()
         .getOauthTokenRegistry(getQueryUser(storage.getPlugin(name).getConfig(), authEnabled, sc));
 
       // Add a token registry table if none exists

--- a/exec/java-exec/src/main/resources/rest/storage/update.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/update.ftl
@@ -204,8 +204,14 @@
 
     function deleteFunction() {
       showConfirmationDialog('"${model.getPlugin().getName()}"' + ' plugin will be deleted. Proceed?', function() {
-        $.get("/storage/" + encodeURIComponent("${model.getPlugin().getName()}") + "/delete", serverMessage).fail(function() {
-					serverMessage({ errorMessage: "Error while trying to delete." })
+        $.ajax({
+            url: '/storage/' + encodeURIComponent('${model.getPlugin().getName()}') + '.json',
+            method: 'DELETE',
+            contentType: 'application/json',
+            success: serverMessage,
+            error: function(request,msg,error) {
+              serverMessage({ errorMessage: 'Error while trying to delete.' })
+            }
         });
       });
     }


### PR DESCRIPTION
# [DRILL-8348](https://issues.apache.org/jira/browse/DRILL-8348): Cannot delete disabled storage plugins

## Description

Attempting to delete a disabled storage plugin fails due to code that tries to clean up its OAuth token registries in the process.

## Documentation
N/A

## Testing
Manually delete a disabled storage plugin in the web UI.
