### PR TITLE
DRILL-5033: Query on JSON That Has Null as Value For Each Key

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
@@ -281,7 +281,8 @@ public class JsonReader extends BaseJsonReader {
           break;
 
         case VALUE_NULL:
-          // do nothing as we don't have a type.
+          // handle a null value as a string
+		  handleString(parser, map, fieldName);
           break;
 
         case VALUE_NUMBER_FLOAT:
@@ -413,6 +414,10 @@ public class JsonReader extends BaseJsonReader {
 
   private void handleString(JsonParser parser, MapWriter writer, String fieldName) throws IOException {
     try {
+		if (parser.nextToken() == VALUE_NULL)
+        writer.varChar(fieldName)
+          .writeVarChar(0, workingBuffer.prepareVarCharHolder("null"), workingBuffer.getBuf());
+      else
       writer.varChar(fieldName)
           .writeVarChar(0, workingBuffer.prepareVarCharHolder(parser.getText()), workingBuffer.getBuf());
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
# [DRILL-5033](https://issues.apache.org/jira/browse/DRILL-5033): Query on JSON That Has Null as Value For Each Key

## Description

Drill returns same result with or without `store.json.all_text_mode`=true
Note that each key in the JSON has null as its value.
[root@cent01 null_eq_joins]# cat right_all_nulls.json
```json
{
"intKey" : null,
"bgintKey": null,
"strKey": null,
"boolKey": null,
"fltKey": null,
"dblKey": null,
"timKey": null,
"dtKey": null,
"tmstmpKey": null,
"intrvldyKey": null,
"intrvlyrKey": null
}
```

Querying the above JSON file results in null as query result.
We should see each of the keys in the JSON as a column in query result.
And in each column the value should be a null value.
Current behavior does not look right.

```
0: jdbc:drill:schema=dfs.tmp> select * from `right_all_nulls.json`;
+-------+
|   *   |
+-------+
| null  |
+-------+
1 row selected (0.313 seconds)
```

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
