### PR TITLE
DRILL-8296: Possible type mismatch bug in SplunkBatchReader

### DIFF
--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkUtils.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.drill.exec.store.splunk;
 
+import java.util.Arrays;
+
 public class SplunkUtils {
   /**
    * These are special fields that alter the queries sent to Splunk.
@@ -46,19 +48,15 @@ public class SplunkUtils {
       this.field = field;
     }
 
-  }
-
-  /**
-   * Indicates whether the field in question is a special field and should be pushed down to the query or not.
-   * @param unknownField The field to be pushed down
-   * @return true if the field is a special field, false if not.
-   */
-  public static boolean isSpecialField (String unknownField) {
-    for (SPECIAL_FIELDS specialFieldName : SPECIAL_FIELDS.values()) {
-      if (specialFieldName.field.equalsIgnoreCase(unknownField)) {
-        return true;
-      }
+    /**
+     * Indicates whether the field in question is a special field and should be
+     * pushed down to the query or not.
+     * @param unknownField The field to be pushed down
+     * @return true if the field is a special field, false if not.
+     */
+    public static boolean includes(String field) {
+      return Arrays.stream(SplunkUtils.SPECIAL_FIELDS.values())
+        .anyMatch(special -> field.equals(special.name()));
     }
-    return false;
   }
 }

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSplunkUtils.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSplunkUtils.java
@@ -31,17 +31,17 @@ public class SplunkTestSplunkUtils {
 
   @Test
   public void testIsSpecialField() {
-    assertTrue(SplunkUtils.isSpecialField("sourcetype"));
-    assertTrue(SplunkUtils.isSpecialField("earliestTime"));
-    assertTrue(SplunkUtils.isSpecialField("latestTime"));
-    assertTrue(SplunkUtils.isSpecialField("spl"));
+    assertTrue(SplunkUtils.SPECIAL_FIELDS.includes("sourcetype"));
+    assertTrue(SplunkUtils.SPECIAL_FIELDS.includes("earliestTime"));
+    assertTrue(SplunkUtils.SPECIAL_FIELDS.includes("latestTime"));
+    assertTrue(SplunkUtils.SPECIAL_FIELDS.includes("spl"));
   }
 
   @Test
   public void testIsNotSpecialField() {
-    assertFalse(SplunkUtils.isSpecialField("bob"));
-    assertFalse(SplunkUtils.isSpecialField("ip_address"));
-    assertFalse(SplunkUtils.isSpecialField("mac_address"));
-    assertFalse(SplunkUtils.isSpecialField("latest_Time"));
+    assertFalse(SplunkUtils.SPECIAL_FIELDS.includes("bob"));
+    assertFalse(SplunkUtils.SPECIAL_FIELDS.includes("ip_address"));
+    assertFalse(SplunkUtils.SPECIAL_FIELDS.includes("mac_address"));
+    assertFalse(SplunkUtils.SPECIAL_FIELDS.includes("latest_Time"));
   }
 }


### PR DESCRIPTION
# [DRILL-8296](https://issues.apache.org/jira/browse/DRILL-8296): Possible type mismatch bug in SplunkBatchReader

## Description
```
      if (path.nameEquals("**")) {
        return true;
      } else {
        return specialFields.contains(path.getAsNamePart());
      }
```
LGTM and IntelliJ both say that NamePart type does not match the type stored in specialFields collection. This change refactors the code handling special fields.

## Documentation
N/A

## Testing
Splunk plugin unit tests.
