### PR TITLE
DRILL-8411: GoogleSheets Reader Will Not Read More than 1K Rows

### DIFF
--- a/common/src/main/java/org/apache/drill/common/Typifier.java
+++ b/common/src/main/java/org/apache/drill/common/Typifier.java
@@ -272,7 +272,7 @@ public class Typifier {
    * @param date Input date string
    * @return LocalDateTime representation of the input String.
    */
-  private static LocalDateTime stringAsDateTime(String date) {
+  public static LocalDateTime stringAsDateTime(String date) {
     for (DateTimeFormatter format : formats) {
       try {
         return LocalDateTime.parse(date, format);
@@ -289,7 +289,7 @@ public class Typifier {
    * @param date Input date string
    * @return LocalDateTime representation of the input String.
    */
-  private static LocalDate stringAsDate(String date) {
+  public static LocalDate stringAsDate(String date) {
     for (DateTimeFormatter format : dateFormats) {
       try {
         return LocalDate.parse(date, format);

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsBatchReader.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsBatchReader.java
@@ -62,7 +62,7 @@ public class GoogleSheetsBatchReader implements ManagedReader<SchemaNegotiator> 
   // The default batch size is 1k rows.  It appears that Google sets the maximum batch size at 1000
   // rows. There is conflicting information about this online, but during testing, ranges with more than
   // 1000 rows would throw invalid request errors.
-  private static final int BATCH_SIZE = 1000;
+  protected static final int BATCH_SIZE = 1000;
   private static final String SHEET_COLUMN_NAME = "_sheets";
   private static final String TITLE_COLUMN_NAME = "_title";
 
@@ -225,12 +225,7 @@ public class GoogleSheetsBatchReader implements ManagedReader<SchemaNegotiator> 
   @Override
   public boolean next() {
     logger.debug("Processing batch.");
-    while (!rowWriter.isFull()) {
-      if (!processRow()) {
-        return false;
-      }
-    }
-    return true;
+    return processRow();
   }
 
   private boolean processRow() {
@@ -240,6 +235,7 @@ public class GoogleSheetsBatchReader implements ManagedReader<SchemaNegotiator> 
         // Get next range
         String range = rangeBuilder.next();
         if (range == null) {
+          rangeBuilder.lastBatch();
           return false;
         }
         data = GoogleSheetsUtils.getDataFromRange(service, sheetID, range);
@@ -293,12 +289,14 @@ public class GoogleSheetsBatchReader implements ManagedReader<SchemaNegotiator> 
       rowWriter.save();
     }
 
-    // If the results contained less than the batch size, stop iterating.
-    if (rowWriter.rowCount() < BATCH_SIZE) {
+    // If there is another batch, return true
+    if (rowWriter.rowCount() + BATCH_SIZE < rangeBuilder.getRowCount()) {
+      return true;
+    } else {
+      // If the results contained less than the batch size, stop iterating.
       rangeBuilder.lastBatch();
       return false;
     }
-    return true;
   }
 
   private void projectMetadata() {

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsBatchReader.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/GoogleSheetsBatchReader.java
@@ -241,7 +241,10 @@ public class GoogleSheetsBatchReader implements ManagedReader<SchemaNegotiator> 
         data = GoogleSheetsUtils.getDataFromRange(service, sheetID, range);
       } else {
         List<String> batches = rangeBuilder.nextBatch();
-        if (!batches.isEmpty()) {
+        if (batches == null) {
+          rangeBuilder.lastBatch();
+          return false;
+        } else if (!batches.isEmpty()) {
           data = GoogleSheetsUtils.getBatchData(service, sheetID, batches);
         } else {
           data = Collections.emptyList();

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/columns/GoogleSheetsColumnWriter.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/columns/GoogleSheetsColumnWriter.java
@@ -19,6 +19,7 @@
 package org.apache.drill.exec.store.googlesheets.columns;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.Typifier;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.slf4j.Logger;
@@ -27,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 
 public abstract class GoogleSheetsColumnWriter {
   protected static final Logger logger = LoggerFactory.getLogger(GoogleSheetsColumnWriter.class);
@@ -106,7 +109,7 @@ public abstract class GoogleSheetsColumnWriter {
       if (StringUtils.isNotEmpty(stringValue)) {
         LocalDate finalValue;
         try {
-          finalValue = LocalDate.parse(stringValue);
+          finalValue = Typifier.stringAsDate(stringValue);
         } catch (NumberFormatException e) {
           finalValue = null;
         }
@@ -211,7 +214,7 @@ public abstract class GoogleSheetsColumnWriter {
       if (StringUtils.isNotEmpty(stringValue)) {
         Instant finalValue;
         try {
-          finalValue = Instant.parse(stringValue);
+          finalValue = Typifier.stringAsDateTime(stringValue).toInstant(ZoneOffset.UTC);
         } catch (NumberFormatException e) {
           finalValue = null;
         }

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/columns/GoogleSheetsColumnWriter.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/columns/GoogleSheetsColumnWriter.java
@@ -29,7 +29,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
-import java.util.TimeZone;
 
 public abstract class GoogleSheetsColumnWriter {
   protected static final Logger logger = LoggerFactory.getLogger(GoogleSheetsColumnWriter.class);

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/utils/GoogleSheetsRangeBuilder.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/utils/GoogleSheetsRangeBuilder.java
@@ -146,7 +146,7 @@ public class GoogleSheetsRangeBuilder implements Iterator<String> {
     if (!hasMore) {
       return null;
     } else if (getStartIndex() > getEndIndex()) {
-      hasMore = false;
+      lastBatch();
       return null;
     }
 
@@ -196,6 +196,9 @@ public class GoogleSheetsRangeBuilder implements Iterator<String> {
 
   private List<String> buildBatchList() {
     if (isStarQuery) {
+      return null;
+    } else if (getStartIndex() > getEndIndex()) {
+      hasMore = false;
       return null;
     }
 

--- a/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/utils/GoogleSheetsRangeBuilder.java
+++ b/contrib/storage-googlesheets/src/main/java/org/apache/drill/exec/store/googlesheets/utils/GoogleSheetsRangeBuilder.java
@@ -238,6 +238,10 @@ public class GoogleSheetsRangeBuilder implements Iterator<String> {
     return buildBatchList();
   }
 
+  public int getRowCount() {
+    return rowCount;
+  }
+
   @Override
   public String toString() {
     return new PlanStringBuilder(this)

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
@@ -558,6 +558,23 @@ public class TestGoogleSheetsQueries extends ClusterTest {
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
 
+  @Test
+  public void testBigFile() throws Exception {
+    try {
+      initializeTokens("googlesheets");
+    } catch (PluginException e) {
+      fail(e.getMessage());
+    }
+
+    String sql = "SELECT *\n" +
+        "FROM googlesheets.`1fGepMXyRZ2WgaRt7v_AJtdtTvgUTTrtC33v823ncoNI`.`Contacts`";
+
+    RowSet results = queryBuilder().sql(sql).rowSet();
+    System.out.println(results.rowCount());
+    results.clear();
+  }
+
+
   /**
    * This function is used for testing only.  It initializes a {@link PersistentTokenTable} and populates it
    * with a valid access and refresh token.

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
@@ -558,23 +558,6 @@ public class TestGoogleSheetsQueries extends ClusterTest {
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
 
-  @Test
-  public void testBigFile() throws Exception {
-    try {
-      initializeTokens("googlesheets");
-    } catch (PluginException e) {
-      fail(e.getMessage());
-    }
-
-    String sql = "SELECT *\n" +
-        "FROM googlesheets.`1fGepMXyRZ2WgaRt7v_AJtdtTvgUTTrtC33v823ncoNI`.`Contacts`";
-
-    RowSet results = queryBuilder().sql(sql).rowSet();
-    System.out.println(results.rowCount());
-    results.clear();
-  }
-
-
   /**
    * This function is used for testing only.  It initializes a {@link PersistentTokenTable} and populates it
    * with a valid access and refresh token.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -1275,7 +1275,7 @@ public class TestAggregateFunctions extends ClusterTest {
   @Test
   public void testAggregateWithPivot() throws Exception {
     String query = "SELECT * FROM (\n" +
-        "SELECT education_level, salary, marital_status, extract(year from age(birth_date)) age\n" +
+        "SELECT education_level, salary, marital_status, extract(year from age('2023-02-23', birth_date)) age\n" +
         "FROM cp.`employee.json`)\n" +
         "PIVOT (avg(salary) avg_salary, avg(age) avg_age FOR marital_status IN ('M' married, 'S' single))";
     testBuilder()


### PR DESCRIPTION
# [DRILL-8411](https://issues.apache.org/jira/browse/DRILL-8411): GoogleSheets Reader Will Not Read More than 1K Rows

## Description
The GoogleSheets reader hits the batch limit from the GoogleSheets SDK of 1000 rows and stops.   This PR fixes that.  

It also fixes a minor but annoying issue whereby the GoogleSheets reader determines a column is a date/time, but is then unable to parse it because it is in a non-standard format.

## Documentation
N/A

## Testing
Ran existing unit tests and tested manually.