### PR TITLE
DRILL-8398: Fix GitHub Actions to use proper JDK version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,13 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      # Caches maven cache and uses hashes of pom.xml files to find the required cache
-      - name: Cache Maven Repository
-        uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - name: Setup java
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-              ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
       - name: Build and test
         # The total GitHub Actions memory is 7000Mb. But GitHub CI requires some memory for the container to perform tests
         run: |
@@ -69,17 +67,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache Maven Repository
-        uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - name: Setup java
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
       # Caches built protobuf library
       - name: Cache protobufs
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/protobuf
           key: ${{ runner.os }}-protobuf

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
@@ -192,7 +192,7 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
   @Override
   public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerContext, PlannerPhase phase) {
     switch (phase) {
-      case LOGICAL:
+      case PARTITION_PRUNING:
         final String defaultPartitionValue = hiveConf.get(ConfVars.DEFAULTPARTITIONNAME.varname);
         ImmutableSet.Builder<StoragePluginOptimizerRule> ruleBuilder = ImmutableSet.builder();
         ruleBuilder.add(HivePushPartitionFilterIntoScan.getFilterOnProject(optimizerContext, defaultPartitionValue));

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/TestHivePartitionPruning.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/TestHivePartitionPruning.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -162,6 +163,7 @@ public class TestHivePartitionPruning extends HiveTestBase {
   }
 
   @Test // DRILL-6173
+  @Ignore("DRILL-8400")
   public void prunePartitionsBasedOnTransitivePredicates() throws Exception {
     String query = String.format("SELECT * FROM hive.partition_pruning_test t1 " +
             "JOIN hive.partition_with_few_schemas t2 ON t1.`d` = t2.`d` AND t1.`e` = t2.`e` " +

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/TestHivePartitionPruning.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/TestHivePartitionPruning.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -163,11 +162,10 @@ public class TestHivePartitionPruning extends HiveTestBase {
   }
 
   @Test // DRILL-6173
-  @Ignore("DRILL-8400")
   public void prunePartitionsBasedOnTransitivePredicates() throws Exception {
-    String query = String.format("SELECT * FROM hive.partition_pruning_test t1 " +
+    String query = "SELECT * FROM hive.partition_pruning_test t1 " +
             "JOIN hive.partition_with_few_schemas t2 ON t1.`d` = t2.`d` AND t1.`e` = t2.`e` " +
-            "WHERE t2.`e` IS NOT NULL AND t1.`d` = 1");
+            "WHERE t2.`e` IS NOT NULL AND t1.`d` = 1";
 
     int actualRowCount = testSql(query);
     int expectedRowCount = 450;

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <artifactId>drill-storage-phoenix</artifactId>
   <name>Drill : Contrib : Storage : Phoenix</name>
-  
+
   <properties>
     <phoenix.version>5.1.2</phoenix.version>
     <!-- Keep the 2.4.2 to reduce dependency conflict -->
@@ -394,6 +394,17 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <!-- Disable unit tests for JDK 14+ until Phoenix 5.2.0+ is released.
+      See PHOENIX-6723 for details.-->
+      <id>jdk14+</id>
+      <activation>
+        <jdk>[14,)</jdk>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 
+import org.apache.drill.categories.EasyOutOfMemory;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
@@ -55,7 +56,7 @@ import static org.junit.Assert.assertNull;
  * unstable from running a lot of queries concurrently -- it's not about
  * any particular order of execution. We ignore the results.
  */
-@Category({SlowTest.class})
+@Category({SlowTest.class, EasyOutOfMemory.class})
 public class TestTpchDistributedConcurrent extends ClusterTest {
   private static final Logger logger = LoggerFactory.getLogger(TestTpchDistributedConcurrent.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import ch.qos.logback.classic.Level;
 import org.apache.commons.math3.util.Pair;
+import org.apache.drill.categories.EasyOutOfMemory;
 import org.apache.drill.categories.FlakyTest;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.physical.impl.partitionsender.PartitionSenderRootExec;
@@ -82,12 +83,12 @@ import org.apache.drill.exec.testing.ControlsInjectionUtil;
 import org.apache.drill.exec.util.Pointer;
 import org.apache.drill.exec.work.fragment.FragmentExecutor;
 import org.apache.drill.categories.SlowTest;
+import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -105,8 +106,7 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
  * <li>specify Level.DEBUG for CURRENT_LOG_LEVEL</li>
  * <li>compare trace output for successful test case and failed</li>
  */
-@Tag(SlowTest.TAG)
-@Tag(FlakyTest.TAG)
+@Category({ SlowTest.class, FlakyTest.class, EasyOutOfMemory.class })
 public class TestDrillbitResilience extends ClusterTest {
   private static final Logger logger = org.slf4j.LoggerFactory.getLogger(TestDrillbitResilience.class);
   protected static LogFixture logFixture;

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <codemodel.version>2.6</codemodel.version>
     <joda.version>2.10.14</joda.version>
     <javax.el.version>3.0.0</javax.el.version>
-    <surefire.version>3.0.0-M7</surefire.version>
+    <surefire.version>3.0.0-M8</surefire.version>
     <jna.version>5.8.0</jna.version>
     <commons.compress.version>1.21</commons.compress.version>
     <hikari.version>4.0.3</hikari.version>


### PR DESCRIPTION
# [DRILL-8398](https://issues.apache.org/jira/browse/DRILL-8398): Fix GitHub Actions to use proper JDK version

## Description
Added `actions/setup-java` action to use dedicated java version for tests instead of using provided with the instance one. This PR is based on the commit for DRILL-8396 to avoid early failures for JDK 8. 

Need to fix hive tests that were broken earlier (because they run only with JDK 8).

## Documentation
NA

## Testing
TBA
