### PR TITLE
DRILL-8392: Empty Tables Causes Index Out of Bounds Exception on PDF Reader

### DIFF
--- a/contrib/format-pdf/src/main/java/org/apache/drill/exec/store/pdf/PdfBatchReader.java
+++ b/contrib/format-pdf/src/main/java/org/apache/drill/exec/store/pdf/PdfBatchReader.java
@@ -218,8 +218,16 @@ public class PdfBatchReader implements ManagedReader {
 
       if (!Strings.isNullOrEmpty(value)) {
         writers.get(rowPosition).load(row.get(rowPosition));
+
+        // If there is not a provided schema, advance the row position index only when values are found
+        if (negotiator.providedSchema() == null) {
+          rowPosition++;
+        }
       }
-      rowPosition++;
+      // Advance the row position index when there is a provided schema.
+      if (negotiator.providedSchema() != null) {
+        rowPosition++;
+      }
     }
 
     metadataReader.writeMetadata();


### PR DESCRIPTION
# [DRILL-8392](https://issues.apache.org/jira/browse/DRILL-XXXX): Empty Tables Causes Index Out of Bounds Exception on PDF Reader

## Description
In certain conditions, Drill will generate an Index Out of Bounds exception.  This minor PR fixes that.  Basically, when a schema is not provided, Drill will ignore empty cells in rows. 

## Documentation
No user facing changes.

## Testing
Ran existing unit tests and tested with customer data.