### PR TITLE
DRILL-8369: Add support for querying DeltaLake snapshots by version

### DIFF
--- a/contrib/format-deltalake/README.md
+++ b/contrib/format-deltalake/README.md
@@ -16,6 +16,25 @@ For the case of filter pushdown, all expressions supported by Delta Lake API wil
 matches the filter expression will be read. Additionally, filtering logic for parquet files is enabled
 to allow pruning of parquet files that do not match the filter expression.
 
+### Querying specific table versions (snapshots)
+
+Delta Lake has the ability to travel back in time to the specific data version.
+
+The following ways of specifying data version are supported:
+
+- `version` - the version number of the specific snapshot
+- `timestamp` - the timestamp in milliseconds at or before which the specific snapshot was generated
+
+Table function can be used to specify one of the above configs in the following way:
+
+```sql
+SELECT *
+FROM table(dfs.tmp.testAllTypes(type => 'delta', version => 0));
+
+SELECT *
+FROM table(dfs.tmp.testAllTypes(type => 'delta', timestamp => 1636231332000));
+```
+
 ## Configuration
 
 The format plugin has the following configuration options:

--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/format/DeltaFormatPluginConfig.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/format/DeltaFormatPluginConfig.java
@@ -18,15 +18,55 @@
 package org.apache.drill.exec.store.delta.format;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.logical.FormatPluginConfig;
+
+import java.util.Objects;
 
 @JsonTypeName(DeltaFormatPluginConfig.NAME)
 public class DeltaFormatPluginConfig implements FormatPluginConfig {
 
   public static final String NAME = "delta";
 
+  private final Long version;
+  private final Long timestamp;
+
   @JsonCreator
-  public DeltaFormatPluginConfig() {
+  public DeltaFormatPluginConfig(@JsonProperty("version") Long version,
+    @JsonProperty("timestamp") Long timestamp) {
+    this.version = version;
+    this.timestamp = timestamp;
+  }
+
+  @JsonProperty("version")
+  public Long getVersion() {
+    return version;
+  }
+
+  @JsonProperty("timestamp")
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeltaFormatPluginConfig that = (DeltaFormatPluginConfig) o;
+    return Objects.equals(version, that.version) && Objects.equals(timestamp, that.timestamp);
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+      .field("version", version)
+      .field("timestamp", timestamp)
+      .toString();
   }
 }

--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaLatestSnapshot.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaLatestSnapshot.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.delta.snapshot;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Snapshot;
+
+public class DeltaLatestSnapshot implements DeltaSnapshot {
+  public static final DeltaLatestSnapshot INSTANCE = new DeltaLatestSnapshot();
+
+  @Override
+  public Snapshot apply(DeltaLog log) {
+    return log.snapshot();
+  }
+}

--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshot.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshot.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.delta.snapshot;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Snapshot;
+
+public interface DeltaSnapshot {
+
+  Snapshot apply(DeltaLog log);
+}

--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshotByTimestamp.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshotByTimestamp.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.delta.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Snapshot;
+
+@JsonTypeName("timestamp")
+public class DeltaSnapshotByTimestamp implements DeltaSnapshot {
+  private final long timestamp;
+
+  public DeltaSnapshotByTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @Override
+  public Snapshot apply(DeltaLog log) {
+    return log.getSnapshotForTimestampAsOf(timestamp);
+  }
+}

--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshotByVersion.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshotByVersion.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.delta.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Snapshot;
+
+@JsonTypeName("version")
+public class DeltaSnapshotByVersion implements DeltaSnapshot {
+  private final long version;
+
+  public DeltaSnapshotByVersion(long version) {
+    this.version = version;
+  }
+
+  @Override
+  public Snapshot apply(DeltaLog log) {
+    return log.getSnapshotForVersionAsOf(version);
+  }
+}

--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshotFactory.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/snapshot/DeltaSnapshotFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.delta.snapshot;
+
+public class DeltaSnapshotFactory {
+  public static final DeltaSnapshotFactory INSTANCE = new DeltaSnapshotFactory();
+
+  public DeltaSnapshot create(SnapshotContext context) {
+    if (context.getSnapshotAsOfVersion() != null) {
+      return new DeltaSnapshotByVersion(context.getSnapshotAsOfVersion());
+    } else if (context.getSnapshotAsOfTimestamp() != null) {
+      return new DeltaSnapshotByTimestamp(context.getSnapshotAsOfTimestamp());
+    } else {
+      return DeltaLatestSnapshot.INSTANCE;
+    }
+  }
+
+  public static class SnapshotContext {
+    private final Long snapshotAsOfVersion;
+
+    private final Long snapshotAsOfTimestamp;
+
+    SnapshotContext(SnapshotContextBuilder builder) {
+      this.snapshotAsOfVersion = builder.snapshotAsOfVersion;
+      this.snapshotAsOfTimestamp = builder.snapshotAsOfTimestamp;
+    }
+
+    public static SnapshotContextBuilder builder() {
+      return new SnapshotContextBuilder();
+    }
+
+    public Long getSnapshotAsOfVersion() {
+      return this.snapshotAsOfVersion;
+    }
+
+    public Long getSnapshotAsOfTimestamp() {
+      return this.snapshotAsOfTimestamp;
+    }
+
+    public static class SnapshotContextBuilder {
+      private Long snapshotAsOfVersion;
+
+      private Long snapshotAsOfTimestamp;
+
+      public SnapshotContextBuilder snapshotAsOfVersion(Long snapshotAsOfVersion) {
+        this.snapshotAsOfVersion = snapshotAsOfVersion;
+        return this;
+      }
+
+      public SnapshotContextBuilder snapshotAsOfTimestamp(Long snapshotAsOfTime) {
+        this.snapshotAsOfTimestamp = snapshotAsOfTime;
+        return this;
+      }
+
+      public SnapshotContext build() {
+        return new SnapshotContext(this);
+      }
+    }
+  }
+}

--- a/contrib/format-deltalake/src/test/java/org/apache/drill/exec/store/delta/DeltaQueriesTest.java
+++ b/contrib/format-deltalake/src/test/java/org/apache/drill/exec/store/delta/DeltaQueriesTest.java
@@ -44,7 +44,7 @@ public class DeltaQueriesTest extends ClusterTest {
     StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
     FileSystemConfig pluginConfig = (FileSystemConfig) pluginRegistry.getPlugin(DFS_PLUGIN_NAME).getConfig();
     Map<String, FormatPluginConfig> formats = new HashMap<>(pluginConfig.getFormats());
-    formats.put("delta", new DeltaFormatPluginConfig());
+    formats.put("delta", new DeltaFormatPluginConfig(null, null));
     FileSystemConfig newPluginConfig = new FileSystemConfig(
       pluginConfig.getConnection(),
       pluginConfig.getConfig(),
@@ -192,5 +192,18 @@ public class DeltaQueriesTest extends ClusterTest {
 
     long count = queryBuilder().sql(query).run().recordCount();
     assertEquals(1, count);
+  }
+
+  @Test
+  public void testSnapshotVersion() throws Exception {
+    String query = "select as_int, as_string " +
+      "from table(dfs.`data-reader-partition-values`(type => 'delta', version => 0))  where as_long = 1";
+
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("as_int", "as_string")
+      .baselineValues("1", "1")
+      .go();
   }
 }


### PR DESCRIPTION
# [DRILL-8369](https://issues.apache.org/jira/browse/DRILL-8369): Add support for querying DeltaLake snapshots by version

## Description
Added functionality for querying specific Delta Lake data versions.

## Documentation
See README.md

## Testing
Added UT.
