### PR TITLE
DRILL-8413: Add DNS Lookup Functions

### DIFF
--- a/contrib/udfs/README.md
+++ b/contrib/udfs/README.md
@@ -436,3 +436,11 @@ The functions are:
 
 [1]: https://github.com/target/huntlib
 
+
+# DNS Functions
+These functions enable DNS research using Drill.
+
+* `getHostName(<IP address>)`:  Returns the host name associated with an IP address.
+* `getHostAddress(<host>)`:  Returns an IP address associated with a host name.
+* `dnsLookup(<host>, [<Resolver>])`:  Performs a DNS lookup on a given host.  You can optionally provide a resolver.  Possible resolver values are: `cloudflare`,  `cloudflare_secondary`, `google`, `google_secondary`, `verisign`, `verisign_secondary`, `yandex`, `yandex_secondary`.
+* `whois(<host>, [<Resolver>])`:  Performs a whois lookup on the given host name.  You can optionally provide a resolver URL. Note that not all providers allow bulk automated whois lookups, so please follow the terms fo service for your provider.

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -32,9 +32,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+      <version>3.5.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.drill.exec</groupId>
       <artifactId>drill-java-exec</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>dnsjava</groupId>
+          <artifactId>dnsjava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -76,13 +88,6 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>dnsjava</groupId>
-      <artifactId>dnsjava</artifactId>
-      <version>3.5.2</version>
-    </dependency>
-
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -90,6 +95,12 @@
       <classifier>tests</classifier>
       <version>${project.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>dnsjava</groupId>
+          <artifactId>dnsjava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -30,13 +30,6 @@
   <artifactId>drill-udfs</artifactId>
   <name>Drill : Contrib : UDFs</name>
 
-  <repositories>
-    <repository>
-      <id>jabylon</id>
-      <url>https://www.jabylon.org/maven/</url>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -84,10 +77,11 @@
     </dependency>
 
     <dependency>
-      <groupId>org.xbill</groupId>
-      <artifactId>dns</artifactId>
-      <version>2.0.8</version>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+      <version>3.5.2</version>
     </dependency>
+
 
     <!-- Test dependencies -->
     <dependency>

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -30,6 +30,13 @@
   <artifactId>drill-udfs</artifactId>
   <name>Drill : Contrib : UDFs</name>
 
+  <repositories>
+    <repository>
+      <id>jabylon</id>
+      <url>http://www.jabylon.org/maven/</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -74,6 +81,12 @@
           <artifactId>caffeine</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.xbill</groupId>
+      <artifactId>dns</artifactId>
+      <version>2.0.8</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -33,7 +33,7 @@
   <repositories>
     <repository>
       <id>jabylon</id>
-      <url>http://www.jabylon.org/maven/</url>
+      <url>https://www.jabylon.org/maven/</url>
     </repository>
   </repositories>
 

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
@@ -23,6 +23,7 @@ import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.Output;
 import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter;
@@ -308,18 +309,21 @@ public class DNSFunctions {
     @Param
     NullableVarCharHolder rawDomainName;
 
-    @Param
+    @Param(constant = true)
     VarCharHolder resolverHolder;
 
     @Output
     BaseWriter.ComplexWriter out;
+
+    @Workspace
+    String resolver;
 
     @Inject
     DrillBuf buffer;
 
     @Override
     public void setup() {
-      // no op
+      resolver = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(resolverHolder.start, resolverHolder.end, resolverHolder.buffer);
     }
 
     @Override
@@ -336,7 +340,6 @@ public class DNSFunctions {
 
       try {
         String domainName = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawDomainName.start, rawDomainName.end, rawDomainName.buffer);
-        String resolver = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(resolverHolder.start, resolverHolder.end, resolverHolder.buffer);
         org.apache.drill.exec.udfs.DNSUtils.getDNS(domainName, resolver, out, buffer);
       } catch (Exception e) {
         org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter = out.rootAsList();
@@ -348,5 +351,4 @@ public class DNSFunctions {
       }
     }
   }
-
 }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
@@ -73,7 +73,6 @@ public class DNSFunctions {
   }
 
   /* This function takes a host name and returns the IP address associated with that host, and "Unknown if there is an error */
