### PR TITLE
[MINOR UPDATE]: Clear Results after Splunk Unit Tests

### DIFF
--- a/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/CassandraUserTranslationTest.java
+++ b/contrib/storage-cassandra/src/test/java/org/apache/drill/exec/store/cassandra/CassandraUserTranslationTest.java
@@ -55,7 +55,7 @@ public class CassandraUserTranslationTest extends BaseCassandraTest {
 
   @Test
   public void testInfoSchemaQueryWithValidCredentials() throws Exception {
-    // This test validates that the cassandra connection with user translation appears whne the user is
+    // This test validates that the cassandra connection with user translation appears when the user is
     // authenticated.
     ClientFixture client = cluster
         .clientBuilder()
@@ -71,7 +71,7 @@ public class CassandraUserTranslationTest extends BaseCassandraTest {
   }
 
   @Test
-  public void testSplunkQueryWithUserTranslation() throws Exception {
+  public void testCassandraQueryWithUserTranslation() throws Exception {
     ClientFixture client = cluster
         .clientBuilder()
         .property(DrillProperties.USER, TEST_USER_1)
@@ -85,7 +85,7 @@ public class CassandraUserTranslationTest extends BaseCassandraTest {
   }
 
   @Test
-  public void testSplunkQueryWithUserTranslationAndInvalidCredentials() throws Exception {
+  public void testCassandraQueryWithUserTranslationAndInvalidCredentials() throws Exception {
     ClientFixture client = cluster
         .clientBuilder()
         .property(DrillProperties.USER, ADMIN_USER)

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -52,6 +52,7 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
 
     RowSet results = client.queryBuilder().sql(sql).rowSet();
     assertEquals(1, results.rowCount());
+    results.clear();
   }
 
   @Test
@@ -66,6 +67,7 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
 
     RowSet results = client.queryBuilder().sql(sql).rowSet();
     assertEquals(2, results.rowCount());
+    results.clear();
   }
 
   @Test
@@ -79,6 +81,7 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
     String sql = "SELECT acceleration_id, action, add_offset, add_timestamp FROM ut_splunk._audit LIMIT 2";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
     assertEquals(2, results.rowCount());
+    results.clear();
   }
 
   @Test


### PR DESCRIPTION
## Description
This minor modification to the Splunk unit tests clears for user translation explicitly clears the result sets.  During some other work, I found that these tests would occasionally fail.   This fixes that.

## Documentation
No user facing changes.

## Testing
Existing unit tests.