### PR TITLE
DRILL-8363: upgrade postgresql to 42.4.3 due to security issue

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -34,7 +34,7 @@
     <mysql.connector.version>8.0.28</mysql.connector.version>
     <clickhouse.jdbc.version>0.3.1</clickhouse.jdbc.version>
     <h2.version>2.1.210</h2.version>
-    <postgresql.version>42.4.1</postgresql.version>
+    <postgresql.version>42.4.3</postgresql.version>
     <mssql-jdbc.version>9.2.0.jre8</mssql-jdbc.version>
     <jtds.version>1.3.1</jtds.version>
   </properties>


### PR DESCRIPTION
## Description

* https://issues.apache.org/jira/browse/DRILL-8363
* https://github.com/advisories/GHSA-562r-vg33-8x8h

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