-
   @FunctionTemplate(names = {"get_host_address", "host_lookup"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
 
   public static class HostLookup implements DrillSimpleFunc {

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import io.netty.buffer.DrillBuf;
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.holders.BigIntHolder;
+import org.apache.drill.exec.expr.holders.VarCharHolder;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter;
+
+import javax.inject.Inject;
+
+public class DNSFunctions {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DNSFunctions.class);
+
+  private DNSFunctions() {
+  }
+
+  /* This function gets the host name associated with an IP address */
+  @FunctionTemplate(names = {"get_host_name", "reverse_ip_lookup"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+
+  public static class ReverseIPLookup implements DrillSimpleFunc {
+
+    @Param
+    VarCharHolder ipaddress;
+
+    @Output
+    VarCharHolder out;
+
+    @Inject
+    DrillBuf buffer;
+
+    @Override
+    public void setup() {
+
+    }
+
+    @Override
+    public void eval() {
+      String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(ipaddress.start, ipaddress.end, ipaddress.buffer);
+      String hostname = "";
+
+      try {
+        java.net.InetAddress address = java.net.InetAddress.getByName(ipString);
+        hostname = address.getHostName();
+
+      } catch (java.net.UnknownHostException e) {
+        hostname = "Unknown host";
+      }
+      out.buffer = buffer;
+      out.start = 0;
+      out.end = hostname.getBytes().length;
+      buffer.setBytes(0, hostname.getBytes());
+    }
+  }
+
+  /* This function takes a host name and returns the IP address associated with that host, and "Unknown if there is an error */
+
+  @FunctionTemplate(names = {"get_host_address", "host_lookup"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+
+  public static class HostLookup implements DrillSimpleFunc {
+
+    @Param
+    VarCharHolder hostname;
+
+    @Output
+    VarCharHolder out;
+
+    @Inject
+    DrillBuf buffer;
+
+    @Override
+    public void setup() {
+
+    }
+
+    @Override
+    public void eval() {
+      String host = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(hostname.start, hostname.end, hostname.buffer);
+      String result = "";
+      try {
+        java.net.Inet4Address ip = (java.net.Inet4Address) java.net.Inet4Address.getByName(host);
+        result = ip.getHostAddress();
+      } catch (Exception e) {
+        result = "Unknown";
+      }
+
+      out.buffer = buffer;
+      out.start = 0;
+      out.end = result.getBytes().length;
+      buffer.setBytes(0, result.getBytes());
+    }
+  }
+
+  /* This function gets the host name associated with a domain */
+  @FunctionTemplate(name = "get_mx_record", scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+
+  public static class MXRecordFunction implements DrillSimpleFunc {
+
+    @Param
+    VarCharHolder ipaddress;
+
+    @Output
+    VarCharHolder out;
+
+    @Inject
+    DrillBuf buffer;
+
+    @Override
+    public void setup() {
+
+    }
+
+    @Override
+    public void eval() {
+      String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(ipaddress.start, ipaddress.end, ipaddress.buffer);
+      String MXRecordName = "";
+      int minPriority = 1000000000;
+      try {
+        org.xbill.DNS.Record[] records = new org.xbill.DNS.Lookup(ipString, org.xbill.DNS.Type.MX).run();
+        for (int i = 0; i < records.length; i++) {
+          org.xbill.DNS.MXRecord mx = (org.xbill.DNS.MXRecord) records[i];
+
+          //Assign the return value to the MX record with the lowest priority (the primary record)
+          if (mx.getPriority() < minPriority) {
+            minPriority = mx.getPriority();
+            MXRecordName = mx.getTarget().toString();
+          }
+          //System.out.println("Nameserver " + mx.getTarget() + " " + mx.getPriority());
+        }
+      } catch (Exception e) {
+        MXRecordName = "MX Record not found";
+      }
+
+      out.buffer = buffer;
+      out.start = 0;
+      out.end = MXRecordName.getBytes().length;
+      buffer.setBytes(0, MXRecordName.getBytes());
+    }
+  }
+
+  /* This function gets the host name associated with an IP address */
+  @FunctionTemplate(name = "get_mx_records", scope = FunctionTemplate.FunctionScope.SIMPLE)
+
+  public static class MXRecordListFunction implements DrillSimpleFunc {
+    @Param
+    VarCharHolder ipaddress;
+
+    @Output
+    BaseWriter.ComplexWriter out;
+
+    @Inject
+    DrillBuf buffer;
+
+    @Override
+    public void setup() {
+
+    }
+
+    @Override
+    public void eval() {
+      String domainName = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(ipaddress.start, ipaddress.end, ipaddress.buffer);
+
+      org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter = out.rootAsList();
+      try {
+        org.xbill.DNS.Record[] records = new org.xbill.DNS.Lookup(domainName, org.xbill.DNS.Type.MX).run();
+        String mxRecordName;
+
+        for (int i = 0; i < records.length; i++) {
+          org.xbill.DNS.MXRecord mx = (org.xbill.DNS.MXRecord) records[i];
+          org.apache.drill.exec.expr.holders.VarCharHolder rowHolder = new org.apache.drill.exec.expr.holders.VarCharHolder();
+          mxRecordName = mx.getTarget().toString();
+
+          byte[] rowStringBytes = mxRecordName.getBytes();
+          buffer.reallocIfNeeded(rowStringBytes.length);
+          buffer.setBytes(0, rowStringBytes);
+
+          rowHolder.start = 0;
+          rowHolder.end = rowStringBytes.length;
+          rowHolder.buffer = buffer;
+
+          listWriter.varChar().write(rowHolder);
+        }
+      } catch (Exception e) {
+        logger.warn("Could not find MX records for " + domainName);
+      }
+    }
+  }
+
+  /* This function performs a complete DNS lookup */
+  @FunctionTemplate(name = "dns_lookup", scope = FunctionTemplate.FunctionScope.SIMPLE)
+  public static class DNSLookupFunction implements DrillSimpleFunc {
+
+    @Param
+    VarCharHolder rawDomainName;
+
+    @Output
+    BaseWriter.ComplexWriter out;
+
+    @Inject
+    DrillBuf buffer;
+
+    @Override
+    public void setup() {
+
+    }
+
+    @Override
+    public void eval() {
+      org.xbill.DNS.Record[] records = null;
+      org.xbill.DNS.Lookup look;
+
+      String domainName = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawDomainName.start, rawDomainName.end, rawDomainName.buffer);
+      try {
+        look = new org.xbill.DNS.Lookup(domainName, org.xbill.DNS.Type.ANY);
+        records = look.run();
+        for (int i = 0; i < records.length; i++) {
+          org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter = out.rootAsList();
+          org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter rowMapWriter = listWriter.map();
+          org.apache.drill.exec.expr.holders.VarCharHolder fieldHolder = new org.apache.drill.exec.expr.holders.VarCharHolder();
+
+          byte[] dnsType = records[i].getName().toString().getBytes();
+          buffer.reallocIfNeeded(dnsType.length);
+          buffer.setBytes(0, dnsType);
+
+          fieldHolder.start = 0;
+          fieldHolder.end = dnsType.length;
+          fieldHolder.buffer = buffer;
+
+          rowMapWriter.start();
+          rowMapWriter.varChar("field1").write(fieldHolder);
+          rowMapWriter.bigInt("ttl").writeBigInt(records[i].getTTL());
+          rowMapWriter.end();
+          System.out.println(records[i]);
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
@@ -36,8 +36,9 @@ public class DNSFunctions {
   }
 
   /* This function gets the host name associated with an IP address */
-  @FunctionTemplate(names = {"get_host_name", "reverse_ip_lookup"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
-
+  @FunctionTemplate(names = {"get_host_name", "getHostName", "reverse_ip_lookup"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE,
+      nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class ReverseIPLookup implements DrillSimpleFunc {
 
     @Param
@@ -74,8 +75,9 @@ public class DNSFunctions {
   }
 
   /* This function takes a host name and returns the IP address associated with that host, and "Unknown if there is an error */
-  @FunctionTemplate(names = {"get_host_address", "host_lookup"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
-
+  @FunctionTemplate(names = {"get_host_address", "getHostAddress", "host_lookup", "hostLookup"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE,
+      nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
   public static class HostLookup implements DrillSimpleFunc {
 
     @Param
@@ -203,7 +205,8 @@ public class DNSFunctions {
     }
   }
 
-  @FunctionTemplate(names = {"whois"}, scope = FunctionTemplate.FunctionScope.SIMPLE)
+  @FunctionTemplate(names = {"whois"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE)
   public static class WhoIsFunction implements DrillSimpleFunc {
 
     @Param

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSFunctions.java
@@ -302,4 +302,51 @@ public class DNSFunctions {
     }
   }
 
+  @FunctionTemplate(names = {"dns_lookup", "dnsLookup", "dns"}, scope = FunctionTemplate.FunctionScope.SIMPLE)
+  public static class DNSLookupFunctionWithResolver implements DrillSimpleFunc {
+
+    @Param
+    NullableVarCharHolder rawDomainName;
+
+    @Param
+    VarCharHolder resolverHolder;
+
+    @Output
+    BaseWriter.ComplexWriter out;
+
+    @Inject
+    DrillBuf buffer;
+
+    @Override
+    public void setup() {
+      // no op
+    }
+
+    @Override
+    public void eval() {
+      if (rawDomainName.isSet == 0) {
+        org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter = out.rootAsList();
+        org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter rowMapWriter = listWriter.map();
+        listWriter.startList();
+        rowMapWriter.start();
+        rowMapWriter.end();
+        listWriter.endList();
+        return;
+      }
+
+      try {
+        String domainName = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawDomainName.start, rawDomainName.end, rawDomainName.buffer);
+        String resolver = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(resolverHolder.start, resolverHolder.end, resolverHolder.buffer);
+        org.apache.drill.exec.udfs.DNSUtils.getDNS(domainName, resolver, out, buffer);
+      } catch (Exception e) {
+        org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter = out.rootAsList();
+        org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter rowMapWriter = listWriter.map();
+        listWriter.startList();
+        rowMapWriter.start();
+        rowMapWriter.end();
+        listWriter.endList();
+      }
+    }
+  }
+
 }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSUtils.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import io.netty.buffer.DrillBuf;
+import org.apache.drill.exec.expr.holders.VarCharHolder;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+
+public class DNSUtils {
+
+  public static void getDNS(String domainName, ComplexWriter out, DrillBuf buffer) throws TextParseException {
+    Lookup look = new Lookup(domainName, Type.ANY);
+    Record[] records = look.run();
+
+    // Initialize writers
+    ListWriter listWriter = out.rootAsList();
+    MapWriter rowMapWriter = listWriter.map();
+    // If there are no records, return an empty list.
+    if (records == null) {
+      listWriter.startList();
+      rowMapWriter.start();
+      rowMapWriter.end();
+      listWriter.endList();
+      return;
+    }
+
+    for (int i = 0; i < records.length; i++) {
+      VarCharHolder fieldHolder = new VarCharHolder();
+
+      Record record = records[i];
+
+      rowMapWriter.start();
+      byte[] name = record.getName().toString().getBytes();
+      buffer = buffer.reallocIfNeeded(name.length);
+      buffer.setBytes(0, name);
+      rowMapWriter.varChar("name").writeVarChar(0, name.length, buffer);
+
+      byte[] completeRecord = record.toString().getBytes();
+      buffer = buffer.reallocIfNeeded(completeRecord.length);
+      buffer.setBytes(0, completeRecord);
+      fieldHolder.start = 0;
+      fieldHolder.end = completeRecord.length;
+      fieldHolder.buffer = buffer;
+      rowMapWriter.varChar("record").write(fieldHolder);
+
+      rowMapWriter.bigInt("ttl").writeBigInt(record.getTTL());
+
+      byte[] type = Type.string(record.getType()).getBytes();
+      buffer = buffer.reallocIfNeeded(type.length);
+      buffer.setBytes(0, type);
+      rowMapWriter.varChar("type").writeVarChar(0, type.length, buffer);
+
+      byte[] rdata = record.rdataToString().getBytes();
+      buffer.reallocIfNeeded(rdata.length);
+      buffer.setBytes(0, rdata);
+      rowMapWriter.varChar("rdata").writeVarChar(0, rdata.length, buffer);
+      rowMapWriter.end();
+    }
+  }
+}

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSUtils.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/DNSUtils.java
@@ -30,7 +30,7 @@ import org.xbill.DNS.Type;
 
 public class DNSUtils {
 
-  public static void getDNS(String domainName, ComplexWriter out, DrillBuf buffer) throws TextParseException {
+  public static void getDNS(String domainName, String resolver, ComplexWriter out, DrillBuf buffer) throws TextParseException {
     Lookup look = new Lookup(domainName, Type.ANY);
     Record[] records = look.run();
 
@@ -78,5 +78,9 @@ public class DNSUtils {
       rowMapWriter.varChar("rdata").writeVarChar(0, rdata.length, buffer);
       rowMapWriter.end();
     }
+  }
+
+  public static void getDNS(String domainName, ComplexWriter out, DrillBuf buffer) throws TextParseException {
+    getDNS(domainName, null, out, buffer);
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -38,8 +38,8 @@ public class TestDNSFunctions extends ClusterTest {
 
   @Test
   public void testGetHostAddress() throws Exception {
-    String query = "select get_host_address('gtkcyber.com') as hostname from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("35.224.172.16").go();
+    String query = "select get_host_address('apache.org') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("151.101.2.132").go();
 
     query = "select get_host_address('google') as hostname from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("Unknown").go();
@@ -53,8 +53,8 @@ public class TestDNSFunctions extends ClusterTest {
 
   @Test
   public void testGetHostName() throws Exception {
-    String query = "select get_host_name('216.239.36.21') as hostname from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("any-in-2415.1e100.net").go();
+    String query = "select get_host_name('142.251.16.102') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("bl-in-f102.1e100.net").go();
 
     query = "select get_host_name('sdfsdfafsdfadfdsf') as hostname from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("Unknown host").go();
@@ -68,16 +68,13 @@ public class TestDNSFunctions extends ClusterTest {
 
   @Test
   public void testDNSLookup() throws Exception {
-    String sql = "SELECT dns_lookup('datadistillr.io') FROM (VALUES(1))";
-    RowSet results = client.queryBuilder().sql(sql).rowSet();
-    results.clear();
+    String sql = "SELECT dns_lookup('google.com') AS dns_info FROM (VALUES(1))";
+    testBuilder().sqlQuery(sql).ordered().baselineColumns("dns_info").go();
   }
 
   @Test
   public void testWhois() throws Exception {
-    String sql = "SELECT whois('cnn.com') FROM (VALUES(1))";
-    RowSet results = client.queryBuilder().sql(sql).rowSet();
-    results.print();
-    results.clear();
+    String sql = "SELECT whois('google.com') AS whois FROM (VALUES(1))";
+    testBuilder().sqlQuery(sql).ordered().baselineColumns("whois").go();
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -106,7 +106,14 @@ public class TestDNSFunctions extends ClusterTest {
   public void testDNSLookup() throws Exception {
     String sql = "SELECT dns_lookup('datadistillr.io') FROM (VALUES(1))";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
-
     results.clear();
   }
+
+  @Test
+  public void testWhois() throws Exception {
+    String sql = "SELECT whois('datadistillr.com') FROM (VALUES(1))";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    results.clear();
+  }
+
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.udfs;
 
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
@@ -99,8 +100,13 @@ public class TestDNSFunctions extends ClusterTest {
 
     query = "select get_mx_records('') as record from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
+  }
 
-    //query = "select get_mx_records(cast(null as varchar)) as record from (values(1))";
-    //testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
+  @Test
+  public void testDNSLookup() throws Exception {
+    String sql = "SELECT dns_lookup('datadistillr.io') FROM (VALUES(1))";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+
+    results.clear();
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.udfs;
+
+import org.apache.drill.categories.SqlFunctionTest;
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import java.util.ArrayList;
+
+@Category({UnlikelyTest.class, SqlFunctionTest.class})
+public class TestDNSFunctions extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+  }
+
+  @Test
+  public void testGetHostAddress() throws Exception {
+    String query = "select get_host_address('gtkcyber.com') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("216.239.36.21").go();
+
+    query = "select get_host_address('google') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("Unknown").go();
+
+    query = "select get_host_address('') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("127.0.0.1").go();
+
+    query = "select get_host_address(cast(null as varchar)) as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues((String)null).go();
+  }
+
+  @Test
+  public void testGetHostName() throws Exception {
+    String query = "select get_host_name('216.239.36.21') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("any-in-2415.1e100.net").go();
+
+    query = "select get_host_name('sdfsdfafsdfadfdsf') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("Unknown host").go();
+
+    query = "select get_host_name('') as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("localhost").go();
+
+    query = "select get_host_name(cast(null as varchar)) as hostname from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues((String)null).go();
+  }
+
+  @Test
+  public void testGetMXName() throws Exception {
+    String query = "select get_mx_record('gmail.com') as record from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues("gmail-smtp-in.l.google.com.").go();
+
+    query = "select get_mx_record('sdfsdfafsdfadfdsf') as record from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues("MX Record not found").go();
+
+    query = "select get_mx_record('') as record from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues("MX Record not found").go();
+
+    query = "select get_mx_record(cast(null as varchar)) as record from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
+  }
+
+  @Test
+  public void testGetMXNames() throws Exception {
+    String query =  "select flatten(get_mx_records('gmail.com')) AS mx_records FROM (VALUES(1)) order by mx_records ASC";
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .baselineColumns("mx_records")
+      .baselineValues("alt1.gmail-smtp-in.l.google.com.")
+      .baselineValues("alt2.gmail-smtp-in.l.google.com.")
+      .baselineValues("alt3.gmail-smtp-in.l.google.com.")
+      .baselineValues("alt4.gmail-smtp-in.l.google.com.")
+      .baselineValues("gmail-smtp-in.l.google.com.")
+      .go();
+
+    query = "select get_mx_records('sdfsdfafsdfadfdsf') as record from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
+
+    query = "select get_mx_records('') as record from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
+
+    //query = "select get_mx_records(cast(null as varchar)) as record from (values(1))";
+    //testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
+  }
+}

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -67,42 +67,6 @@ public class TestDNSFunctions extends ClusterTest {
   }
 
   @Test
-  public void testGetMXName() throws Exception {
-    String query = "select get_mx_record('gmail.com') as record from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues("gmail-smtp-in.l.google.com.").go();
-
-    query = "select get_mx_record('sdfsdfafsdfadfdsf') as record from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues("MX Record not found").go();
-
-    query = "select get_mx_record('') as record from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues("MX Record not found").go();
-
-    query = "select get_mx_record(cast(null as varchar)) as record from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
-  }
-
-  @Test
-  public void testGetMXNames() throws Exception {
-    String query =  "select flatten(get_mx_records('gmail.com')) AS mx_records FROM (VALUES(1)) order by mx_records ASC";
-    testBuilder()
-      .sqlQuery(query)
-      .unOrdered()
-      .baselineColumns("mx_records")
-      .baselineValues("alt1.gmail-smtp-in.l.google.com.")
-      .baselineValues("alt2.gmail-smtp-in.l.google.com.")
-      .baselineValues("alt3.gmail-smtp-in.l.google.com.")
-      .baselineValues("alt4.gmail-smtp-in.l.google.com.")
-      .baselineValues("gmail-smtp-in.l.google.com.")
-      .go();
-
-    query = "select get_mx_records('sdfsdfafsdfadfdsf') as record from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
-
-    query = "select get_mx_records('') as record from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("record").baselineValues((String)null).go();
-  }
-
-  @Test
   public void testDNSLookup() throws Exception {
     String sql = "SELECT dns_lookup('datadistillr.io') FROM (VALUES(1))";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
@@ -111,9 +75,9 @@ public class TestDNSFunctions extends ClusterTest {
 
   @Test
   public void testWhois() throws Exception {
-    String sql = "SELECT whois('datadistillr.com') FROM (VALUES(1))";
+    String sql = "SELECT whois('cnn.com') FROM (VALUES(1))";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
+    results.print();
     results.clear();
   }
-
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -25,7 +25,6 @@ import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import java.util.ArrayList;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
 public class TestDNSFunctions extends ClusterTest {
@@ -39,7 +38,7 @@ public class TestDNSFunctions extends ClusterTest {
   @Test
   public void testGetHostAddress() throws Exception {
     String query = "select get_host_address('gtkcyber.com') as hostname from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("216.239.36.21").go();
+    testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("35.224.172.16").go();
 
     query = "select get_host_address('google') as hostname from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("hostname").baselineValues("Unknown").go();

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestDNSFunctions.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.udfs;
 
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
-import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;

--- a/pom.xml
+++ b/pom.xml
@@ -2207,6 +2207,10 @@
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -2373,6 +2377,10 @@
               <exclusion>
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3034,6 +3042,10 @@
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -3541,6 +3553,10 @@
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>servlet-api-2.5</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -3660,6 +3676,10 @@
               <exclusion>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>servlet-api-2.5</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3991,6 +4011,10 @@
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -4239,6 +4263,10 @@
               <exclusion>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
               </exclusion>
             </exclusions>
           </dependency>


### PR DESCRIPTION
# [DRILL-8413](https://issues.apache.org/jira/browse/DRILL-8413): Add DNS Lookup Functions


## Description
See below

## Documentation

These functions enable DNS research using Drill.

* `getHostName(<IP address>)`:  Returns the host name associated with an IP address.
* `getHostAddress(<host>)`:  Returns an IP address associated with a host name.
* `dnsLookup(<host>, [<Resolver>])`:  Performs a DNS lookup on a given host.  You can optionally provide a resolver.  Possible resolver values are: `cloudflare`,  `cloudflare_secondary`, `google`, `google_secondary`, `verisign`, `verisign_secondary`, `yandex`, `yandex_secondary`.
* `whois(<host>, [<Resolver>])`:  Performs a whois lookup on the given host name.  You can optionally provide a resolver URL. Note that not all providers allow bulk automated whois lookups, so please follow the terms fo service for your provider.

## Testing
Added unit tests.