### PR TITLE
DRILL-8391: Disable auto complete on the password field of web UI login forms

### DIFF
--- a/drill-yarn/src/main/resources/drill-am/login.ftl
+++ b/drill-yarn/src/main/resources/drill-am/login.ftl
@@ -33,7 +33,7 @@
           </div>
           </#if>
           <p><input type="text" size="30" name="j_username" placeholder="Username"></p>
-          <p><input type="password" size="30" name="j_password" placeholder="Password"></p>
+          <p><input type="password" size="30" name="j_password" placeholder="Password" autocomplete="off"></p>
           <p><button type="submit" class="btn btn-primary">Log In</button></p>
         </div>
       </fieldset>

--- a/exec/java-exec/src/main/resources/rest/login.ftl
+++ b/exec/java-exec/src/main/resources/rest/login.ftl
@@ -32,7 +32,7 @@
           </#if>
           <h4>Log In to Drill Web Console</h4></br>
           <p><input type="text" size="30" name="j_username" placeholder="Username" autofocus></p>
-          <p><input type="password" size="30" name="j_password" placeholder="Password"></p>
+          <p><input type="password" size="30" name="j_password" placeholder="Password" autocomplete="off"></p>
           <p><button type="submit" class="btn btn-light">Log In</button> </p>
         </div>
       </fieldset>


### PR DESCRIPTION
# [DRILL-8391](https://issues.apache.org/jira/browse/DRILL-8391): Disable auto complete on the password field of web UI login forms

## Description

In order to avoid triggering security scanners it is necessary to set autocomplete = "off" on the password field in the web UI login forms. This change probably has no real world security benefit (or cost) because

> Even without a master password, in-browser password management is generally seen as a net gain for security. Since users do not have to remember passwords that the browser stores for them, they are able to choose stronger passwords than they would otherwise.
> 
> For this reason, many modern browsers do not support autocomplete="off" for login fields:
> 
> - If a site sets autocomplete="off" for a form, and the form includes username and password input fields, then the browser still offers to remember this login, and if the user agrees, the browser will autofill those fields the next time the user visits the page.
> - If a site sets autocomplete="off" for username and password input fields, then the browser still offers to remember this login, and if the user agrees, the browser will autofill those fields the next time the user visits the page

Excerpt taken from [this Mozilla Developer Network page](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion).

## Documentation
N/A

## Testing
Confirm that the attribute assignment `autocomplete="off"` is present on the password of the web UI login form.
