### PR TITLE
DRILL-8394: ANALYZE TABLE ... COMPUTE STATISTICS fails with a trailing slash

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/DrillHiveViewTable.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/DrillHiveViewTable.java
@@ -26,7 +26,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.drill.exec.dotdrill.View;
 import org.apache.drill.exec.planner.logical.DrillViewTable;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.conversion.DrillViewExpander;
 import org.apache.drill.exec.planner.types.DrillRelDataTypeSystem;
 import org.apache.drill.exec.planner.types.HiveToRelDataTypeConverter;
@@ -68,7 +68,7 @@ public class DrillHiveViewTable extends DrillViewTable {
   @Override
   protected RelNode expandViewForImpersonatedUser(DrillViewExpander context,
                                                   List<String> workspaceSchemaPath, SchemaPlus tokenSchemaTree) {
-    SchemaPlus drillHiveSchema = SchemaUtilites.findSchema(tokenSchemaTree, workspaceSchemaPath);
+    SchemaPlus drillHiveSchema = SchemaUtilities.findSchema(tokenSchemaTree, workspaceSchemaPath);
     workspaceSchemaPath = ImmutableList.of();
     return super.expandViewForImpersonatedUser(context, workspaceSchemaPath, drillHiveSchema);
   }

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -28,7 +28,7 @@ import org.apache.drill.common.expression.PathSegment;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.alias.AliasRegistryProvider;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePlugin;
@@ -157,7 +157,7 @@ public class DynamicRootSchema extends DynamicSchema {
       }
 
       // Could not find the plugin of schemaName. The schemaName could be `dfs.tmp`, a 2nd level schema under 'dfs'
-      List<String> paths = SchemaUtilites.getSchemaPathAsList(schemaName);
+      List<String> paths = SchemaUtilities.getSchemaPathAsList(schemaName);
       if (paths.size() == 2) {
         plugin = storages.getPlugin(paths.get(0));
         if (plugin == null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TableModifyPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TableModifyPrel.java
@@ -32,7 +32,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.planner.logical.ModifyTableEntry;
 import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.record.BatchSchema;
 import org.jetbrains.annotations.NotNull;
 
@@ -67,7 +67,7 @@ public class TableModifyPrel extends TableModify implements Prel {
     String tableName = tablePath.get(tablePath.size() - 1);
     SchemaPlus schema = ((CalciteCatalogReader) getTable().getRelOptSchema()).getRootSchema().plus();
 
-    ModifyTableEntry modifyTableEntry = SchemaUtilites.resolveToDrillSchema(schema, schemaPath)
+    ModifyTableEntry modifyTableEntry = SchemaUtilities.resolveToDrillSchema(schema, schemaPath)
       .modifyTable(tableName);
 
     PhysicalOperator childPOP = child.getPhysicalOperator(creator);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilities.java
@@ -34,8 +34,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class SchemaUtilites {
-  private static final Logger logger = LoggerFactory.getLogger(SchemaUtilites.class);
+public class SchemaUtilities {
+  private static final Logger logger = LoggerFactory.getLogger(SchemaUtilities.class);
   public static final Joiner SCHEMA_PATH_JOINER = Joiner.on(".").skipNulls();
 
   /**
@@ -313,9 +313,9 @@ public class SchemaUtilites {
    */
   public static AbstractSchema resolveToTemporarySchema(List<String> tableSchema, SchemaPlus defaultSchema, DrillConfig config) {
     if (tableSchema.size() == 0) {
-      return SchemaUtilites.getTemporaryWorkspace(defaultSchema, config);
+      return SchemaUtilities.getTemporaryWorkspace(defaultSchema, config);
     } else {
-      return SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, tableSchema);
+      return SchemaUtilities.resolveToMutableDrillSchema(defaultSchema, tableSchema);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/conversion/DrillCalciteCatalogReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/conversion/DrillCalciteCatalogReader.java
@@ -33,7 +33,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
 import org.apache.drill.exec.planner.logical.DrillTable;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.shaded.guava.com.google.common.cache.CacheBuilder;
 import org.apache.drill.shaded.guava.com.google.common.cache.CacheLoader;
@@ -152,10 +152,10 @@ class DrillCalciteCatalogReader extends CalciteCatalogReader {
     if (names.size() == 1) {
       return true;
     }
-    String schemaPath = SchemaUtilites.getSchemaPath(names.subList(0, names.size() - 1));
-    return SchemaUtilites.isTemporaryWorkspace(schemaPath, drillConfig) ||
-        SchemaUtilites.isTemporaryWorkspace(
-            SchemaUtilites.SCHEMA_PATH_JOINER.join(defaultSchemaPath, schemaPath), drillConfig);
+    String schemaPath = SchemaUtilities.getSchemaPath(names.subList(0, names.size() - 1));
+    return SchemaUtilities.isTemporaryWorkspace(schemaPath, drillConfig) ||
+        SchemaUtilities.isTemporaryWorkspace(
+            SchemaUtilities.SCHEMA_PATH_JOINER.join(defaultSchemaPath, schemaPath), drillConfig);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/conversion/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/conversion/SqlConverter.java
@@ -57,7 +57,7 @@ import org.apache.drill.exec.planner.physical.DrillDistributionTraitDef;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.planner.sql.DrillConformance;
 import org.apache.drill.exec.planner.sql.DrillConvertletTable;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.impl.DrillParserWithCompoundIdConverter;
 import org.apache.drill.exec.planner.sql.parser.impl.DrillSqlParseException;
 import org.apache.drill.exec.planner.types.DrillRelDataTypeSystem;
@@ -137,7 +137,7 @@ public class SqlConverter {
     this.isExpandedView = false;
     this.typeFactory = new JavaTypeFactoryImpl(DrillRelDataTypeSystem.DRILL_REL_DATATYPE_SYSTEM);
     this.defaultSchema = context.getNewDefaultSchema();
-    this.rootSchema = SchemaUtilites.rootSchema(defaultSchema);
+    this.rootSchema = SchemaUtilities.rootSchema(defaultSchema);
     this.temporarySchema = context.getConfig().getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE);
     this.session = context.getSession();
     this.drillConfig = context.getConfig();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
@@ -41,7 +41,7 @@ import org.apache.drill.exec.planner.logical.DrillScreenRel;
 import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.planner.logical.DrillWriterRel;
 import org.apache.drill.exec.planner.physical.Prel;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.parser.SqlAnalyzeTable;
 import org.apache.drill.exec.store.AbstractSchema;
@@ -84,7 +84,7 @@ public class AnalyzeTableHandler extends DefaultSqlHandler {
     RelNode relScan = convertedRelNode.getConvertedNode();
     DrillTableInfo drillTableInfo = DrillTableInfo.getTableInfoHolder(sqlAnalyzeTable.getTableRef(), config);
     String tableName = drillTableInfo.tableName();
-    AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+    AbstractSchema drillSchema = SchemaUtilities.resolveToDrillSchema(
         config.getConverter().getDefaultSchema(), drillTableInfo.schemaPath());
     Table table = SqlHandlerUtil.getTableFromSchema(drillSchema, tableName);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.planner.sql.handlers;
 
 import java.io.IOException;
+
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.schema.Table;
@@ -28,6 +29,7 @@ import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
@@ -116,10 +118,13 @@ public class AnalyzeTableHandler extends DefaultSqlHandler {
         formatSelection.getFormat()).getFsConf());
 
     Path selectionRoot = formatSelection.getSelection().getSelectionRoot();
-    if (!selectionRoot.toUri().getPath().endsWith(tableName) || !fs.getFileStatus(selectionRoot).isDirectory()) {
+    String tablePath = selectionRoot.toUri().getPath();
+    boolean pathMatchesTableName = tablePath.endsWith(StringUtils.stripEnd(tableName, "/"));
+
+    if (!pathMatchesTableName || !fs.getFileStatus(selectionRoot).isDirectory()) {
       return DrillStatsTable.notSupported(context, tableName);
     }
-    // Do not recompute statistics, if stale
+    // Do not recompute statistics if they already exist and are not stale.
     Path statsFilePath = new Path(selectionRoot, DotDrillType.STATS.getEnding());
     if (fs.exists(statsFilePath) && !isStatsStale(fs, statsFilePath)) {
      return DrillStatsTable.notRequired(context, tableName);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateAliasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateAliasHandler.java
@@ -27,7 +27,7 @@ import org.apache.drill.exec.alias.AliasTarget;
 import org.apache.drill.exec.alias.Aliases;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlCreateAlias;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.slf4j.Logger;
@@ -86,12 +86,12 @@ public class CreateAliasHandler extends BaseAliasHandler {
   }
 
   private String getStorageQualifier(List<String> path) {
-    SchemaUtilites.resolveToDrillSchema(
+    SchemaUtilities.resolveToDrillSchema(
       config.getConverter().getDefaultSchema(), path);
     if (path.size() > 1) {
       throw UserException.validationError()
         .message("Storage name expected, but provided [%s]",
-          SchemaUtilites.getSchemaPath(path))
+          SchemaUtilities.getSchemaPath(path))
         .build(logger);
     }
     return SchemaPath.getCompoundPath(path.get(0)).toExpr();
@@ -103,7 +103,7 @@ public class CreateAliasHandler extends BaseAliasHandler {
     if (drillTableInfo.drillTable() == null) {
       throw UserException.validationError()
         .message("No table with given name [%s] exists in schema [%s]", drillTableInfo.tableName(),
-          SchemaUtilites.getSchemaPath(drillTableInfo.schemaPath()))
+          SchemaUtilities.getSchemaPath(drillTableInfo.schemaPath()))
         .build(logger);
     }
     String[] paths = new String[drillTableInfo.schemaPath().size() + 1];

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateTableHandler.java
@@ -53,7 +53,7 @@ import org.apache.drill.exec.planner.physical.ProjectPrel;
 import org.apache.drill.exec.planner.physical.WriterPrel;
 import org.apache.drill.exec.planner.physical.visitor.BasePrelVisitor;
 import org.apache.drill.exec.planner.sql.DrillSqlOperator;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlCreateTable;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.util.Pointer;
@@ -282,14 +282,14 @@ public class CreateTableHandler extends DefaultSqlHandler {
   private AbstractSchema resolveSchema(SqlCreateTable sqlCreateTable, SchemaPlus defaultSchema, DrillConfig config) {
     AbstractSchema resolvedSchema;
     if (sqlCreateTable.isTemporary() && sqlCreateTable.getSchemaPath().size() == 0) {
-      resolvedSchema = SchemaUtilites.getTemporaryWorkspace(defaultSchema, config);
+      resolvedSchema = SchemaUtilities.getTemporaryWorkspace(defaultSchema, config);
     } else {
-      resolvedSchema = SchemaUtilites.resolveToMutableDrillSchema(
+      resolvedSchema = SchemaUtilities.resolveToMutableDrillSchema(
           defaultSchema, sqlCreateTable.getSchemaPath());
     }
 
     if (sqlCreateTable.isTemporary()) {
-      return SchemaUtilites.resolveToValidTemporaryWorkspace(resolvedSchema, config);
+      return SchemaUtilities.resolveToValidTemporaryWorkspace(resolvedSchema, config);
     }
 
     return resolvedSchema;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeSchemaHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeSchemaHandler.java
@@ -33,7 +33,7 @@ import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
@@ -76,7 +76,7 @@ public class DescribeSchemaHandler extends DefaultSqlHandler {
   @Override
   public PhysicalPlan getPlan(SqlNode sqlNode) throws ForemanSetupException {
     SqlIdentifier schema = unwrap(sqlNode, SqlDescribeSchema.class).getSchema();
-    SchemaPlus schemaPlus = SchemaUtilites.findSchema(config.getConverter().getDefaultSchema(), schema.names);
+    SchemaPlus schemaPlus = SchemaUtilities.findSchema(config.getConverter().getDefaultSchema(), schema.names);
 
     if (schemaPlus == null) {
       throw UserException.validationError()
@@ -84,7 +84,7 @@ public class DescribeSchemaHandler extends DefaultSqlHandler {
         .build(logger);
     }
 
-    AbstractSchema drillSchema = SchemaUtilites.unwrapAsDrillSchemaInstance(schemaPlus);
+    AbstractSchema drillSchema = SchemaUtilities.unwrapAsDrillSchemaInstance(schemaPlus);
     StoragePlugin storagePlugin;
     try {
       storagePlugin = context.getStorage().getPlugin(drillSchema.getSchemaPath().get(0));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
@@ -42,7 +42,7 @@ import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.conversion.SqlConverter;
 import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
@@ -71,22 +71,21 @@ public class DescribeTableHandler extends DefaultSqlHandler {
 
       SchemaPlus defaultSchema = config.getConverter().getDefaultSchema();
       List<String> schemaPathGivenInCmd = Util.skipLast(node.getTable().names);
-      SchemaPlus schema = SchemaUtilites.findSchema(defaultSchema, schemaPathGivenInCmd);
+      SchemaPlus schema = SchemaUtilities.findSchema(defaultSchema, schemaPathGivenInCmd);
 
       if (schema == null) {
-        SchemaUtilites.throwSchemaNotFoundException(defaultSchema, SchemaUtilites.getSchemaPath(schemaPathGivenInCmd));
+        SchemaUtilities.throwSchemaNotFoundException(defaultSchema, SchemaUtilities.getSchemaPath(schemaPathGivenInCmd));
       }
 
-      if (SchemaUtilites.isRootSchema(schema)) {
+      if (SchemaUtilities.isRootSchema(schema)) {
         throw UserException.validationError()
             .message("No schema selected.")
             .build(logger);
       }
 
       // find resolved schema path
-      AbstractSchema drillSchema = SchemaUtilites.unwrapAsDrillSchemaInstance(schema);
+      AbstractSchema drillSchema = SchemaUtilities.unwrapAsDrillSchemaInstance(schema);
       String schemaPath = drillSchema.getFullSchemaName();
-
       String tableName = Util.last(node.getTable().names);
 
       if (schema.getTable(tableName) == null) {
@@ -96,7 +95,7 @@ public class DescribeTableHandler extends DefaultSqlHandler {
       }
 
       SqlNode schemaCondition = null;
-      if (!SchemaUtilites.isRootSchema(schema)) {
+      if (!SchemaUtilities.isRootSchema(schema)) {
         schemaCondition = DrillParserUtil.createCondition(
             new SqlIdentifier(SHRD_COL_TABLE_SCHEMA, SqlParserPos.ZERO),
             SqlStdOperatorTable.EQUALS,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
@@ -31,7 +31,7 @@ import org.apache.calcite.sql.validate.SqlUserDefinedTableMacro;
 import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.logical.DrillTable;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -88,16 +88,16 @@ public class DrillTableInfo {
         SqlUserDefinedTableMacro tableMacro = (SqlUserDefinedTableMacro) operator;
         SqlIdentifier tableIdentifier = tableMacro.getSqlIdentifier();
 
-        AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
-            config.getConverter().getDefaultSchema(), SchemaUtilites.getSchemaPath(tableIdentifier));
+        AbstractSchema drillSchema = SchemaUtilities.resolveToDrillSchema(
+            config.getConverter().getDefaultSchema(), SchemaUtilities.getSchemaPath(tableIdentifier));
 
         DrillTable table = (DrillTable) tableMacro.getTable(new SqlCallBinding(config.getConverter().getValidator(), null, call.operand(0)));
         return new DrillTableInfo(table, drillSchema.getSchemaPath(), Util.last(tableIdentifier.names));
       }
       case IDENTIFIER: {
         SqlIdentifier tableIdentifier = (SqlIdentifier) tableRef;
-        AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
-            config.getConverter().getDefaultSchema(), SchemaUtilites.getSchemaPath(tableIdentifier));
+        AbstractSchema drillSchema = SchemaUtilities.resolveToDrillSchema(
+            config.getConverter().getDefaultSchema(), SchemaUtilities.getSchemaPath(tableIdentifier));
         String tableName = Util.last(tableIdentifier.names);
         DrillTable table = getDrillTable(drillSchema, tableName);
         return new DrillTableInfo(table, drillSchema.getSchemaPath(), tableName);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropTableHandler.java
@@ -28,7 +28,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.util.DrillStringUtils;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlDropTable;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.store.AbstractSchema;
@@ -60,13 +60,13 @@ public class DropTableHandler extends DefaultSqlHandler {
     DrillConfig drillConfig = context.getConfig();
     UserSession session = context.getSession();
 
-    AbstractSchema temporarySchema = SchemaUtilites.resolveToTemporarySchema(tableSchema, defaultSchema, drillConfig);
+    AbstractSchema temporarySchema = SchemaUtilities.resolveToTemporarySchema(tableSchema, defaultSchema, drillConfig);
     boolean isTemporaryTable = session.isTemporaryTable(temporarySchema, drillConfig, originalTableName);
 
     if (isTemporaryTable) {
       session.removeTemporaryTable(temporarySchema, originalTableName, drillConfig);
     } else {
-      AbstractSchema drillSchema = SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, tableSchema);
+      AbstractSchema drillSchema = SchemaUtilities.resolveToMutableDrillSchema(defaultSchema, tableSchema);
       Table tableToDrop = SqlHandlerUtil.getTableFromSchema(drillSchema, originalTableName);
       // TableType.OTHER started getting reported for H2 DB when it was upgraded to v2.
       if (tableToDrop == null || (tableToDrop.getJdbcTableType() != Schema.TableType.TABLE &&

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/InsertHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/InsertHandler.java
@@ -22,7 +22,7 @@ import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.util.Pointer;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
@@ -43,7 +43,7 @@ public class InsertHandler extends DefaultSqlHandler {
     throws ForemanSetupException, RelConversionException, ValidationException {
     ConvertedRelNode convertedRelNode = super.validateAndConvert(sqlNode);
 
-    String storageName = SchemaUtilites.getSchemaPathAsList(
+    String storageName = SchemaUtilities.getSchemaPathAsList(
       convertedRelNode.getConvertedNode().getTable().getQualifiedName().iterator().next()).iterator().next();
     try {
       if (!context.getStorage().getPlugin(storageName).supportsInsert()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreDropTableMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreDropTableMetadataHandler.java
@@ -22,7 +22,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlDropTableMetadata;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.util.Pointer;
@@ -56,7 +56,7 @@ public class MetastoreDropTableMetadataHandler extends DefaultSqlHandler {
 
     SqlDropTableMetadata dropTableMetadata = unwrap(sqlNode, SqlDropTableMetadata.class);
 
-    AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+    AbstractSchema drillSchema = SchemaUtilities.resolveToDrillSchema(
         config.getConverter().getDefaultSchema(), dropTableMetadata.getSchemaPath());
 
     List<String> schemaPath = drillSchema.getSchemaPath();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
@@ -29,7 +29,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlRefreshMetadata;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.dfs.FileSelection;
@@ -45,7 +45,7 @@ import org.apache.hadoop.fs.Path;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.apache.drill.exec.planner.sql.SchemaUtilites.findSchema;
+import static org.apache.drill.exec.planner.sql.SchemaUtilities.findSchema;
 
 public class RefreshMetadataHandler extends DefaultSqlHandler {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RefreshMetadataHandler.class);
@@ -73,7 +73,7 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
 
       if (schema == null) {
         return direct(false, "Storage plugin or workspace does not exist [%s]",
-            SchemaUtilites.SCHEMA_PATH_JOINER.join(refreshTable.getSchemaPath()));
+            SchemaUtilities.SCHEMA_PATH_JOINER.join(refreshTable.getSchemaPath()));
       }
 
       final String tableName = refreshTable.getName();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SchemaHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SchemaHandler.java
@@ -26,7 +26,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlCreateType;
 import org.apache.drill.exec.planner.sql.parser.SqlSchema;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
@@ -72,13 +72,13 @@ public abstract class SchemaHandler extends DefaultSqlHandler {
 
   public WorkspaceSchemaFactory.WorkspaceSchema getWorkspaceSchema(List<String> tableSchema, String tableName) {
     SchemaPlus defaultSchema = config.getConverter().getDefaultSchema();
-    AbstractSchema temporarySchema = SchemaUtilites.resolveToTemporarySchema(tableSchema, defaultSchema, context.getConfig());
+    AbstractSchema temporarySchema = SchemaUtilities.resolveToTemporarySchema(tableSchema, defaultSchema, context.getConfig());
 
     if (context.getSession().isTemporaryTable(temporarySchema, context.getConfig(), tableName)) {
       produceErrorResult(String.format("Indicated table [%s] is temporary table", tableName), true);
     }
 
-    AbstractSchema drillSchema = SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, tableSchema);
+    AbstractSchema drillSchema = SchemaUtilities.resolveToMutableDrillSchema(defaultSchema, tableSchema);
     Table table = SqlHandlerUtil.getTableFromSchema(drillSchema, tableName);
     if (table == null || table.getJdbcTableType() != Schema.TableType.TABLE) {
       produceErrorResult(String.format("Table [%s] was not found", tableName), true);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowFilesHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowFilesHandler.java
@@ -23,7 +23,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlShowFiles;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.dfs.WorkspaceSchemaFactory.WorkspaceSchema;
@@ -59,10 +59,10 @@ public class ShowFilesHandler extends DefaultSqlHandler {
     if (from != null) {
       // We are not sure if the full from clause is just the schema or includes table name,
       // first try to see if the full path specified is a schema
-      drillSchema = SchemaUtilites.findSchema(defaultSchema, from.names);
+      drillSchema = SchemaUtilities.findSchema(defaultSchema, from.names);
       if (drillSchema == null) {
         // Entire from clause is not a schema, try to obtain the schema without the last part of the specified clause.
-        drillSchema = SchemaUtilites.findSchema(defaultSchema, from.names.subList(0, from.names.size() - 1));
+        drillSchema = SchemaUtilities.findSchema(defaultSchema, from.names.subList(0, from.names.size() - 1));
         // Listing for specific directory: show files in dfs.tmp.specific_directory
         fromDir = from.names.get((from.names.size() - 1));
       }
@@ -80,7 +80,7 @@ public class ShowFilesHandler extends DefaultSqlHandler {
     } catch (ClassCastException e) {
       throw UserException.validationError()
           .message("SHOW FILES is supported in workspace type schema only. Schema [%s] is not a workspace schema.",
-              SchemaUtilites.getSchemaPath(drillSchema))
+              SchemaUtilities.getSchemaPath(drillSchema))
           .build(logger);
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
@@ -33,7 +33,7 @@ import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.SqlSelectBuilder;
 import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
 import org.apache.drill.exec.planner.sql.parser.SqlShowTables;
@@ -63,11 +63,11 @@ public class ShowTablesHandler extends DefaultSqlHandler {
     SchemaPlus schemaPlus;
     if (node.getDb() != null) {
       List<String> schemaNames = node.getDb().names;
-      schemaPlus = SchemaUtilites.findSchema(config.getConverter().getDefaultSchema(), schemaNames);
+      schemaPlus = SchemaUtilities.findSchema(config.getConverter().getDefaultSchema(), schemaNames);
 
       if (schemaPlus == null) {
         throw UserException.validationError()
-            .message("Invalid schema name [%s]", SchemaUtilites.getSchemaPath(schemaNames))
+            .message("Invalid schema name [%s]", SchemaUtilities.getSchemaPath(schemaNames))
             .build(logger);
       }
 
@@ -76,14 +76,14 @@ public class ShowTablesHandler extends DefaultSqlHandler {
       schemaPlus = config.getConverter().getDefaultSchema();
     }
 
-    if (SchemaUtilites.isRootSchema(schemaPlus)) {
+    if (SchemaUtilities.isRootSchema(schemaPlus)) {
       // If the default schema is a root schema, throw an error to select a default schema
       throw UserException.validationError()
           .message("No default schema selected. Select a schema using 'USE schema' command")
           .build(logger);
     }
 
-    AbstractSchema drillSchema = SchemaUtilites.unwrapAsDrillSchemaInstance(schemaPlus);
+    AbstractSchema drillSchema = SchemaUtilities.unwrapAsDrillSchemaInstance(schemaPlus);
 
     SqlNode where = DrillParserUtil.createCondition(
         new SqlIdentifier(SHRD_COL_TABLE_SCHEMA, SqlParserPos.ZERO),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerConfig.java
@@ -35,7 +35,7 @@ import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.planner.PlannerPhase;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
 import org.apache.drill.exec.planner.logical.DrillTable;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.conversion.SqlConverter;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -109,7 +109,7 @@ public class SqlHandlerConfig {
     }
 
     private void collectPlugins(RelNode relNode) {
-      String pluginName = SchemaUtilites.getSchemaPathAsList(
+      String pluginName = SchemaUtilities.getSchemaPathAsList(
         relNode.getTable().getQualifiedName().iterator().next()).iterator().next();
       CheckedSupplier<StoragePlugin, StoragePluginRegistry.PluginException> pluginsProvider =
         () -> storagePlugins.getPlugin(pluginName);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ViewHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ViewHandler.java
@@ -32,7 +32,7 @@ import org.apache.drill.exec.dotdrill.View;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.parser.SqlCreateView;
 import org.apache.drill.exec.planner.sql.parser.SqlDropView;
 import org.apache.drill.exec.store.AbstractSchema;
@@ -75,10 +75,10 @@ public abstract class ViewHandler extends DefaultSqlHandler {
       final RelNode newViewRelNode = SqlHandlerUtil.resolveNewTableRel(true, createView.getFieldNames(), validatedRowType, queryRelNode);
 
       final SchemaPlus defaultSchema = context.getNewDefaultSchema();
-      final AbstractSchema drillSchema = SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, createView.getSchemaPath());
+      final AbstractSchema drillSchema = SchemaUtilities.resolveToMutableDrillSchema(defaultSchema, createView.getSchemaPath());
 
       final View view = new View(newViewName, viewSql, newViewRelNode.getRowType(),
-          SchemaUtilites.getSchemaPathAsList(defaultSchema));
+          SchemaUtilities.getSchemaPathAsList(defaultSchema));
       final String schemaPath = drillSchema.getFullSchemaName();
 
       // check view creation possibility
@@ -159,7 +159,7 @@ public abstract class ViewHandler extends DefaultSqlHandler {
       SqlDropView dropView = unwrap(sqlNode, SqlDropView.class);
       final String viewName = DrillStringUtils.removeLeadingSlash(dropView.getName());
       final AbstractSchema drillSchema =
-          SchemaUtilites.resolveToMutableDrillSchema(context.getNewDefaultSchema(), dropView.getSchemaPath());
+          SchemaUtilities.resolveToMutableDrillSchema(context.getNewDefaultSchema(), dropView.getSchemaPath());
 
       final String schemaPath = drillSchema.getFullSchemaName();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateTable.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.planner.sql.parser;
 
 import java.util.List;
 
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
@@ -131,7 +131,7 @@ public class SqlCreateTable extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    return SchemaUtilites.getSchemaPath(tblName);
+    return SchemaUtilities.getSchemaPath(tblName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateView.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateView.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.planner.sql.parser;
 
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
@@ -106,7 +106,7 @@ public class SqlCreateView extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    return SchemaUtilites.getSchemaPath(viewName);
+    return SchemaUtilities.getSchemaPath(viewName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTable.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.planner.sql.parser;
 
 import java.util.List;
 
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.DropTableHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
@@ -88,7 +88,7 @@ public class SqlDropTable extends DrillSqlCall {
   }
 
   public List<String> getSchema() {
-    return SchemaUtilites.getSchemaPath(tableName);
+    return SchemaUtilities.getSchemaPath(tableName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTableMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTableMetadata.java
@@ -27,7 +27,7 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.Util;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.MetastoreDropTableMetadataHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
@@ -94,7 +94,7 @@ public class SqlDropTableMetadata extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    return SchemaUtilites.getSchemaPath(tableName);
+    return SchemaUtilities.getSchemaPath(tableName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropView.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropView.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.planner.sql.parser;
 
 import java.util.List;
 
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
 import org.apache.drill.exec.planner.sql.handlers.ViewHandler.DropView;
@@ -88,7 +88,7 @@ public class SqlDropView extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    return SchemaUtilites.getSchemaPath(viewName);
+    return SchemaUtilities.getSchemaPath(viewName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlRefreshMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlRefreshMetadata.java
@@ -29,7 +29,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.RefreshMetadataHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
@@ -104,7 +104,7 @@ public class SqlRefreshMetadata extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    return SchemaUtilites.getSchemaPath(tblName);
+    return SchemaUtilities.getSchemaPath(tblName);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlSchema.java
@@ -30,7 +30,7 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.drill.common.util.DrillStringUtils;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
 import org.apache.drill.exec.planner.sql.handlers.SchemaHandler;
@@ -79,7 +79,7 @@ public abstract class SqlSchema extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    return hasTable() ? SchemaUtilites.getSchemaPath(table) : null;
+    return hasTable() ? SchemaUtilities.getSchemaPath(table) : null;
   }
 
   public String getTableName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
@@ -35,7 +35,7 @@ import org.apache.calcite.tools.ValidationException;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerUtil;
 import org.apache.drill.exec.proto.UserBitShared.UserCredentials;
 import org.apache.drill.exec.proto.UserProtos.UserProperties;
@@ -218,23 +218,23 @@ public class UserSession implements AutoCloseable {
    */
   public void setDefaultSchemaPath(String newDefaultSchemaPath, SchemaPlus currentDefaultSchema)
       throws ValidationException {
-    final List<String> newDefaultPathAsList = SchemaUtilites.getSchemaPathAsList(newDefaultSchemaPath);
+    final List<String> newDefaultPathAsList = SchemaUtilities.getSchemaPathAsList(newDefaultSchemaPath);
     SchemaPlus newDefault;
 
     // First try to find the given schema relative to the current default schema.
-    newDefault = SchemaUtilites.findSchema(currentDefaultSchema, newDefaultPathAsList);
+    newDefault = SchemaUtilities.findSchema(currentDefaultSchema, newDefaultPathAsList);
 
     if (newDefault == null) {
       // If we fail to find the schema relative to current default schema, consider the given new default schema path as
       // absolute schema path.
-      newDefault = SchemaUtilites.findSchema(currentDefaultSchema, newDefaultPathAsList);
+      newDefault = SchemaUtilities.findSchema(currentDefaultSchema, newDefaultPathAsList);
     }
 
     if (newDefault == null) {
-      SchemaUtilites.throwSchemaNotFoundException(currentDefaultSchema, newDefaultSchemaPath);
+      SchemaUtilities.throwSchemaNotFoundException(currentDefaultSchema, newDefaultSchemaPath);
     }
 
-    properties.setProperty(DrillProperties.SCHEMA, SchemaUtilites.getSchemaPath(newDefault));
+    properties.setProperty(DrillProperties.SCHEMA, SchemaUtilities.getSchemaPath(newDefault));
   }
 
   /**
@@ -256,7 +256,7 @@ public class UserSession implements AutoCloseable {
       return null;
     }
 
-    return SchemaUtilites.findSchema(rootSchema, defaultSchemaPath);
+    return SchemaUtilities.findSchema(rootSchema, defaultSchemaPath);
   }
 
   /**
@@ -292,7 +292,7 @@ public class UserSession implements AutoCloseable {
    * @throws IOException if error during session temporary location creation
    */
   public String registerTemporaryTable(AbstractSchema schema, String tableName, DrillConfig config) throws IOException {
-    addTemporaryLocation(SchemaUtilites.resolveToValidTemporaryWorkspace(schema, config));
+    addTemporaryLocation(SchemaUtilities.resolveToValidTemporaryWorkspace(schema, config));
     String temporaryTableName = new Path(sessionId, UUID.randomUUID().toString()).toUri().getPath();
     String oldTemporaryTableName = temporaryTables.putIfAbsent(tableName.toLowerCase(), temporaryTableName);
     return oldTemporaryTableName == null ? temporaryTableName : oldTemporaryTableName;
@@ -334,7 +334,7 @@ public class UserSession implements AutoCloseable {
    * @return true if temporary table exists in schema, false otherwise
    */
   public boolean isTemporaryTable(AbstractSchema drillSchema, DrillConfig config, String tableName) {
-    if (drillSchema == null || !SchemaUtilites.isTemporaryWorkspace(drillSchema.getFullSchemaName(), config)) {
+    if (drillSchema == null || !SchemaUtilities.isTemporaryWorkspace(drillSchema.getFullSchemaName(), config)) {
       return false;
     }
     String temporaryTableName = resolveTemporaryTableName(tableName);
@@ -361,7 +361,7 @@ public class UserSession implements AutoCloseable {
     if (temporaryTable == null) {
       return;
     }
-    SqlHandlerUtil.dropTableFromSchema(SchemaUtilites.resolveToValidTemporaryWorkspace(schema, config), temporaryTable);
+    SqlHandlerUtil.dropTableFromSchema(SchemaUtilities.resolveToValidTemporaryWorkspace(schema, config), temporaryTable);
     temporaryTables.remove(tableName.toLowerCase());
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
@@ -63,7 +63,7 @@ import org.apache.drill.exec.planner.logical.DrillViewTable;
 import org.apache.drill.exec.planner.logical.DynamicDrillTable;
 import org.apache.drill.exec.planner.logical.FileSystemCreateTableEntry;
 import org.apache.drill.exec.planner.sql.ExpandingConcurrentMap;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.record.metadata.schema.FsMetastoreSchemaProvider;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.PartitionNotFoundException;
@@ -413,7 +413,7 @@ public class WorkspaceSchemaFactory {
     }
 
     private boolean isTemporaryWorkspace() {
-      return SchemaUtilites.getSchemaPath(schemaPath).equals(schemaConfig.getTemporaryWorkspace());
+      return SchemaUtilities.getSchemaPath(schemaPath).equals(schemaConfig.getTemporaryWorkspace());
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/EnumerableRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/enumerable/EnumerableRecordReader.java
@@ -30,7 +30,7 @@ import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.SchemaUtilities;
 import org.apache.drill.exec.record.ColumnConverter;
 import org.apache.drill.exec.record.ColumnConverterFactory;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -87,7 +87,7 @@ public class EnumerableRecordReader implements ManagedReader<SchemaNegotiator> {
   private void setup(OperatorContext context) {
     SchemaPlus rootSchema = context.getFragmentContext().getFullRootSchema();
     DataContext root = new DrillDataContext(
-        schemaPath != null ? SchemaUtilites.searchSchemaTree(rootSchema, SchemaUtilites.getSchemaPathAsList(schemaPath)) : rootSchema,
+        schemaPath != null ? SchemaUtilities.searchSchemaTree(rootSchema, SchemaUtilities.getSchemaPathAsList(schemaPath)) : rootSchema,
         new JavaTypeFactoryImpl(),
         Collections.emptyMap());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
@@ -631,6 +631,17 @@ public class TestAnalyze extends ClusterTest {
     }
   }
 
+  @Test // DRILL-8394
+  public void testTrailingSlashInTableName() throws Exception {
+    try {
+      client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "parquet");
+      run("create table dfs.tmp.nation as select * from cp.`tpch/orders.parquet`");
+      run("analyze table dfs.tmp.`nation/` compute statistics");
+    } finally {
+      client.resetSession(ExecConstants.OUTPUT_FORMAT_OPTION);
+    }
+  }
+
   //Helper function to verify output of ANALYZE statement
   private void verifyAnalyzeOutput(String query, String message) throws Exception {
     DirectRowSet rowSet = queryBuilder().sql(query).rowSet();


### PR DESCRIPTION
# [DRILL-8394](https://issues.apache.org/jira/browse/DRILL-8394): ANALYZE TABLE ... COMPUTE STATISTICS fails with a trailing slash

## Description

1. Trim trailing slashes before comparing the table path to the table name.
2. Add a unit test.
3. Fix the spelling error in the class name org.apache.drill.exec.planner.sql.SchemaUtilites.

## Documentation
N/A

## Testing
New unit test.
