### PR TITLE
DRILL-8399: MS Access Reader Misinterprets Data Types

### DIFF
--- a/contrib/format-access/src/main/java/org/apache/drill/exec/store/msaccess/MSAccessBatchReader.java
+++ b/contrib/format-access/src/main/java/org/apache/drill/exec/store/msaccess/MSAccessBatchReader.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
@@ -155,6 +156,9 @@ public class MSAccessBatchReader implements ManagedReader {
           drillDataType = MinorType.BIT;
           break;
         case BYTE:
+          builder.addNullable(columnName, MinorType.TINYINT);
+          drillDataType = MinorType.TINYINT;
+          break;
         case INT:
           builder.addNullable(columnName, MinorType.SMALLINT);
           drillDataType = MinorType.SMALLINT;
@@ -172,6 +176,10 @@ public class MSAccessBatchReader implements ManagedReader {
           builder.addNullable(columnName, MinorType.FLOAT4);
           drillDataType = MinorType.FLOAT4;
           break;
+        case DOUBLE:
+          builder.addNullable(columnName, MinorType.FLOAT8);
+          drillDataType = MinorType.FLOAT8;
+          break;
         case MEMO:
         case TEXT:
         case GUID:
@@ -179,10 +187,9 @@ public class MSAccessBatchReader implements ManagedReader {
           drillDataType = MinorType.VARCHAR;
           break;
         case MONEY:
-        case DOUBLE:
         case NUMERIC:
-          builder.addNullable(columnName, MinorType.FLOAT8);
-          drillDataType = MinorType.FLOAT8;
+          builder.addNullable(columnName, MinorType.VARDECIMAL);
+          drillDataType = MinorType.VARDECIMAL;
           break;
         case OLE:
         case BINARY:
@@ -292,6 +299,10 @@ public class MSAccessBatchReader implements ManagedReader {
           Short shortValue = next.getShort(col.columnName);
           rowWriter.scalar(col.columnName).setInt(shortValue);
           break;
+        case TINYINT:
+          Byte byteValue = next.getByte(col.columnName);
+          rowWriter.scalar(col.columnName).setInt(byteValue);
+          break;
         case BIGINT:
         case INT:
           Integer intValue = next.getInt(col.columnName);
@@ -309,6 +320,10 @@ public class MSAccessBatchReader implements ManagedReader {
           Double doubleValue = next.getDouble(col.columnName);
           rowWriter.scalar(col.columnName).setDouble(doubleValue);
           break;
+        case VARDECIMAL:
+          BigDecimal bigDecimal = next.getBigDecimal(col.columnName);
+          rowWriter.scalar(col.columnName).setDecimal(bigDecimal);
+          break;
         case VARCHAR:
           String stringValue = next.getString(col.columnName);
           if (StringUtils.isNotEmpty(stringValue)) {
@@ -322,8 +337,8 @@ public class MSAccessBatchReader implements ManagedReader {
           }
           break;
         case VARBINARY:
-          byte[] byteValue = next.getBytes(col.columnName);
-          rowWriter.scalar(col.columnName).setBytes(byteValue, byteValue.length);
+          byte[] byteValueArray = next.getBytes(col.columnName);
+          rowWriter.scalar(col.columnName).setBytes(byteValueArray, byteValueArray.length);
           break;
       }
     }

--- a/contrib/format-access/src/test/java/org/apache/drill/exec/store/msaccess/TestMSAccessReader.java
+++ b/contrib/format-access/src/test/java/org/apache/drill/exec/store/msaccess/TestMSAccessReader.java
@@ -96,6 +96,32 @@ public class TestMSAccessReader extends ClusterTest {
   }
 
   @Test
+  public void testStarQueryWithDataTypes() throws Exception {
+    String sql = "SELECT * " +
+        "FROM table(cp.`data/V2010/testV2010.accdb` (type=> 'msaccess', tableName => 'Table1')) LIMIT 5";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("A", MinorType.VARCHAR)
+        .addNullable("B", MinorType.VARCHAR)
+        .addNullable("C", MinorType.TINYINT)
+        .addNullable("D", MinorType.SMALLINT)
+        .addNullable("E", MinorType.INT)
+        .addNullable("F", MinorType.FLOAT8)
+        .addNullable("G", MinorType.TIMESTAMP)
+        .addNullable("H", MinorType.VARDECIMAL)
+        .addNullable("I", MinorType.BIT)
+        .buildSchema();
+
+    RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+        .addRow("a", "b", 0, 0, 0, 0.0, QueryTestUtil.ConvertDateToLong("1981-12-12T00:00:00Z"), 0, false)
+        .addRow("abcdefg", "hijklmnop", 2, 222, 333333333, 444.555, QueryTestUtil.ConvertDateToLong("1974-09-21T00:00:00Z"), 4, true)
+        .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+  
+  @Test
   public void testMetadataStarQuery() throws Exception {
     String sql = "SELECT * FROM cp.`data/V2019/extDateTestV2019.accdb`";
     RowSet results = client.queryBuilder().sql(sql).rowSet();

--- a/contrib/format-access/src/test/java/org/apache/drill/exec/store/msaccess/TestMSAccessReader.java
+++ b/contrib/format-access/src/test/java/org/apache/drill/exec/store/msaccess/TestMSAccessReader.java
@@ -120,7 +120,7 @@ public class TestMSAccessReader extends ClusterTest {
 
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
-  
+
   @Test
   public void testMetadataStarQuery() throws Exception {
     String sql = "SELECT * FROM cp.`data/V2019/extDateTestV2019.accdb`";


### PR DESCRIPTION
# [DRILL-8399](https://issues.apache.org/jira/browse/DRILL-8399): MS Access Reader Misinterprets Data Types

## Description
Minor bug fix.  Drill was misinterpreting some data types in MS Access files.  This fixes that.

## Documentation
N/A

## Testing
Added unit test.