### PR TITLE
DRILL-8309: Upgrade slf4j to 2.0.x

### DIFF
--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -66,7 +66,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.calcite.avatica</groupId>
-          <artifactId>avatica</artifactId>
+          <artifactId>avatica-core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.calcite</groupId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -239,7 +239,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica</artifactId>
+      <artifactId>avatica-core</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.jpam</groupId>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.calcite.avatica</groupId>
-      <artifactId>avatica</artifactId>
+      <artifactId>avatica-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.drill</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1202,7 +1202,7 @@
     <dependency>
       <groupId>de.huxhorn.lilith</groupId>
       <artifactId>de.huxhorn.lilith.logback.appender.multiplex-classic</artifactId>
-      <version>0.9.44</version>
+      <version>8.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1206,11 +1206,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>1.1.2.6</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.kerby</groupId>
       <artifactId>kerb-client</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <curator.version>5.2.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.4.5</logback.version>
     <mockito.version>3.11.2</mockito.version>
     <!--
       Currently, Hive storage plugin only supports Apache Hive 3.1.3 or vendor specific variants of the

--- a/pom.xml
+++ b/pom.xml
@@ -1302,13 +1302,9 @@
       </dependency>
       <dependency>
         <groupId>org.apache.calcite.avatica</groupId>
-        <artifactId>avatica</artifactId>
+        <artifactId>avatica-core</artifactId>
         <version>${avatica.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.apache.calcite.avatica</groupId>
-            <artifactId>avatica-core</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <javassist.version>3.28.0-GA</javassist.version>
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>
-    <avro.version>1.11.0</avro.version>
+    <avro.version>1.11.1</avro.version>
     <metrics.version>4.2.10</metrics.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jersey.version>2.34</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <httpdlog-parser.version>5.8</httpdlog-parser.version>
     <yauaa.version>7.9.0</yauaa.version>
-    <log4j.version>2.18.0</log4j.version>
+    <log4j.version>2.19.0</log4j.version>
     <aircompressor.version>0.20</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>
     <univocity-parsers.version>2.8.3</univocity-parsers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <junit.version>5.7.2</junit.version>
     <junit4.version>4.13.2</junit4.version>
     <junit.platform.version>1.8.2</junit.platform.version>
-    <slf4j.version>1.7.26</slf4j.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <shaded.guava.version>28.2-jre</shaded.guava.version>
     <guava.version>30.1.1-jre</guava.version>
     <forkCount>1</forkCount>


### PR DESCRIPTION
# [DRILL-8309](https://issues.apache.org/jira/browse/DRILL-8309): Upgrade slf4j to 2.0.x

## Description

- logback 1.2.11 → 1.4.5.
- log4j 2.18.0 → 2.19.0.
- slf4j 1.7.26 → 2.0.6.

## Documentation
N/A

## Testing
Run embedded Drill and check its log output.
