### PR TITLE
DRILL-8365: HTTP Plugin Places Parameters in Wrong Place

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -263,8 +263,8 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
     logger.debug("Building URL from {}", baseUrl);
     HttpApiConfig apiConfig = subScan.tableSpec().connectionConfig();
 
-    // Append table name, if available.
-    if (subScan.tableSpec().tableName() != null) {
+    // Append table name, if present. When pagination is used, the paginator adds this.
+    if (subScan.tableSpec().tableName() != null && paginator == null) {
       baseUrl += subScan.tableSpec().tableName();
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -110,7 +110,16 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
 
     private Paginator getPaginator() {
       HttpUrl.Builder urlBuilder;
-      HttpUrl rawUrl = HttpUrl.parse(subScan.tableSpec().connectionConfig().url());
+      HttpUrl rawUrl;
+
+      // Append table name, if present.
+      if (subScan.tableSpec().tableName() != null) {
+        rawUrl = HttpUrl.parse(subScan.tableSpec().connectionConfig().url() + subScan.tableSpec().tableName());
+      } else {
+        rawUrl = HttpUrl.parse(subScan.tableSpec().connectionConfig().url());
+      }
+
+
 
       // If the URL is not parsable or otherwise invalid
       if (rawUrl == null) {


### PR DESCRIPTION
# [DRILL-8365](https://issues.apache.org/jira/browse/DRILL-8365): HTTP Plugin Places Parameters in Wrong Place

## Description
This PR fixes a bug when a user configures a HTTP plugin with the `requireTail` option.  The plugin was putting the URL parameters in the wrong place when pagination is used.  This fixes that.

## Documentation
N/A

## Testing
Added unit test and ran existing unit tests.