### PR TITLE
DRILL-8354: Add IS_EMPTY Function

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/IsEmptyDataFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/IsEmptyDataFunctions.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+<@pp.dropOutputFile />
+
+<@pp.changeOutputFile name="/org/apache/drill/exec/expr/fn/impl/IsEmptyRepeatedFunctions.java" />
+
+<#include "/@includes/license.ftl" />
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.*;
+
+/*
+ * This class is generated using freemarker and the ${.template_name} template.
+ */
+public class IsEmptyRepeatedFunctions {
+
+  private IsEmptyRepeatedFunctions() {
+  }
+
+  <#list countAggrTypes.countFunctionsInput as type>
+    <#if type?starts_with("Repeated")>
+  @FunctionTemplate(names = {"isempty", "is_empty"}, scope = FunctionTemplate.FunctionScope.SIMPLE)
+  public static class ContainsDataRepeated${type} implements DrillSimpleFunc {
+
+    @Param
+    ${type}Holder input;
+    @Output
+    BitHolder out;
+
+    @Override
+    public void setup() {
+    }
+
+    @Override
+    public void eval() {
+      out.value = input.reader.size() != 0 ? 1 : 0;
+    }
+  }
+
+    </#if>
+  </#list>
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/IsEmptyScalarFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/IsEmptyScalarFunctions.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.holders.BitHolder;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+
+
+@SuppressWarnings("unused")
+public class IsEmptyScalarFunctions {
+
+  private IsEmptyScalarFunctions() {
+  }
+
+  @FunctionTemplate(names = {"isempty", "is_empty"},
+    scope = FunctionTemplate.FunctionScope.SIMPLE)
+  public static class IsEmptyVarcharFunctions implements DrillSimpleFunc {
+
+    @Param
+    NullableVarCharHolder input;
+
+    @Output
+    BitHolder out;
+
+    @Override
+    public void setup() {
+      // no op
+    }
+
+    @Override
+    public void eval() {
+      if (input.start == 0 && input.end == 0) {
+        out.value = 1;
+      } else {
+        String data = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
+        out.value = org.apache.commons.lang3.StringUtils.isEmpty(data) ? 1 : 0;
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"isempty", "is_empty"},
+    scope = FunctionTemplate.FunctionScope.SIMPLE,
+    nulls = NullHandling.INTERNAL)
+  public static class IsEmptyMapFunctions implements DrillSimpleFunc {
+
+    @Param
+    FieldReader input;
+
+    @Output
+    BitHolder out;
+
+    @Override
+    public void setup() {
+      // no op
+    }
+
+    @Override
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.IsEmptyUtils.mapIsEmpty(input) ? 1 : 0;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/IsEmptyUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/IsEmptyUtils.java
@@ -34,7 +34,7 @@ public class IsEmptyUtils {
     if (reader.getType().getMinorType() == MinorType.MAP) {
       SingleMapReaderImpl mapReader = (SingleMapReaderImpl) reader;
 
-      // If the map reader has no fields returns nothing return true
+      // If the map reader has no fields return true
       if (!mapReader.iterator().hasNext()) {
         return true;
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/IsEmptyUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/IsEmptyUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.vector.complex.impl.SingleMapReaderImpl;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+
+public class IsEmptyUtils {
+
+  /**
+   * This function recursively traverses a Drill map to determine whether the map is empty or not.
+   * @param reader A {@link FieldReader} containing the field in question
+   * @return True if the field contains no data, false if it does.
+   */
+  public static boolean mapIsEmpty(FieldReader reader) {
+
+    if (reader.getType().getMinorType() == MinorType.MAP) {
+      SingleMapReaderImpl mapReader = (SingleMapReaderImpl) reader;
+
+      // If the map reader has no fields returns nothing return true
+      if (!mapReader.iterator().hasNext()) {
+        return true;
+      }
+      // Now check to see whether the fields contain anything
+      boolean isEmpty = true;
+      for (String fieldName : reader) {
+        FieldReader fieldReader = reader.reader(fieldName);
+        if (fieldReader.isSet() && fieldReader.getType().getMinorType() == MinorType.MAP) {
+          boolean innerMapIsEmpty = mapIsEmpty(fieldReader);
+
+          if (!innerMapIsEmpty) {
+            isEmpty = false;
+          }
+
+        } else if (fieldReader.isSet()) {
+          isEmpty = false;
+        }
+      }
+      return isEmpty;
+    } else {
+      return ! reader.isSet();
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestIsEmptyFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestIsEmptyFunctions.java
@@ -44,6 +44,7 @@ public class TestIsEmptyFunctions extends ClusterTest {
       .baselineColumns("numeric_col")
       .baselineValues(1.3)
       .baselineValues(2.3)
+      .baselineValues(1.0)
       .go();
   }
 
@@ -79,7 +80,7 @@ public class TestIsEmptyFunctions extends ClusterTest {
       .sqlQuery(sql)
       .unOrdered()
       .baselineColumns("row_count")
-      .baselineValues(2L)
+      .baselineValues(3L)
       .go();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestIsEmptyFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestIsEmptyFunctions.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.fn.impl;
+
+import org.apache.drill.categories.SqlFunctionTest;
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({UnlikelyTest.class, SqlFunctionTest.class})
+public class TestIsEmptyFunctions extends ClusterTest {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
+  }
+
+  @Test
+  public void testIsEmptyWithNumericColumn() throws Exception {
+    String sql = "SELECT numeric_col FROM cp.`jsoninput/is_empty_tests.json` WHERE NOT is_empty" +
+      "(numeric_col)";
+    testBuilder()
+      .sqlQuery(sql)
+      .unOrdered()
+      .baselineColumns("numeric_col")
+      .baselineValues(1.3)
+      .baselineValues(2.3)
+      .go();
+  }
+
+  @Test
+  public void testIsEmptyWithTextColumn() throws Exception {
+    String sql = "SELECT text_col FROM cp.`jsoninput/is_empty_tests.json` WHERE NOT is_empty" +
+      "(text_col)";
+    testBuilder()
+      .sqlQuery(sql)
+      .unOrdered()
+      .baselineColumns("text_col")
+      .baselineValues("text")
+      .go();
+  }
+
+  @Test
+  public void testIsEmptyWithList() throws Exception {
+    String sql = "SELECT COUNT(*) AS row_count FROM cp.`jsoninput/is_empty_tests.json` WHERE " +
+      "is_empty(list_col)";
+    testBuilder()
+      .sqlQuery(sql)
+      .unOrdered()
+      .baselineColumns("row_count")
+      .baselineValues(1L)
+      .go();
+  }
+
+  @Test
+  public void testIsEmptyWithMap() throws Exception {
+    String sql = "SELECT COUNT(*) AS row_count FROM cp.`jsoninput/is_empty_tests.json` WHERE " +
+      "is_empty(map_column)";
+    testBuilder()
+      .sqlQuery(sql)
+      .unOrdered()
+      .baselineColumns("row_count")
+      .baselineValues(2L)
+      .go();
+  }
+
+}

--- a/exec/java-exec/src/test/resources/jsoninput/is_empty_tests.json
+++ b/exec/java-exec/src/test/resources/jsoninput/is_empty_tests.json
@@ -1,0 +1,27 @@
+[
+  {
+    "numeric_col": 1.3,
+    "text_col": "text",
+    "list_col": [
+      "v1", "v2"
+    ],
+   "map_column": {
+    "field1": "value1",
+    "field2": "value2",
+    "nested_map": {
+      "nested_field1": "nested_value1",
+      "nested_field2" : "nested_value2"
+      }
+    }
+  },{
+    "numeric_col": 2.3,
+    "text_col": "",
+    "list_col": [],
+    "map_column": {}
+  },{
+    "numeric_col": null,
+    "text_col": null,
+    "list_col": [],
+    "map_column": {}
+  }
+]

--- a/exec/java-exec/src/test/resources/jsoninput/is_empty_tests.json
+++ b/exec/java-exec/src/test/resources/jsoninput/is_empty_tests.json
@@ -23,5 +23,7 @@
     "text_col": null,
     "list_col": [],
     "map_column": {}
+  },{
+  "numeric_col": 1
   }
 ]


### PR DESCRIPTION
# [DRILL-8354](https://issues.apache.org/jira/browse/DRILL-8354): Add IS_EMPTY Function

## Description
When analyzing data, there is currently no single function to evaluate whether a given field is empty.  With scalar fields, this can be accomplished with the `IS NOT NULL` operator, but with complex fields, this is more challenging as complex fields are never null. 
This PR adds a UDF called `IS_EMPTY()` which accepts any type of field and returns true if the field does not contain data.  

In the case of scalar fields, if the field is `null` this returns true.  In the case of complex fields, which can never be `null`, in the case of lists, the function returns true if the list is empty.  In the case of maps, it returns true if all of the map's fields are unpopulated. 

## Documentation
I will update the documentation once this is merged.

## Testing
Added unit tests.