### PR TITLE
[MINOR-UPDATE]: Drop conjars repo and revert ci.yml runner image to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Main Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 150
     strategy:
       matrix:

--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -33,6 +33,14 @@
     <okhttp.version>4.5.0</okhttp.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>splunk-artifactory</id>
+      <name>Splunk Releases</name>
+      <url>https://splunk.jfrog.io/artifactory/ext-releases-local</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>

--- a/distribution/src/main/resources/drill-override-example.conf
+++ b/distribution/src/main/resources/drill-override-example.conf
@@ -44,7 +44,8 @@ drill.exec: {
         threads: 1
       }
     },
-    use.ip : false
+    use.ip : false,
+    bind_addr: 0.0.0.0
   },
   operator: {
     packages += "org.apache.drill.exec.physical.config"
@@ -95,6 +96,7 @@ drill.exec: {
   http: {
     enabled: true,
     ssl_enabled: false,
+    bind_addr: 0.0.0.0,
     port: 8047
     session_max_idle_secs: 3600, # Default value 1hr
     cors: {

--- a/exec/java-exec/src/test/resources/drill-udf/pom.xml
+++ b/exec/java-exec/src/test/resources/drill-udf/pom.xml
@@ -32,7 +32,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <jar.finalName>${project.name}</jar.finalName>
     <custom.buildDirectory>${project.basedir}/target</custom.buildDirectory>
-    <drill.version>1.17.0</drill.version>
+    <drill.version>1.21.0</drill.version>
     <include.files>**/*.java</include.files>
     <include.resources>**/*.conf</include.resources>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -176,21 +176,6 @@
 
   <repositories>
     <repository>
-      <id>conjars</id>
-      <name>Conjars</name>
-      <url>https://conjars.org/repo</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>fail</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
       <id>mapr-releases</id>
       <url>https://repository.mapr.com/maven/</url>
       <releases>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
     <shaded.guava.version>28.2-jre</shaded.guava.version>
     <guava.version>30.1.1-jre</guava.version>
     <forkCount>1</forkCount>
-    <parquet.version>1.12.2</parquet.version>
-    <parquet.format.version>2.8.0</parquet.format.version>
+    <parquet.version>1.12.3</parquet.version>
+    <parquet.format.version>2.9.0</parquet.format.version>
     <calcite.groupId>org.apache.calcite</calcite.groupId>
     <calcite.version>1.34.0</calcite.version>
     <avatica.version>1.23.0</avatica.version>

--- a/pom.xml
+++ b/pom.xml
@@ -218,11 +218,6 @@
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>
-    <repository>
-      <id>splunk-artifactory</id>
-      <name>Splunk Releases</name>
-      <url>https://splunk.jfrog.io/artifactory/ext-releases-local</url>
-    </repository>
   </repositories>
 
   <issueManagement>


### PR DESCRIPTION
- Set drill.version in drill-udf/pom.xml to 1.22.0-SNAPSHOT.
- Drop conjars repository.
- Upgrade parquet to 1.12.3 and parquet-format to 2.9.0.
- Move Splunk Maven repository declaration to contrib/storage-splunk/pom.xml.
- Revert ci.yml to ubuntu-latest.
- Add RPC and HTTP bind address lines to drill-override-example.conf.
