### PR TITLE
DRILL-8238: Translation of IS NOT NULL($1) is not supported by MongoProject

### DIFF
--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
@@ -67,8 +67,9 @@ public interface MongoTestConstants {
 
   // test query template1
   String TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_1 = "SELECT `employee_id` FROM mongo.%s.`%s`";
-  String TEST_QUERY_PROJECT_PUSH_DOWN__TEMPLATE_2 = "select `employee_id`, `rating` from mongo.%s.`%s`";
-  String TEST_QUERY_PROJECT_PUSH_DOWN__TEMPLATE_3 = "select * from mongo.%s.`%s`";
+  String TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_2 = "select `employee_id`, `rating`, coalesce(`full_name`, 'Bob') from mongo.%s.`%s`";
+  String TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_3 = "select * from mongo.%s.`%s`";
+  String TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_4 = "select coalesce(`position_id`, -1) position_id_or_default from mongo.%s.`%s`";
   String TEST_FILTER_PUSH_DOWN_IS_NULL_QUERY_TEMPLATE_1 = "SELECT `employee_id` FROM mongo.%s.`%s` where position_id is null";
   String TEST_FILTER_PUSH_DOWN_IS_NOT_NULL_QUERY_TEMPLATE_1 = "SELECT `employee_id` FROM mongo.%s.`%s` where position_id is not null";
   String TEST_FILTER_PUSH_DOWN_EQUAL_QUERY_TEMPLATE_1 = "SELECT `full_name` FROM mongo.%s.`%s` where rating = 52.17";

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoFilterPushDown.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoFilterPushDown.java
@@ -60,4 +60,25 @@ public class TestMongoFilterPushDown extends MongoTestBase {
         .go();
   }
 
+  @Test
+  public void testFilterPushDownIsNull() throws Exception {
+    String queryString = String.format(TEST_FILTER_PUSH_DOWN_IS_NULL_QUERY_TEMPLATE_1, EMPLOYEE_DB, EMPINFO_COLLECTION);
+
+    testBuilder()
+        .sqlQuery(queryString)
+        .unOrdered()
+        .expectsNumRecords(2)
+        .go();
+  }
+
+  @Test
+  public void testFilterPushDownIsNotNull() throws Exception {
+    String queryString = String.format(TEST_FILTER_PUSH_DOWN_IS_NOT_NULL_QUERY_TEMPLATE_1, EMPLOYEE_DB, EMPINFO_COLLECTION);
+
+    testBuilder()
+        .sqlQuery(queryString)
+        .unOrdered()
+        .expectsNumRecords(17)
+        .go();
+  }
 }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoProjectPushDown.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoProjectPushDown.java
@@ -81,7 +81,7 @@ public class TestMongoProjectPushDown extends MongoTestBase {
 
   @Test
   public void testMultipleColumnsProject() throws Exception {
-    String query = String.format(TEST_QUERY_PROJECT_PUSH_DOWN__TEMPLATE_2, EMPLOYEE_DB, EMPINFO_COLLECTION);
+    String query = String.format(TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_2, EMPLOYEE_DB, EMPINFO_COLLECTION);
 
     testBuilder()
         .sqlQuery(query)
@@ -93,10 +93,23 @@ public class TestMongoProjectPushDown extends MongoTestBase {
 
   @Test
   public void testStarProject() throws Exception {
-    String query = String.format(TEST_QUERY_PROJECT_PUSH_DOWN__TEMPLATE_3, EMPLOYEE_DB, EMPINFO_COLLECTION);
+    String query = String.format(TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_3, EMPLOYEE_DB, EMPINFO_COLLECTION);
     testBuilder()
         .sqlQuery(query)
         .unOrdered()
+        .expectsNumRecords(19)
+        .go();
+  }
+
+  // DRILL-8238
+  @Test
+  public void testOperatorsProject() throws Exception {
+    String query = String.format(TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_4, EMPLOYEE_DB, EMPINFO_COLLECTION);
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("position_id_or_default")
         .expectsNumRecords(19)
         .go();
   }
@@ -122,5 +135,4 @@ public class TestMongoProjectPushDown extends MongoTestBase {
       .baselineValues(1194L, 1194L)
       .go();
   }
-
 }


### PR DESCRIPTION
# [DRILL-8238](https://issues.apache.org/jira/browse/DRILL-8238): Translation of IS NOT NULL($1) is not supported by MongoProject

## Description
Add translations of IS NULL and IS NOT NULL to $eq( , null) and $ne( , null) respectively. Note that $eq(x, null) matches records where x is missing _or_ x is null  while $ne(x, null) matches records where x is present _and_ x is not null making the second condition the logical negation of the first and preserving the SQL operator identity IS NOT NULL = NOT IS NULL.

## Documentation
N/A

## Testing
TestMongoProjectPushdown#testOperatorsProject
