### PR TITLE
DRILL-8386: Add Support for User Translation for Cassandra

### DIFF
--- a/contrib/storage-cassandra/README.md
+++ b/contrib/storage-cassandra/README.md
@@ -5,7 +5,7 @@ This storage plugin implementation is based on [Apache Calcite adapter for Cassa
 
 This storage plugin may be used for querying Scylla DB.
 
-### Supported optimizations and features
+## Supported Optimizations and Features
 
 This storage plugin supports the following optimizations:
 
@@ -16,7 +16,7 @@ This storage plugin supports the following optimizations:
 Except for these optimizations, Cassandra storage plugin supports the schema provisioning feature.
 For more details please refer to [Specifying the Schema as Table Function Parameter](https://drill.apache.org/docs/plugin-configuration-basics/#specifying-the-schema-as-table-function-parameter).
 
-### Plugin registration
+## Plugin Registration
 
 The plugin can be registered in Apache Drill using the drill web interface by navigating to the `storage` page.
 Following is the default registration configuration.
@@ -32,7 +32,10 @@ Following is the default registration configuration.
 }
 ```
 
-### Developer notes
+### User Translation
+The Cassandra plugin supports user translation, which allows each user to authenticate using their own credentials instead of using system-wide credentials.  Simply set the `authMode` parameter to `USER_TRANSLATION` and use either the plain or vault credential provider for credentials.
+
+## Developer Notes
 
 Most of the common classes required for creating storage plugins based on Calcite adapters are placed in the 
 `java-exec` module, so they can be reused in future plugin implementations.

--- a/contrib/storage-cassandra/src/main/java/org/apache/drill/exec/store/cassandra/CassandraStorageConfig.java
+++ b/contrib/storage-cassandra/src/main/java/org/apache/drill/exec/store/cassandra/CassandraStorageConfig.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.exec.store.security.CredentialProviderUtils;
 import org.apache.drill.common.logical.security.CredentialsProvider;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
@@ -35,7 +37,6 @@ import java.util.Optional;
 @JsonTypeName(CassandraStorageConfig.NAME)
 public class CassandraStorageConfig extends StoragePluginConfig {
   public static final String NAME = "cassandra";
-
   private final String host;
   private final int port;
 
@@ -51,6 +52,12 @@ public class CassandraStorageConfig extends StoragePluginConfig {
         credentialsProvider == null, AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER));
     this.host = host;
     this.port = port;
+  }
+
+  private CassandraStorageConfig(CassandraStorageConfig that, CredentialsProvider credentialsProvider) {
+    super(getCredentialsProvider(credentialsProvider), credentialsProvider == null, that.authMode);
+    this.host = that.host;
+    this.port = that.port;
   }
 
   public String getHost() {
@@ -102,6 +109,15 @@ public class CassandraStorageConfig extends StoragePluginConfig {
     return result;
   }
 
+  @Override
+  public CassandraStorageConfig updateCredentialProvider(CredentialsProvider credentialsProvider) {
+    return new CassandraStorageConfig(this, credentialsProvider);
+  }
+
+  private static CredentialsProvider getCredentialsProvider(CredentialsProvider credentialsProvider) {
+    return credentialsProvider != null ? credentialsProvider : PlainCredentialsProvider.EMPTY_CREDENTIALS_PROVIDER;
+  }
+
   @JsonIgnore
   public Map<String, Object> toConfigMap() {
     Optional<UsernamePasswordCredentials> credentials = getUsernamePasswordCredentials();
@@ -125,12 +141,22 @@ public class CassandraStorageConfig extends StoragePluginConfig {
       return false;
     }
     CassandraStorageConfig that = (CassandraStorageConfig) o;
-    return Objects.equals(host, that.host)
-        && Objects.equals(credentialsProvider, that.credentialsProvider);
+    return Objects.equals(host, that.host) &&
+        Objects.equals(port, that.port) &&
+        Objects.equals(credentialsProvider, that.credentialsProvider);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, credentialsProvider);
+    return Objects.hash(host, port, credentialsProvider);
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+        .field("host", host)
+        .field("port", port)
+        .field("credentialsProvider", credentialsProvider)
+        .toString();
   }
 }

--- a/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/CassandraUserTranslationTest.java
+++ b/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/CassandraUserTranslationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.cassandra;
+
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.config.DrillProperties;
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.test.ClientFixture;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.ADMIN_USER_PASSWORD;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1;
+import static org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl.TEST_USER_1_PASSWORD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Category({SlowTest.class})
+public class CassandraUserTranslationTest extends BaseCassandraTest {
+  @Test
+  public void testInfoSchemaQueryWithMissingCredentials() throws Exception {
+    // This test validates that the correct credentials are sent down to Cassandra.
+    // This user should not see the ut_cassandra because they do not have valid credentials.
+    ClientFixture client = cluster
+        .clientBuilder()
+        .property(DrillProperties.USER, ADMIN_USER)
+        .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+        .build();
+
+    String sql = "SHOW DATABASES WHERE schema_name LIKE '%cassandra%'";
+
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(1, results.rowCount());
+    results.clear();
+  }
+
+  @Test
+  public void testInfoSchemaQueryWithValidCredentials() throws Exception {
+    // This test validates that the cassandra connection with user translation appears whne the user is
+    // authenticated.
+    ClientFixture client = cluster
+        .clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_1)
+        .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+        .build();
+
+    String sql = "SHOW DATABASES WHERE schema_name LIKE '%cassandra%'";
+
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(2, results.rowCount());
+    results.clear();
+  }
+
+  @Test
+  public void testSplunkQueryWithUserTranslation() throws Exception {
+    ClientFixture client = cluster
+        .clientBuilder()
+        .property(DrillProperties.USER, TEST_USER_1)
+        .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
+        .build();
+
+    String sql = "select * from ut_cassandra.test_keyspace.`employee` order by employee_id";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(10, results.rowCount());
+    results.clear();
+  }
+
+  @Test
+  public void testSplunkQueryWithUserTranslationAndInvalidCredentials() throws Exception {
+    ClientFixture client = cluster
+        .clientBuilder()
+        .property(DrillProperties.USER, ADMIN_USER)
+        .property(DrillProperties.PASSWORD, ADMIN_USER_PASSWORD)
+        .build();
+
+    String sql = "select * from ut_cassandra.test_keyspace.`employee` order by employee_id";
+    try {
+      client.queryBuilder().sql(sql).rowSet();
+      fail();
+    } catch (UserRemoteException e) {
+      assertTrue(e.getMessage().contains("Schema [[ut_cassandra, test_keyspace]] is not valid"));
+    }
+  }
+}

--- a/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/TestCassandraSuite.java
+++ b/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/TestCassandraSuite.java
@@ -31,7 +31,7 @@ import org.testcontainers.containers.CassandraContainer;
 
 @Category(SlowTest.class)
 @RunWith(Suite.class)
-@Suite.SuiteClasses({CassandraComplexTypesTest.class, CassandraPlanTest.class, CassandraQueryTest.class})
+@Suite.SuiteClasses({CassandraComplexTypesTest.class, CassandraPlanTest.class, CassandraQueryTest.class, CassandraUserTranslationTest.class})
 public class TestCassandraSuite extends BaseTest {
 
   protected static CassandraContainer<?> cassandra;

--- a/contrib/storage-splunk/README.md
+++ b/contrib/storage-splunk/README.md
@@ -42,6 +42,10 @@ Sometimes Splunk has issue in connection to it:
 https://github.com/splunk/splunk-sdk-java/issues/62 <br>
 To bypass it by Drill please specify "reconnectRetries": 3. It allows you to retry the connection several times.
 
+### User Translation
+The Splunk plugin supports user translation.  Simply set the `authMode` parameter to `USER_TRANSLATION` and use either the plain or vault credential provider for credentials.
+
+
 ## Understanding Splunk's Data Model
 Splunk's primary use case is analyzing event logs with a timestamp. As such, data is indexed by the timestamp, with the most recent data being indexed first.  By default, Splunk
  will sort the data in reverse chronological order.  Large Splunk installations will put older data into buckets of hot, warm and cold storage with the "cold" storage on the


### PR DESCRIPTION
# [DRILL-8386](https://issues.apache.org/jira/browse/DRILL-8386): Add Support for User Translation for Cassandra

## Description
Adds support for user translation for Apache Cassandra.

## Documentation
Updated README.

## Testing
Added unit tests.