### PR TITLE
DRILL-8409: Support the configuration of bind addresses for network services

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -913,7 +913,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin> <!-- generate the parser (Parser.jj is itself generated wit fmpp above) -->
+      <plugin> <!-- generate the parser (Parser.jj is itself generated with fmpp above) -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>javacc-maven-plugin</artifactId>
         <version>2.6</version>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -59,6 +59,7 @@ public final class ExecConstants {
   public static final String BIT_RETRY_DELAY = "drill.exec.rpc.bit.server.retry.delay";
   public static final String BIT_TIMEOUT = "drill.exec.bit.timeout";
   public static final String SERVICE_NAME = "drill.exec.cluster-id";
+  public static final String RPC_BIND_ADDR = "drill.exec.rpc.bind_addr";
   public static final String INITIAL_BIT_PORT = "drill.exec.rpc.bit.server.port";
   public static final String INITIAL_DATA_PORT = "drill.exec.rpc.bit.server.dataport";
   public static final String BIT_RPC_TIMEOUT = "drill.exec.rpc.bit.timeout";
@@ -222,6 +223,7 @@ public final class ExecConstants {
   public static final String HTTP_ENABLE = "drill.exec.http.enabled";
   public static final String HTTP_MAX_PROFILES = "drill.exec.http.max_profiles";
   public static final String HTTP_PROFILES_PER_PAGE = "drill.exec.http.profiles_per_page";
+  public static final String HTTP_BIND_ADDR = "drill.exec.http.bind_addr";
   public static final String HTTP_PORT = "drill.exec.http.port";
   public static final String HTTP_PORT_HUNT = "drill.exec.http.porthunt";
   public static final String HTTP_JETTY_SERVER_DUMP_AFTER_START = "drill.exec.http.jetty.server.dumpAfterStart";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.rpc.control;
 import java.util.List;
 
 import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -56,8 +57,10 @@ public class ControllerImpl implements Controller {
   @Override
   public DrillbitEndpoint start(DrillbitEndpoint partialEndpoint, final boolean allowPortHunting) {
     server = new ControlServer(config, connectionRegistry);
-    int port = config.getBootstrapContext().getConfig().getInt(ExecConstants.INITIAL_BIT_PORT);
-    port = server.bind(port, allowPortHunting);
+    DrillConfig drillConfig = config.getBootstrapContext().getConfig();
+    String bindAddr = drillConfig.getString(ExecConstants.RPC_BIND_ADDR);
+    int port = drillConfig.getInt(ExecConstants.INITIAL_BIT_PORT);
+    port = server.bind(bindAddr, port, allowPortHunting);
     DrillbitEndpoint completeEndpoint = partialEndpoint.toBuilder().setControlPort(port).build();
     connectionRegistry.setLocalEndpoint(completeEndpoint);
     handlerRegistry.setEndpoint(completeEndpoint);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataConnectionCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataConnectionCreator.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.rpc.data;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -52,10 +53,13 @@ public class DataConnectionCreator implements AutoCloseable {
   public DrillbitEndpoint start(DrillbitEndpoint partialEndpoint, boolean allowPortHunting) {
     server = new DataServer(config);
     int port = partialEndpoint.getControlPort() + 1;
-    if (config.getBootstrapContext().getConfig().hasPath(ExecConstants.INITIAL_DATA_PORT)) {
-      port = config.getBootstrapContext().getConfig().getInt(ExecConstants.INITIAL_DATA_PORT);
+    DrillConfig drillConfig = config.getBootstrapContext().getConfig();
+
+    String bindAddr = drillConfig.getString(ExecConstants.RPC_BIND_ADDR);
+    if (drillConfig.hasPath(ExecConstants.INITIAL_DATA_PORT)) {
+      port = drillConfig.getInt(ExecConstants.INITIAL_DATA_PORT);
     }
-    port = server.bind(port, allowPortHunting);
+    port = server.bind(bindAddr, port, allowPortHunting);
     return partialEndpoint.toBuilder().setDataPort(port).build();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.DrillVersionInfo;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
@@ -53,6 +54,7 @@ public class ServiceEngine implements AutoCloseable {
   private final DataConnectionCreator dataPool;
 
   private final String hostName;
+  private final String bindAddr;
   private final int intialUserPort;
   private final boolean allowPortHunting;
   private final boolean isDistributedMode;
@@ -73,14 +75,16 @@ public class ServiceEngine implements AutoCloseable {
     dataAllocator = newAllocator(context, "rpc:bit-data",
         "drill.exec.rpc.bit.server.memory.data.reservation", "drill.exec.rpc.bit.server.memory.data.maximum");
 
+    DrillConfig drillConfig = context.getConfig();
     final EventLoopGroup eventLoopGroup = TransportCheck.createEventLoopGroup(
-        context.getConfig().getInt(ExecConstants.USER_SERVER_RPC_THREADS), "UserServer-");
+        drillConfig.getInt(ExecConstants.USER_SERVER_RPC_THREADS), "UserServer-");
     userServer = new UserServer(context, userAllocator, eventLoopGroup, manager.getUserWorker());
     controller = new ControllerImpl(context, controlAllocator, manager.getControlMessageHandler());
     dataPool = new DataConnectionCreator(context, dataAllocator, manager.getWorkBus(), manager.getBee());
 
     hostName = context.getHostName();
-    intialUserPort = context.getConfig().getInt(ExecConstants.INITIAL_USER_PORT);
+    bindAddr = drillConfig.getString(ExecConstants.RPC_BIND_ADDR);
+    intialUserPort = drillConfig.getInt(ExecConstants.INITIAL_USER_PORT);
     this.allowPortHunting = allowPortHunting;
     this.isDistributedMode = isDistributedMode;
   }
@@ -97,7 +101,7 @@ public class ServiceEngine implements AutoCloseable {
       throw new DrillbitStartupException("Drillbit is disallowed to bind to loopback address in distributed mode.");
     }
 
-    userPort = userServer.bind(intialUserPort, allowPortHunting);
+    userPort = userServer.bind(bindAddr, intialUserPort, allowPortHunting);
     DrillbitEndpoint partialEndpoint = DrillbitEndpoint.newBuilder()
         .setAddress(hostName)
         .setUserPort(userPort)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
@@ -97,8 +97,10 @@ public class ServiceEngine implements AutoCloseable {
 
   public DrillbitEndpoint start() throws DrillbitStartupException, UnknownHostException {
     // loopback address check
-    if (isDistributedMode && InetAddress.getByName(hostName).isLoopbackAddress()) {
-      throw new DrillbitStartupException("Drillbit is disallowed to bind to loopback address in distributed mode.");
+    if (isDistributedMode && InetAddress.getByName(bindAddr).isLoopbackAddress()) {
+      throw new DrillbitStartupException(
+        "Drillbit may not bind to a loopback address in distributed mode."
+      );
     }
 
     userPort = userServer.bind(bindAddr, intialUserPort, allowPortHunting);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetRecordReader.java
@@ -231,7 +231,14 @@ public class ParquetRecordReader extends CommonParquetRecordReader {
         "\nRow group index: " + rowGroupIndex +
         "\nRecords to read: " + numRecordsToRead, e);
     } finally {
-      parquetReaderStats.timeProcess.addAndGet(timer.elapsed(TimeUnit.NANOSECONDS));
+      if (parquetReaderStats != null) {
+        parquetReaderStats.timeProcess.addAndGet(timer.elapsed(TimeUnit.NANOSECONDS));
+      } else {
+        logger.warn(
+          "Cannot log batch read timing because no Parquet reader stats tracker " +
+          "is available (probably due to an earlier error during query execution)."
+        );
+      }
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/parquet/hadoop/ParquetColumnChunkPageWriteStore.java
+++ b/exec/java-exec/src/main/java/org/apache/parquet/hadoop/ParquetColumnChunkPageWriteStore.java
@@ -57,7 +57,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @InterfaceAudience.Private
-public class ParquetColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWriteStore, Closeable {
+public class ParquetColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWriteStore,
+AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(ParquetColumnChunkPageWriteStore.class);
 
   private static ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -104,7 +104,8 @@ drill.exec: {
         }
       }
     },
-    use.ip: false
+    use.ip: false,
+    bind_addr: "0.0.0.0"
   },
   optimizer: {
     implementation: "org.apache.drill.exec.opt.IdentityOptimizer"
@@ -154,6 +155,7 @@ drill.exec: {
     },
     ssl_enabled: false,
     porthunt: false,
+    bind_addr: "0.0.0.0",
     port: 8047,
     jetty : {
       server : {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
@@ -81,6 +81,7 @@ import static org.mockito.Mockito.when;
 @Category(SecurityTest.class)
 public class TestBitBitKerberos extends ClusterTest {
   private static KerberosHelper krbHelper;
+  private static final String BIND_ADDR = "127.0.0.1";
 
   private int port = 1234;
 
@@ -172,7 +173,7 @@ public class TestBitBitKerberos extends ClusterTest {
         new DataServerRequestHandler(workBus, bee));
     DataServer server = new DataServer(config);
 
-    port = server.bind(port, true);
+    port = server.bind(BIND_ADDR, port, true);
     DrillbitEndpoint ep = DrillbitEndpoint.newBuilder().setAddress("localhost").setDataPort(port).build();
     DataConnectionManager connectionManager = new DataConnectionManager(ep, config);
     DataTunnel tunnel = new DataTunnel(connectionManager);
@@ -218,7 +219,7 @@ public class TestBitBitKerberos extends ClusterTest {
         new DataConnectionConfig(c2.getAllocator(), c2, new DataServerRequestHandler(workBus, bee));
       final DataServer server = new DataServer(config);
 
-      port = server.bind(port, true);
+      port = server.bind(BIND_ADDR, port, true);
       DrillbitEndpoint ep = DrillbitEndpoint.newBuilder().setAddress("localhost").setDataPort(port).build();
       final DataConnectionManager connectionManager = new DataConnectionManager(ep, config);
       final DataTunnel tunnel = new DataTunnel(connectionManager);
@@ -265,7 +266,7 @@ public class TestBitBitKerberos extends ClusterTest {
         new DataServerRequestHandler(workBus, bee));
       final DataServer server = new DataServer(config);
 
-      port = server.bind(port, true);
+      port = server.bind(BIND_ADDR, port, true);
       final DrillbitEndpoint ep = DrillbitEndpoint.newBuilder().setAddress("localhost").setDataPort(port).build();
       final DataConnectionManager connectionManager = new DataConnectionManager(ep, config);
       final DataTunnel tunnel = new DataTunnel(connectionManager);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
@@ -61,6 +61,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestBitRpc extends ExecTest {
+
+  private static final String BIND_ADDR = "127.0.0.1";
+
   @Test
   public void testConnectionBackpressure() throws Exception {
     final WorkerBee bee = mock(WorkerBee.class);
@@ -80,7 +83,7 @@ public class TestBitRpc extends ExecTest {
         new DataServerRequestHandler(workBus, bee));
     DataServer server = new DataServer(config);
 
-    port = server.bind(port, true);
+    port = server.bind(BIND_ADDR, port, true);
     DrillbitEndpoint ep = DrillbitEndpoint.newBuilder().setAddress("localhost").setDataPort(port).build();
     DataConnectionManager manager = new DataConnectionManager(ep, config);
     DataTunnel tunnel = new DataTunnel(manager);
@@ -113,7 +116,7 @@ public class TestBitRpc extends ExecTest {
             new DataServerRequestHandler(workBus, bee));
     DataServer server = new DataServer(config);
 
-    port = server.bind(port, true);
+    port = server.bind(BIND_ADDR, port, true);
     DrillbitEndpoint ep = DrillbitEndpoint.newBuilder().setAddress("localhost").setDataPort(port).build();
     DataConnectionManager manager = new DataConnectionManager(ep, config);
     DataTunnel tunnel = new DataTunnel(manager);

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicServer.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicServer.java
@@ -189,11 +189,11 @@ public abstract class BasicServer<T extends EnumLite, SC extends ServerConnectio
     return null;
   }
 
-  public int bind(final int initialPort, boolean allowPortHunting) {
+  public int bind(String bindAddr, final int initialPort, boolean allowPortHunting) {
     int port = initialPort - 1;
     while (true) {
       try {
-        b.bind(++port).sync();
+        b.bind(bindAddr, ++port).sync();
         break;
       } catch (Exception e) {
         // TODO(DRILL-3026):  Revisit:  Exception is not (always) BindException.


### PR DESCRIPTION
# [DRILL-8409](https://issues.apache.org/jira/browse/DRILL-8409): Support the configuration of bind addresses for network services

## Description

Drill provides the DRILL_HOST_NAME env var which determines what Drillbit host name will be exchanged over RPC for later look up by a remote client or Drillbit. This host name is used to check whether Drill is being asked to bind to the loopback address in distributed mode
```
    if (isDistributedMode && InetAddress.getByName(hostName).isLoopbackAddress()) {
      throw new DrillbitStartupException("Drillbit is disallowed to bind to loopback address in distributed mode.");
    }
```
but is not ever used set the bind address used for the Drillbit's RPC and web ports! This PR adds new boot options
```
drill.exec.rpc.bind_addr
drill.exec.http.bind_addr
```
and uses them to set the bind addresses used for RPC services and the HTTP service respectively.

## Documentation
Document all three of DRILL_HOST_NAME and the two new bind address options.

## Testing
Provide no bind addresses and confirm that the effective previous default (0.0.0.0) is applied.
Manually set bind addresses and test that Drill is not accessible on other local addresses.
