### PR TITLE
DRILL-8359: Add mount and unmount command support to the filesystem plugin

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -212,6 +212,7 @@ public final class ExecConstants {
 
   public static final String TEXT_LINE_READER_BATCH_SIZE = "drill.exec.storage.file.text.batch.size";
   public static final String TEXT_LINE_READER_BUFFER_SIZE = "drill.exec.storage.file.text.buffer.size";
+  public static final String FILE_PLUGIN_MOUNT_COMMANDS = "drill.exec.storage.file.enable_mount_commands";
   public static final String HAZELCAST_SUBNETS = "drill.exec.cache.hazel.subnets";
   public static final String HTTP_ENABLE = "drill.exec.http.enabled";
   public static final String HTTP_MAX_PROFILES = "drill.exec.http.max_profiles";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
@@ -93,6 +93,12 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
   public void start() throws IOException { }
 
   @Override
+  public void onEnabled() throws Exception { }
+
+  @Override
+  public void onDisabled() throws Exception { }
+
+  @Override
   public void close() throws Exception { }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ClassicConnectorLocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ClassicConnectorLocator.java
@@ -271,9 +271,8 @@ public class ClassicConnectorLocator implements ConnectorLocator {
     }
     try {
       plugin = constructor.newInstance(pluginConfig, context.drillbitContext(), name);
-      plugin.start();
       return plugin;
-    } catch (ReflectiveOperationException | IOException e) {
+    } catch (ReflectiveOperationException e) {
       Throwable t = e instanceof InvocationTargetException ? ((InvocationTargetException) e).getTargetException() : e;
       if (t instanceof ExecutionSetupException) {
         throw ((ExecutionSetupException) t);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
@@ -48,6 +48,20 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
   void start() throws IOException;
 
   /**
+   * Lifecycle method allowing the plugin to perform operations when it has been enabled.
+   * @throws Exception in the event of an error. The exception will be propagated
+   * but the enabling of the plugin will _not_ be rolled back.
+   */
+  void onEnabled() throws Exception;
+
+  /**
+   * Lifecycle method allowing the plugin to perform operations when it has been disabled.
+   * @throws Exception in the event of an error. The exception will be propagated
+   * but the disabling of the plugin will _not_ be rolled back.
+   */
+  void onDisabled() throws Exception;
+
+  /**
    * Indicates if Drill can read the table from this format.
   */
   boolean supportsRead();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemConfig.java
@@ -54,6 +54,7 @@ public class FileSystemConfig extends StoragePluginConfig {
   public static final String NAME = "file";
 
   private final String connection;
+  private final String[] mountCommand, unmountCommand;
   private final Map<String, String> config;
   private final Map<String, WorkspaceConfig> workspaces;
   private final Map<String, FormatPluginConfig> formats;
@@ -65,7 +66,7 @@ public class FileSystemConfig extends StoragePluginConfig {
     Map<String, FormatPluginConfig> formats,
     OAuthConfig oAuthConfig,
     CredentialsProvider credentialsProvider) {
-    this(connection, config, workspaces, formats, oAuthConfig, null,
+    this(connection, null, null, config, workspaces, formats, oAuthConfig, null,
       credentialsProvider);
   }
 
@@ -74,12 +75,14 @@ public class FileSystemConfig extends StoragePluginConfig {
     Map<String, WorkspaceConfig> workspaces,
     Map<String, FormatPluginConfig> formats,
     CredentialsProvider credentialsProvider) {
-    this(connection, config, workspaces, formats, null, null,
+    this(connection, null, null, config, workspaces, formats, null, null,
       credentialsProvider);
   }
 
   @JsonCreator
   public FileSystemConfig(@JsonProperty("connection") String connection,
+                          @JsonProperty("mountCommand") String[] mountCommand,
+                          @JsonProperty("unmountCommand") String[] unmountCommand,
                           @JsonProperty("config") Map<String, String> config,
                           @JsonProperty("workspaces") Map<String, WorkspaceConfig> workspaces,
                           @JsonProperty("formats") Map<String, FormatPluginConfig> formats,
@@ -88,6 +91,8 @@ public class FileSystemConfig extends StoragePluginConfig {
                           @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider) {
     super(credentialsProvider, credentialsProvider == null, AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER), oAuthConfig);
     this.connection = connection;
+    this.mountCommand = mountCommand;
+    this.unmountCommand = unmountCommand;
 
     // Force creation of an empty map so that configs compare equal
     Builder<String, String> builder = ImmutableMap.builder();
@@ -105,6 +110,16 @@ public class FileSystemConfig extends StoragePluginConfig {
   @JsonProperty
   public String getConnection() {
     return connection;
+  }
+
+  @JsonProperty
+  public String[] getMountCommand() {
+    return mountCommand;
+  }
+
+  @JsonProperty
+  public String[] getUnmountCommand() {
+    return unmountCommand;
   }
 
   @JsonProperty
@@ -142,6 +157,8 @@ public class FileSystemConfig extends StoragePluginConfig {
     }
     FileSystemConfig other = (FileSystemConfig) obj;
     return Objects.equals(connection, other.connection) &&
+           Arrays.equals(mountCommand, other.mountCommand) &&
+           Arrays.equals(unmountCommand, other.unmountCommand) &&
            Objects.equals(config, other.config) &&
            Objects.equals(formats, other.formats) &&
            Objects.equals(workspaces, other.workspaces);
@@ -151,6 +168,8 @@ public class FileSystemConfig extends StoragePluginConfig {
   public String toString() {
     return new PlanStringBuilder(this)
         .field("connection", connection)
+        .field("mountCommand", mountCommand)
+        .field("unmountCommand", unmountCommand)
         .field("config", config)
         .field("formats", formats)
         .field("workspaces", workspaces)
@@ -184,9 +203,18 @@ public class FileSystemConfig extends StoragePluginConfig {
       formatsCopy = formatsCopy == null ? new LinkedHashMap<>() : formatsCopy;
       formatsCopy.putAll(newFormats);
     }
-    FileSystemConfig newConfig =
-        new FileSystemConfig(connection, configCopy, workspaces, formatsCopy, oAuthConfig,
-          authMode.name(), credentialsProvider);
+
+    FileSystemConfig newConfig = new FileSystemConfig(
+      connection,
+      mountCommand,
+      unmountCommand,
+      configCopy,
+      workspaces,
+      formatsCopy,
+      oAuthConfig,
+      authMode.name(),
+      credentialsProvider
+    );
     newConfig.setEnabled(isEnabled());
     return newConfig;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemConfig.java
@@ -54,7 +54,7 @@ public class FileSystemConfig extends StoragePluginConfig {
   public static final String NAME = "file";
 
   private final String connection;
-  private final String[] mountCommand, unmountCommand;
+  private final List<String> mountCommand, unmountCommand;
   private final Map<String, String> config;
   private final Map<String, WorkspaceConfig> workspaces;
   private final Map<String, FormatPluginConfig> formats;
@@ -81,8 +81,8 @@ public class FileSystemConfig extends StoragePluginConfig {
 
   @JsonCreator
   public FileSystemConfig(@JsonProperty("connection") String connection,
-                          @JsonProperty("mountCommand") String[] mountCommand,
-                          @JsonProperty("unmountCommand") String[] unmountCommand,
+                          @JsonProperty("mountCommand") List<String> mountCommand,
+                          @JsonProperty("unmountCommand") List<String> unmountCommand,
                           @JsonProperty("config") Map<String, String> config,
                           @JsonProperty("workspaces") Map<String, WorkspaceConfig> workspaces,
                           @JsonProperty("formats") Map<String, FormatPluginConfig> formats,
@@ -113,12 +113,12 @@ public class FileSystemConfig extends StoragePluginConfig {
   }
 
   @JsonProperty
-  public String[] getMountCommand() {
+  public List<String> getMountCommand() {
     return mountCommand;
   }
 
   @JsonProperty
-  public String[] getUnmountCommand() {
+  public List<String> getUnmountCommand() {
     return unmountCommand;
   }
 
@@ -157,8 +157,8 @@ public class FileSystemConfig extends StoragePluginConfig {
     }
     FileSystemConfig other = (FileSystemConfig) obj;
     return Objects.equals(connection, other.connection) &&
-           Arrays.equals(mountCommand, other.mountCommand) &&
-           Arrays.equals(unmountCommand, other.unmountCommand) &&
+           Objects.equals(mountCommand, other.mountCommand) &&
+           Objects.equals(unmountCommand, other.unmountCommand) &&
            Objects.equals(config, other.config) &&
            Objects.equals(formats, other.formats) &&
            Objects.equals(workspaces, other.workspaces);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
@@ -347,8 +346,8 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
    * @return true if the configured mount command was executed
    */
   private synchronized boolean mount() {
-    String[] mountCmd = config.getMountCommand();
-    if (ArrayUtils.isEmpty(mountCmd)) {
+    List<String> mountCmd = config.getMountCommand();
+    if (mountCmd == null || mountCmd.isEmpty()) {
       return false;
     }
     if (!mountCommandsEnabled) {
@@ -361,7 +360,7 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
     }
 
     try {
-      Process proc = Runtime.getRuntime().exec(mountCmd);
+      Process proc = Runtime.getRuntime().exec(mountCmd.toArray(new String[0]));
       if (proc.waitFor() != 0) {
         String stderrOutput = IOUtils.toString(proc.getErrorStream(), StandardCharsets.UTF_8);
         throw new IOException(stderrOutput);
@@ -382,8 +381,8 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
    * @return true if the configured unmount command was executed
    */
   private synchronized boolean unmount() {
-    String[] unmountCmd = config.getUnmountCommand();
-    if (ArrayUtils.isEmpty(unmountCmd)) {
+    List<String> unmountCmd = config.getUnmountCommand();
+    if (unmountCmd == null || unmountCmd.isEmpty()) {
       return false;
     }
     if (!mountCommandsEnabled) {
@@ -395,7 +394,7 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
         .build(logger);
     }
     try {
-      Process proc = Runtime.getRuntime().exec(unmountCmd);
+      Process proc = Runtime.getRuntime().exec(unmountCmd.toArray(new String[0]));
       if (proc.waitFor() != 0) {
         String stderrOutput = IOUtils.toString(proc.getErrorStream(), StandardCharsets.UTF_8);
         throw new IOException(stderrOutput);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -412,9 +412,7 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
 
   @Override
   public void start() {
-    // config.isEnabled() is not a reliable way to tell if we're currently enabled
-    boolean isEnabled = getContext().getStorage().getDefinedConfig(getName()) != null;
-    if (isEnabled) {
+    if (config.isEnabled()) {
       mount();
     }
   }
@@ -431,7 +429,8 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
 
   @Override
   public void close() {
-    // config.isEnabled() is not a reliable way to tell if we're currently enabled
+    // config.isEnabled() is not a reliable way to tell if we're still enabled
+    // at this stage
     boolean isEnabled = getContext().getStorage().getDefinedConfig(getName()) != null;
     if (isEnabled) {
       unmount();

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -115,7 +115,8 @@ drill.exec: {
       text: {
         buffer.size: 262144,
         batch.size: 4000
-      }
+      },
+      enable_mount_commands: false
     },
     # The name of the file to scan for "classic" storage plugins
     # Configured here for ease of testing. Users should NEVER change

--- a/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
@@ -22,7 +22,7 @@ function serverMessage(data) {
         setTimeout(function() { window.location.href = "/storage"; }, 800);
         return true;
     } else {
-	    const errorMessage = data.errorMessage || data.responseJSON["result"];
+	    const errorMessage = data.errorMessage || data.responseJSON["result"] || data.responseJSON["message"];
 
         messageEl.addClass("d-none");
         // Wait a fraction of a second before showing the message again. This

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/BoxFileSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/BoxFileSystemTest.java
@@ -103,7 +103,7 @@ public class BoxFileSystemTest extends ClusterTest {
 
     CredentialsProvider credentialsProvider = new PlainCredentialsProvider(credentials);
 
-    StoragePluginConfig boxConfig = new FileSystemConfig("box:///", boxConfigVars,
+    StoragePluginConfig boxConfig = new FileSystemConfig("box:///", null, null, boxConfigVars,
       workspaces, formats, oAuthConfig, AuthMode.SHARED_USER.name(), credentialsProvider);
     boxConfig.setEnabled(true);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestMountCommand.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestMountCommand.java
@@ -23,13 +23,13 @@ import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
-import org.apache.hadoop.fs.FileSystem;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
 
+import static org.apache.drill.exec.ExecConstants.FILE_PLUGIN_MOUNT_COMMANDS;
 import static org.apache.drill.exec.util.StoragePluginTestUtils.DFS_PLUGIN_NAME;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -37,13 +37,14 @@ import static org.junit.Assert.assertTrue;
 @Category(UnlikelyTest.class)
 public class TestMountCommand extends ClusterTest {
 
-  private static FileSystem fs;
   private static File testFile;
   private static String touchCmd, rmCmd;
 
   @BeforeClass
   public static void setup() throws Exception {
-    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
+      .configProperty(FILE_PLUGIN_MOUNT_COMMANDS, true);
+
     startCluster(builder);
 
     // A file that will be created by the filesystem plugin's mount command
@@ -75,6 +76,7 @@ public class TestMountCommand extends ClusterTest {
       dfsConfig.getConfig(),
       dfsConfig.getWorkspaces(),
       dfsConfig.getFormats(),
+      null, null,
       dfsConfig.getCredentialsProvider()
     );
     dfsConfigNew.setEnabled(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestMountCommand.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestMountCommand.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
+import java.util.Arrays;
 
 import static org.apache.drill.exec.ExecConstants.FILE_PLUGIN_MOUNT_COMMANDS;
 import static org.apache.drill.exec.util.StoragePluginTestUtils.DFS_PLUGIN_NAME;
@@ -71,8 +72,8 @@ public class TestMountCommand extends ClusterTest {
 
     FileSystemConfig dfsConfigNew = new FileSystemConfig(
       dfsConfig.getConnection(),
-      String.format(touchCmd, testFile.getAbsolutePath()).split(" "),
-      String.format(rmCmd, testFile.getAbsolutePath()).split(" "),
+      Arrays.asList(String.format(touchCmd, testFile.getAbsolutePath()).split(" ")),
+      Arrays.asList(String.format(rmCmd, testFile.getAbsolutePath()).split(" ")),
       dfsConfig.getConfig(),
       dfsConfig.getWorkspaces(),
       dfsConfig.getFormats(),

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestMountCommand.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestMountCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.dfs;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+
+import static org.apache.drill.exec.util.StoragePluginTestUtils.DFS_PLUGIN_NAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(UnlikelyTest.class)
+public class TestMountCommand extends ClusterTest {
+
+  private static FileSystem fs;
+  private static File testFile;
+  private static String touchCmd, rmCmd;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+
+    // A file that will be created by the filesystem plugin's mount command
+    // and deleted by its unmount command.
+    testFile = new File(String.format(
+      "%s/drill-mount-test",
+      cluster.getDrillTempDir().getAbsolutePath()
+    ));
+
+   if (SystemUtils.IS_OS_WINDOWS) {
+     touchCmd = "type nul > %s";
+     rmCmd = "del %s";
+   } else {
+     touchCmd = "touch %s";
+     rmCmd = "rm %s";
+   }
+  }
+
+  @Test
+  public void testMountUnmount() throws Exception {
+    StoragePluginRegistry pluginRegistry = cluster.storageRegistry();
+    FileSystemConfig dfsConfig = (FileSystemConfig) pluginRegistry
+      .getDefinedConfig(DFS_PLUGIN_NAME);
+
+    FileSystemConfig dfsConfigNew = new FileSystemConfig(
+      dfsConfig.getConnection(),
+      String.format(touchCmd, testFile.getAbsolutePath()).split(" "),
+      String.format(rmCmd, testFile.getAbsolutePath()).split(" "),
+      dfsConfig.getConfig(),
+      dfsConfig.getWorkspaces(),
+      dfsConfig.getFormats(),
+      dfsConfig.getCredentialsProvider()
+    );
+    dfsConfigNew.setEnabled(true);
+    pluginRegistry.put(DFS_PLUGIN_NAME, dfsConfigNew);
+
+    // Run a query to trigger the mount command because plugins are lazily initialised.
+    run("show files in %s", DFS_PLUGIN_NAME);
+    assertTrue(testFile.exists());
+
+    cluster.storageRegistry().setEnabled(DFS_PLUGIN_NAME, false);
+    assertFalse(testFile.exists());
+  }
+}


### PR DESCRIPTION
# [DRILL-8359](https://issues.apache.org/jira/browse/DRILL-8359): Add mount and unmount command support to the filesystem plugin

## Description

Optional mount and unmount commands are added to the filesystem plugin with the goal of enabling the dynamic definition of filesystem mounts in the storage configuration. It is mainly anticpiated that network and cloud filesystems that have FUSE drivers (sshfs, davfs, rclone, ...) will be used in this way but local device mounts and image/loop device mounts (ISO, IMG, squashfs, etc.) might also be of interest. Filesystems that can be mounted in this way become queryable by Drill without the burden of dedicated storage plugin development.

The provided commands are executed in their own processes by the host OS and run under the OS user that is running the Drill JVM. The mount command will be executed when an enabled plugin is initialised (something that is done lazily) and when it transitions from disabled to enabled. The provided unmount command will be executed whenever a plugin transitions from enabled to disabled and when the Drillbit shuts down while the plugin is enabled.

Example using udisks on Linux to mount and unmount an image of an ext4 filesystem.
```
{
  "type" : "file",
  "connection" : "file:///",
  "mountCommand" : [ "sh", "-c", "udisksctl loop-setup -f /tmp/test.img && udisksctl mount -b /dev/loop0" ],
  "unmountCommand" : [ "sh", "-c", "udisksctl unmount -b /dev/loop0 && udisksctl loop-delete -b /dev/loop0" ],
  "workspaces" : {
     ...
```

## Documentation
New sections to be added to the filesystem doc page. New boot option to be documented.

## Testing
New unit test TestMountCommand.
Manual test of mount commands through different sequences of startup, enable, disable, shutdown.
Manual test that mount commands are disabled by default.