### PR TITLE
DRILL-8412: Upgrade to Calcite 1.35-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <parquet.version>1.12.2</parquet.version>
     <parquet.format.version>2.8.0</parquet.format.version>
     <calcite.groupId>org.apache.calcite</calcite.groupId>
-    <calcite.version>1.34.0</calcite.version>
+    <calcite.version>1.35.0-SNAPSHOT</calcite.version>
     <avatica.version>1.23.0</avatica.version>
     <janino.version>3.1.8</janino.version>
     <sqlline.version>1.12.0</sqlline.version>


### PR DESCRIPTION
# [DRILL-8412](https://issues.apache.org/jira/browse/DRILL-8412): Upgrade to Calcite 1.35-SNAPSHOT

## Description

If we're willing to try basing Drill master on snapshot builds of the upcoming version of Calcite for a while then here's a PR to do that. Please see the related discussion in Drill and Calcite mailing lists this week for more information.

Important notes.

1. The CI tests that run automatically upon commits to Drill master will exercise Drill with present day Calcite.
2. Breaking changes in Calcite would (mostly) break the Drill CI and force us to deal with them in order to proceed.
3. Regressions in Calcite would (mostly) break the Drill CI and force to report them in order to proceed.
4. If Drill master becomes too unstable when it is based on Calcite snapshots then this PR is trivially undoable.

## Documentation
N/A

## Testing
Existing unit test suite.
