### PR TITLE
DRILL-8378: Support doing Maven releases using modern JDKs

### DIFF
--- a/docs/dev/Release.md
+++ b/docs/dev/Release.md
@@ -88,7 +88,10 @@
             1. run `mvn --encrypt-master-password` and add an encrypted master password to `security-settings.xml` file;
             2. run `mvn --encrypt-password` and add an encrypted Apache LDAP password to `settings.xml` file.
     5. Check that `NOTICE` file in sources has the current copyright year.
-    6. ~~Make sure you are using JDK 8~~. Since the completion of DRILL-8113 it is now possible to build Drill using newer JDKs while continuing to target JDK 8. Nevertheless, always test Drill under JDK 8 after building it.
+    6. ~~Make sure you are using JDK 8~~. It is now possible to build (DRILL-8113) and release
+        (DRILL-8378) Drill using newer JDKs while continuing to target JDK 8. Nevertheless, always
+        test Drill under JDK 8 after building it.
+
 3. ## Manual Release process (this section is more for information how release process is performed, release manager should use `automated release process` described later).
     1. Setup GPG Password env variable:
         ```

--- a/pom.xml
+++ b/pom.xml
@@ -246,8 +246,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.1</version>
         <configuration>
-          <sourcepath>${basedir}</sourcepath>
           <sourceFileExcludes>
             <!-- Don't include codegen -->
             <exclude>**/src/main/codegen/**/*.java</exclude>

--- a/tools/release-scripts/release.sh
+++ b/tools/release-scripts/release.sh
@@ -71,7 +71,7 @@ function createDirectoryIfAbsent() {
 
 function readInputAndSetup(){
 
-    read -p "JAVA_HOME of the JDK 8 to use for the release : " JAVA_HOME
+    read -p "JAVA_HOME of the JDK to use for the release : " JAVA_HOME
     export JAVA_HOME
 
     read -p "Drill Working Directory : " WORK_DIR
@@ -152,8 +152,9 @@ runCmd "Clearing release history" mvn release:clean \
   -DpushChanges=false \
   -DskipTests
 
-export MAVEN_OPTS='-Xmx4g -XX:MaxPermSize=512m'
-runCmd "Preparing the release " mvn -X release:prepare \
+# Note that -XX:MaxPermSize=512m' is not supported in new JDKs
+export MAVEN_OPTS=-Xmx4g
+runCmd "Preparing the release " mvn release:prepare \
   -Papache-release \
   -DpushChanges=false \
   -DdevelopmentVersion=${DRILL_DEV_VERSION} \


### PR DESCRIPTION
# [DRILL-8378](https://issues.apache.org/jira/browse/DRILL-8378): Support doing Maven releases using modern JDKs

## Description

While [DRILL-8113](https://issues.apache.org/jira/browse/DRILL-8113) enabled the building of Drill using a modern JDK, more work is required to enable a Maven release of Drill using a modern JDK. Presently, the Maven Release Plugin will fail on Javadoc generation when run with a newer JDK while it succeeds with JDK 8. The failures are due to dependencies missing from the Maven Javadoc Plugin's config which I assume get treated with a more lenient "warn and skip" policy in the javadoc tool shipped with JDK 8 but cause errors in newer JDKs (in my case OpenJDK 17).

In particular, the presence of the `sourcepath` property in the javadoc plugin's config in the root pom causes the default javadoc:javadoc goal to try to generate docs for our src/test packages. Unlike the javadoc:test-javadoc, the javadoc:javadoc goal does not inherit dependencies declared with `test` scope so it fails to resolve those.

## Documentation
N/A

## Testing
Successfully run maven release:prepare using OpenJDK 17.
Successfully run mvn javadoc:javadoc in the Drill root module using OpenJDK 17 with HTML output generated under each module's target/site/apidocs directory.
