### PR TITLE
DRILL-8374: Set the Drill development version to 1.21.0-SNAPSHOT

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-common</artifactId>

--- a/contrib/data/pom.xml
+++ b/contrib/data/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.contrib.data</groupId>

--- a/contrib/data/tpch-sample-data/pom.xml
+++ b/contrib/data/tpch-sample-data/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-data-parent</artifactId>
     <groupId>org.apache.drill.contrib.data</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tpch-sample-data</artifactId>

--- a/contrib/format-deltalake/pom.xml
+++ b/contrib/format-deltalake/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-deltalake-format</artifactId>

--- a/contrib/format-esri/pom.xml
+++ b/contrib/format-esri/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-esri</artifactId>

--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-excel</artifactId>

--- a/contrib/format-hdf5/pom.xml
+++ b/contrib/format-hdf5/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-hdf5</artifactId>

--- a/contrib/format-httpd/pom.xml
+++ b/contrib/format-httpd/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>drill-format-httpd</artifactId>
   <name>Drill : Contrib : Format : Httpd/Nginx Access Log</name>

--- a/contrib/format-iceberg/pom.xml
+++ b/contrib/format-iceberg/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-iceberg-format</artifactId>

--- a/contrib/format-image/pom.xml
+++ b/contrib/format-image/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-image</artifactId>

--- a/contrib/format-log/pom.xml
+++ b/contrib/format-log/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-log</artifactId>

--- a/contrib/format-ltsv/pom.xml
+++ b/contrib/format-ltsv/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-ltsv</artifactId>

--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-mapr</artifactId>

--- a/contrib/format-pcapng/pom.xml
+++ b/contrib/format-pcapng/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-pcapng</artifactId>

--- a/contrib/format-pdf/pom.xml
+++ b/contrib/format-pdf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-pdf</artifactId>

--- a/contrib/format-sas/pom.xml
+++ b/contrib/format-sas/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-sas</artifactId>

--- a/contrib/format-spss/pom.xml
+++ b/contrib/format-spss/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-spss</artifactId>

--- a/contrib/format-syslog/pom.xml
+++ b/contrib/format-syslog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-syslog</artifactId>

--- a/contrib/format-xml/pom.xml
+++ b/contrib/format-xml/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-format-xml</artifactId>

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.contrib</groupId>

--- a/contrib/storage-cassandra/pom.xml
+++ b/contrib/storage-cassandra/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-cassandra</artifactId>

--- a/contrib/storage-drill/pom.xml
+++ b/contrib/storage-drill/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage</artifactId>

--- a/contrib/storage-druid/pom.xml
+++ b/contrib/storage-druid/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>drill-contrib-parent</artifactId>
         <groupId>org.apache.drill.contrib</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/contrib/storage-elasticsearch/pom.xml
+++ b/contrib/storage-elasticsearch/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-elasticsearch</artifactId>

--- a/contrib/storage-googlesheets/pom.xml
+++ b/contrib/storage-googlesheets/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-googlesheets</artifactId>

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-hbase</artifactId>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill.contrib.storage-hive</groupId>
     <artifactId>drill-contrib-storage-hive-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-hive-core</artifactId>

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill.contrib.storage-hive</groupId>
     <artifactId>drill-contrib-storage-hive-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-hive-exec-shaded</artifactId>

--- a/contrib/storage-hive/pom.xml
+++ b/contrib/storage-hive/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.drill.contrib</groupId>
     <artifactId>drill-contrib-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.contrib.storage-hive</groupId>

--- a/contrib/storage-http/pom.xml
+++ b/contrib/storage-http/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-http</artifactId>

--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-jdbc-storage</artifactId>

--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-kafka</artifactId>

--- a/contrib/storage-kudu/pom.xml
+++ b/contrib/storage-kudu/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-kudu-storage</artifactId>

--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-mongo-storage</artifactId>

--- a/contrib/storage-opentsdb/pom.xml
+++ b/contrib/storage-opentsdb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>drill-contrib-parent</artifactId>
         <groupId>org.apache.drill.contrib</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>drill-opentsdb-storage</artifactId>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.drill.contrib</groupId>
     <artifactId>drill-contrib-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>drill-storage-phoenix</artifactId>
   <name>Drill : Contrib : Storage : Phoenix</name>

--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-storage-splunk</artifactId>

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-udfs</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>distribution</artifactId>

--- a/drill-yarn/pom.xml
+++ b/drill-yarn/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-yarn</artifactId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>drill-java-exec</artifactId>
   <name>Drill : Exec : Java Execution Engine</name>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill.exec</groupId>
     <artifactId>exec-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-jdbc-all</artifactId>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.drill.exec</groupId>
     <artifactId>exec-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>drill-jdbc</artifactId>
   <name>Drill : Exec : JDBC Driver using dependencies</name>

--- a/exec/memory/base/pom.xml
+++ b/exec/memory/base/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>memory-parent</artifactId>
     <groupId>org.apache.drill.memory</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>drill-memory-base</artifactId>
   <name>Drill : Exec : Memory : Base</name>

--- a/exec/memory/pom.xml
+++ b/exec/memory/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.memory</groupId>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.exec</groupId>

--- a/exec/rpc/pom.xml
+++ b/exec/rpc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>drill-rpc</artifactId>
   <name>Drill : Exec : RPC</name>

--- a/exec/vector/pom.xml
+++ b/exec/vector/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <artifactId>vector</artifactId>
   <name>Drill : Exec : Vectors</name>

--- a/logical/pom.xml
+++ b/logical/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-logical</artifactId>

--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>metastore-parent</artifactId>
     <groupId>org.apache.drill.metastore</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-iceberg-metastore</artifactId>

--- a/metastore/metastore-api/pom.xml
+++ b/metastore/metastore-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill.metastore</groupId>
     <artifactId>metastore-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-metastore-api</artifactId>

--- a/metastore/mongo-metastore/pom.xml
+++ b/metastore/mongo-metastore/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>metastore-parent</artifactId>
     <groupId>org.apache.drill.metastore</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill</groupId>
     <artifactId>drill-root</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.metastore</groupId>

--- a/metastore/rdbms-metastore/pom.xml
+++ b/metastore/rdbms-metastore/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>metastore-parent</artifactId>
     <groupId>org.apache.drill.metastore</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-rdbms-metastore</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.apache.drill</groupId>
   <artifactId>drill-root</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>1.21.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Drill :</name>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-protocol</artifactId>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tools-parent</artifactId>
     <groupId>org.apache.drill.tools</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drill-fmpp-maven-plugin</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.drill.tools</groupId>


### PR DESCRIPTION
# [DRILL-8374](https://issues.apache.org/jira/browse/DRILL-8374): Set the Drill development version to 1.21.0-SNAPSHOT

## Description
Changes the Maven version numbers in the Drill master branch from 2.0.0 to 1.21.0. Discussion in the Drill mailing list established that the project would prefer to do a release in the near future than to wait to build up a changset for which a version jump to 2.0 would be appropriate.

## Documentation
N/A

## Testing
N/A
