### PR TITLE
DRILL-8397: Drill prints warnings to console when starting it

### DIFF
--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -30,13 +30,11 @@
     <RemoteHosts>${LILITH_HOSTNAME:-localhost}</RemoteHosts>
   </appender>
 
-  <logger name="org.apache.drill" additivity="false">
-    <level value="debug"/>
+  <logger name="org.apache.drill" additivity="false" level="debug">
     <appender-ref ref="SOCKET"/>
   </logger>
 
-  <logger name="query.logger" additivity="false">
-    <level value="info"/>
+  <logger name="query.logger" additivity="false" level="info">
     <appender-ref ref="SOCKET"/>
   </logger>
   -->
@@ -49,8 +47,7 @@
     </encoder>
   </appender>
 
-  <root>
-    <level value="error"/>
+  <root level="error">
     <!-- Uncomment the next line (and the lines above) to be able to use Lilith for viewing log events -->
     <!-- <appender-ref ref="SOCKET"/>-->
     <!-- <appender-ref ref="STDOUT"/> -->

--- a/distribution/docker-cluster-mode/logback.xml
+++ b/distribution/docker-cluster-mode/logback.xml
@@ -24,16 +24,13 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.drill" additivity="false">
-        <level value="${DRILL_LOG_LEVEL:-info}" />
+    <logger name="org.apache.drill" additivity="false" level="${DRILL_LOG_LEVEL:-info}" >
         <appender-ref ref="STDOUT" />
     </logger>
-    <logger name="query.logger" additivity="false">
-        <level value="${DRILL_LOG_LEVEL:-info}" />
+    <logger name="query.logger" additivity="false" level="${DRILL_LOG_LEVEL:-info}">
         <appender-ref ref="STDOUT" />
     </logger>
-    <root>
-        <level value="${DRILL_LOG_LEVEL:-info}" />
+    <root level="${DRILL_LOG_LEVEL:-info}">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/distribution/src/main/resources/logback.xml
+++ b/distribution/src/main/resources/logback.xml
@@ -35,47 +35,45 @@
     </encoder>
   </appender>
 
-    <appender name="QUERY" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${log.query.path}</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-        <fileNamePattern>${log.query.path}.%i</fileNamePattern>
-        <minIndex>1</minIndex>
-        <maxIndex>10</maxIndex>
-      </rollingPolicy>
+  <appender name="QUERY" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${log.query.path}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>${log.query.path}.%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>10</maxIndex>
+    </rollingPolicy>
 
-      <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-        <maxFileSize>100MB</maxFileSize>
-      </triggeringPolicy>
-      <encoder>
-        <pattern>%msg%n</pattern>
-      </encoder>
-    </appender>
-
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${log.path}</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-        <fileNamePattern>${log.path}.%i</fileNamePattern>
-        <minIndex>1</minIndex>
-        <maxIndex>10</maxIndex>
-      </rollingPolicy>
-
-      <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-        <maxFileSize>100MB</maxFileSize>
-      </triggeringPolicy>
-      <encoder>
-        <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
-      </encoder>
-    </appender>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>100MB</maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
 
 
-  <logger name="org.apache.drill" additivity="false">
-    <level value="info" />
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${log.path}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>${log.path}.%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>10</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>100MB</maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+
+  <logger name="org.apache.drill" additivity="false" level="info">
     <appender-ref ref="FILE" />
   </logger>
 
-  <logger name="query.logger" additivity="false">
-    <level value="info" />
+  <logger name="query.logger" additivity="false" level="info">
     <appender-ref ref="QUERY" />
     <!--     <appender-ref ref="SOCKET" /> -->
   </logger>
@@ -87,8 +85,7 @@
   </logger>
    -->
 
-  <root>
-    <level value="error" />
+  <root level="error">
     <appender-ref ref="STDOUT" />
   </root>
 

--- a/drill-yarn/src/test/resources/doy-test-logback.xml
+++ b/drill-yarn/src/test/resources/doy-test-logback.xml
@@ -48,15 +48,13 @@
     </rollingPolicy>
   </appender>
   -->
-  <logger name="org.apache.drill" additivity="false">
-    <level value="error" />
+  <logger name="org.apache.drill" additivity="false" level="error">
     <!--   <appender-ref ref="SOCKET" /> -->
     <appender-ref ref="STDOUT" />
 <!--     <appender-ref ref="FILE" /> -->
   </logger>
 
-  <root>
-    <level value="error" />
+  <root level="error">
     <!-- <appender-ref ref="SOCKET" /> -->
     <appender-ref ref="STDOUT" />
 <!--     <appender-ref ref="FILE" /> -->


### PR DESCRIPTION
# [DRILL-8397](https://issues.apache.org/jira/browse/DRILL-8397): Drill prints warnings to console when starting it

## Description
Replaced the `level` tag with the attribute, so no extra output is printed to the console.

## Documentation
NA

## Testing
Checked manually
