### PR TITLE
DRILL-8396: Checkstyle plugin works only with JDK 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <curator.version>5.2.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
-    <logback.version>1.4.5</logback.version>
+    <logback.version>1.3.5</logback.version>
     <mockito.version>3.11.2</mockito.version>
     <!--
       Currently, Hive storage plugin only supports Apache Hive 3.1.3 or vendor specific variants of the
@@ -481,9 +481,9 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <dependencies>
           <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>10.7.0</version>
+            <groupId>com.github.rnveach</groupId>
+            <artifactId>checkstyle-backport-jre8</artifactId>
+            <version>checkstyle-backport-10.7.0</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -1071,6 +1071,12 @@
       </plugins>
     </pluginManagement>
   </build>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </pluginRepository>
+  </pluginRepositories>
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
# [DRILL-8396](https://issues.apache.org/jira/browse/DRILL-8396): Checkstyle plugin works only with JDK 11+

## Description
As it turned out, Checkstyle 10.x version is supported only on JDK 11+ (https://checkstyle.org/#JRE_and_JDK), so it causes failures when attempting to build Drill on JDK 8. We didn't notice it because CI doesn't use JDK 8 (though it should).

To fix it, I have replaced it with the `checkstyle-backport-jre8` library which works fine on JDK 8 and is referenced in the official docs: https://checkstyle.org/#Backport

Also, logback 1.4.x doesn't work with JDK 8, decreased it to 1.3.5. See https://logback.qos.ch/dependencies.html

## Documentation
NA

## Testing
Checked manually.
