### PR TITLE
DRILL-8299: HashMap key type mismatch in MetadataContext

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/MetadataContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/MetadataContext.java
@@ -50,7 +50,7 @@ public class MetadataContext {
     dirModifCheckMap.put(dir,  false);
   }
 
-  public boolean getStatus(String dir) {
+  public boolean getStatus(Path dir) {
     if (dirModifCheckMap.containsKey(dir)) {
       return dirModifCheckMap.get(dir);
     }
@@ -101,5 +101,3 @@ public class MetadataContext {
   }
 
 }
-
-

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata.java
@@ -575,7 +575,7 @@ public class Metadata {
     try (InputStream is = fs.open(path)) {
       boolean alreadyCheckedModification;
       boolean newMetadata = false;
-      alreadyCheckedModification = metaContext.getStatus(metadataParentDirPath);
+      alreadyCheckedModification = metaContext.getStatus(metadataParentDir);
 
       if (dirsOnly) {
         parquetTableMetadataDirs = mapper.readValue(is, ParquetTableMetadataDirs.class);


### PR DESCRIPTION
# [DRILL-8299](https://issues.apache.org/jira/browse/DRILL-8299): HashMap key type mismatch in MetadataContext

## Description

The Map dirModifCheckMap is keyed using a HDFS Path instance, not a string. This updates accessing code accordingly.

## Documentation
N/A

## Testing
Existing unit tests.
