### PR TITLE
DRILL-8405: Upgrade to snakeyaml 2.0 due to CVE

### DIFF
--- a/metastore/rdbms-metastore/pom.xml
+++ b/metastore/rdbms-metastore/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <jooq.version>3.13.1</jooq.version>
-    <liquibase.version>4.8.0</liquibase.version>
+    <liquibase.version>4.19.1</liquibase.version>
     <sqlite.version>3.30.1</sqlite.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <libthrift.version>0.14.0</libthrift.version>
     <derby.version>10.14.2.0</derby.version>
     <commons.cli.version>1.4</commons.cli.version>
-    <snakeyaml.version>1.33</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
     <commons.lang3.version>3.10</commons.lang3.version>
     <testcontainers.version>1.17.3</testcontainers.version>
     <typesafe.config.version>1.4.2</typesafe.config.version>


### PR DESCRIPTION
## Description

upgrade to snakeyaml 2.0 due to CVE - also upgrades liquibase jar because we need a version of that jar that supports newer APIs of snakeyaml

## Testing
CI build