### PR TITLE
[MINOR UPDATE] Add Email Templates to ASF.yml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,4 @@
-# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-CustomsubjectlinesforGitHubevents
 
 github:
   description: "Apache Drill is a distributed MPP query layer for self describing data"
@@ -20,3 +20,16 @@ github:
     issues: true
     # Enable projects for project management boards
     projects: true
+
+  # Attempt to make the auto-generated github emails more easily readable in email clients.
+  custom_subjects:
+    new_pr: "[PR] {title} ({repository})"
+    close_pr: "Re: [PR] {title} ({repository})"
+    comment_pr: "Re: [PR] {title} ({repository})"
+    diffcomment: "Re: [PR] {title} ({repository})"
+    merge_pr: "Re: [PR] {title} ({repository})"
+    new_issue: "[I] {title} ({repository})"
+    comment_issue: "Re: [I] {title} ({repository})"
+    close_issue: "Re: [I] {title} ({repository})"
+    catchall: "[GH] {title} ({repository})"
+    


### PR DESCRIPTION
# MINOR UPDATE Add Email Templates to ASF.yml

## Description
Per suggestion from Christofer Dutz at ASF, we can add these template subjects to github emails which will facilitate people actually being able to organize and read them. 