### PR TITLE
DRILL-8366: Late release of compressor memory in the Parquet writer

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetRecordWriter.java
@@ -477,6 +477,7 @@ public class ParquetRecordWriter extends ParquetOutputRecordWriter {
     } finally {
       store.close();
       pageStore.close();
+      codecFactory.release();
 
       store = null;
       pageStore = null;
@@ -741,8 +742,6 @@ public class ParquetRecordWriter extends ParquetOutputRecordWriter {
   @Override
   public void cleanup() throws IOException {
     flush(true);
-
-    codecFactory.release();
   }
 
   private void createParquetFileWriter() throws IOException {


### PR DESCRIPTION
# [DRILL-8366](https://issues.apache.org/jira/browse/DRILL-8366): Late release of compressor memory in the Parquet writer

## Description

The Parquet writer waits until the end of the entire write before releasing its compression codec factory. The factory in turn releases compressors which release direct memory buffers used during compression. This deferred release leads a build up of direct memory use and can cause large write jobs to fail. The Parquet writer can instead release the abovementioned each time that a file/row group is flushed.

## Documentation
N/A

## Testing

Manually confirm the release of allocated compression buffers after each flush in the debug log output.
Manually monitor memory usage during a big Parquet write job.
