### PR TITLE
DRILL-8381: Add support for filtered aggregate calls

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -1254,4 +1254,21 @@ public class TestAggregateFunctions extends ClusterTest {
       .baselineValues("USA", 2.0816659994661326, 8L)
       .go();
   }
+
+  @Test
+  public void testAggregateWithFilterCall() throws Exception {
+    testBuilder()
+      .sqlQuery(
+        "SELECT count(n_name) FILTER(WHERE n_regionkey = 1) AS nations_count_in_1_region," +
+          "count(n_name) FILTER(WHERE n_regionkey = 2) AS nations_count_in_2_region," +
+          "count(n_name) FILTER(WHERE n_regionkey = 3) AS nations_count_in_3_region," +
+          "count(n_name) FILTER(WHERE n_regionkey = 4) AS nations_count_in_4_region," +
+          "count(n_name) FILTER(WHERE n_regionkey = 0) AS nations_count_in_0_region\n" +
+          "FROM cp.`tpch/nation.parquet`")
+      .unOrdered()
+      .baselineColumns("nations_count_in_1_region", "nations_count_in_2_region",
+        "nations_count_in_3_region", "nations_count_in_4_region", "nations_count_in_0_region")
+      .baselineValues(5L, 5L, 5L, 5L, 5L)
+      .go();
+  }
 }


### PR DESCRIPTION
# [DRILL-8381](https://issues.apache.org/jira/browse/DRILL-8381): Add support for filtered aggregate calls

## Description
For the case when filtering expression is specified, Drill will generate an `if` expression to obtain field value that will be used in aggregate function only when the filter predicate is true. Filter expression specified within an aggregate function is present in the underlying project, so it is enough to get a reference to it to use it as a condition.

## Documentation
NA

## Testing
Added UT.
