### PR TITLE
DRILL-8368: Update Yauaa to 7.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <httpdlog-parser.version>5.8</httpdlog-parser.version>
-    <yauaa.version>7.1.0</yauaa.version>
+    <yauaa.version>7.9.0</yauaa.version>
     <log4j.version>2.18.0</log4j.version>
     <aircompressor.version>0.20</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>


### PR DESCRIPTION
# [DRILL-8368](https://issues.apache.org/jira/browse/DRILL-8368): Updating Yauaa to 7.9.0

## Description

Updating dependency because of https://github.com/nielsbasjes/yauaa/security/advisories/GHSA-c4pm-63cg-9j7h
