### PR TITLE
DRILL-8385: Add support for disabling SSL certificate verification in the Elasticsearch plugin

### DIFF
--- a/contrib/storage-elasticsearch/README.md
+++ b/contrib/storage-elasticsearch/README.md
@@ -32,6 +32,7 @@ Following is the default registration configuration.
   ],
   "username": null,
   "password": null,
+  "disableSSLVerification": false,
   "enabled": false
 }
 ```

--- a/contrib/storage-elasticsearch/src/main/java/org/apache/drill/exec/store/elasticsearch/ElasticsearchStorageConfig.java
+++ b/contrib/storage-elasticsearch/src/main/java/org/apache/drill/exec/store/elasticsearch/ElasticsearchStorageConfig.java
@@ -54,7 +54,11 @@ public class ElasticsearchStorageConfig extends StoragePluginConfig {
 
   public static final String CREDENTIALS_PROVIDER = "credentialsProvider";
 
+  private static final String DISABLE_SSL_VERIFICATION = "disableSSLVerification";
+
   private static final String EMPTY_STRING = "";
+
+  private final boolean disableSSLVerification;
 
   private final List<String> hosts;
   private final String pathPrefix;
@@ -66,17 +70,20 @@ public class ElasticsearchStorageConfig extends StoragePluginConfig {
       @JsonProperty(PASSWORD) String password,
       @JsonProperty(PATH_PREFIX) String pathPrefix,
       @JsonProperty("authMode") String authMode,
+      @JsonProperty("disableSSLVerification") Boolean disableSSLVerification,
       @JsonProperty(CREDENTIALS_PROVIDER) CredentialsProvider credentialsProvider) {
     super(CredentialProviderUtils.getCredentialsProvider(username, password, credentialsProvider),
         credentialsProvider == null, AuthMode.parseOrDefault(authMode, AuthMode.SHARED_USER));
     this.hosts = hosts;
     this.pathPrefix = pathPrefix;
+    this.disableSSLVerification = disableSSLVerification == null ? false : disableSSLVerification;
   }
 
   private ElasticsearchStorageConfig(ElasticsearchStorageConfig that, CredentialsProvider credentialsProvider) {
     super(getCredentialsProvider(credentialsProvider), credentialsProvider == null, that.authMode);
     this.hosts = that.hosts;
     this.pathPrefix = that.pathPrefix;
+    this.disableSSLVerification = that.disableSSLVerification;
   }
 
   @Override
@@ -138,6 +145,7 @@ public class ElasticsearchStorageConfig extends StoragePluginConfig {
     builder.put(PATH_PREFIX, pathPrefix != null ? pathPrefix : EMPTY_STRING);
     builder.put(USERNAME, credentials.getOrDefault(USERNAME, EMPTY_STRING));
     builder.put(PASSWORD, credentials.getOrDefault(PASSWORD, EMPTY_STRING));
+    builder.put(DISABLE_SSL_VERIFICATION, Boolean.valueOf(disableSSLVerification).toString());
 
     credentials.remove(USERNAME);
     credentials.remove(PASSWORD);
@@ -157,12 +165,13 @@ public class ElasticsearchStorageConfig extends StoragePluginConfig {
     ElasticsearchStorageConfig that = (ElasticsearchStorageConfig) o;
     return Objects.equals(hosts, that.hosts) &&
         Objects.equals(pathPrefix, that.pathPrefix) &&
-        Objects.equals(credentialsProvider, that.credentialsProvider);
+        Objects.equals(credentialsProvider, that.credentialsProvider) &&
+        Objects.equals(disableSSLVerification, that.disableSSLVerification);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(hosts, pathPrefix, credentialsProvider);
+    return Objects.hash(hosts, pathPrefix, disableSSLVerification, credentialsProvider);
   }
 
   @Override
@@ -170,6 +179,7 @@ public class ElasticsearchStorageConfig extends StoragePluginConfig {
     return new PlanStringBuilder(this)
         .field("hosts", hosts)
         .field("pathPrefix", pathPrefix)
+        .field("disableSSLVerification", disableSSLVerification)
         .field("credentialsProvider", credentialsProvider)
         .toString();
   }

--- a/contrib/storage-elasticsearch/src/main/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-elasticsearch/src/main/resources/bootstrap-storage-plugins.json
@@ -3,6 +3,7 @@
     "elastic" : {
       "type" : "elastic",
       "hosts": ["http://localhost:9200"],
+      "disableSSLVerification": false,
       "username" : null,
       "password" : null
     }

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticComplexTypesTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticComplexTypesTest.java
@@ -62,7 +62,7 @@ public class ElasticComplexTypesTest extends ClusterTest {
         Collections.singletonList(TestElasticsearchSuite.getAddress()),
         TestElasticsearchSuite.ELASTICSEARCH_USERNAME,
         TestElasticsearchSuite.ELASTICSEARCH_PASSWORD,
-        null, AuthMode.SHARED_USER.name(),
+        null, AuthMode.SHARED_USER.name(), false,
         null
     );
     config.setEnabled(true);

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticInfoSchemaTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticInfoSchemaTest.java
@@ -54,7 +54,7 @@ public class ElasticInfoSchemaTest extends ClusterTest {
         Collections.singletonList(TestElasticsearchSuite.getAddress()),
         TestElasticsearchSuite.ELASTICSEARCH_USERNAME,
         TestElasticsearchSuite.ELASTICSEARCH_PASSWORD,
-        null, AuthMode.SHARED_USER.name(),
+        null, AuthMode.SHARED_USER.name(), false,
         null
     );
 

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchPlanTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchPlanTest.java
@@ -55,7 +55,7 @@ public class ElasticSearchPlanTest extends ClusterTest {
       TestElasticsearchSuite.ELASTICSEARCH_USERNAME,
       TestElasticsearchSuite.ELASTICSEARCH_PASSWORD,
       null,
-      AuthMode.SHARED_USER.name(),
+      AuthMode.SHARED_USER.name(), true,
       null
     );
     config.setEnabled(true);

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchQueryTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchQueryTest.java
@@ -64,7 +64,7 @@ public class ElasticSearchQueryTest extends ClusterTest {
       Collections.singletonList(TestElasticsearchSuite.getAddress()),
       TestElasticsearchSuite.ELASTICSEARCH_USERNAME,
       TestElasticsearchSuite.ELASTICSEARCH_PASSWORD,
-      null, AuthMode.SHARED_USER.name(),
+      null, AuthMode.SHARED_USER.name(), false,
       null
     );
     config.setEnabled(true);

--- a/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchUserTranslationTest.java
+++ b/contrib/storage-elasticsearch/src/test/java/org/apache/drill/exec/store/elasticsearch/ElasticSearchUserTranslationTest.java
@@ -89,7 +89,7 @@ public class ElasticSearchUserTranslationTest extends ClusterTest {
         TestElasticsearchSuite.ELASTICSEARCH_USERNAME,
         TestElasticsearchSuite.ELASTICSEARCH_PASSWORD,
         null,
-        AuthMode.SHARED_USER.name(),
+        AuthMode.SHARED_USER.name(), false,
         null
     );
 
@@ -101,7 +101,7 @@ public class ElasticSearchUserTranslationTest extends ClusterTest {
         null,
         null,
         null,
-        AuthMode.USER_TRANSLATION.name(),
+        AuthMode.USER_TRANSLATION.name(), false,
         credentialsProvider);
 
     ut_config.setEnabled(true);


### PR DESCRIPTION
# [DRILL-8385](https://issues.apache.org/jira/browse/DRILL-8385): Add support for disabling SSL certificate verification in the Elasticsearch plugin

## Description
Adds a config option to the ElasticSearch plugin, `disableSSLVerification` which disables SSL verification.  Defaults to `false`.

## Documentation
See above. 

## Testing
Updated unit tests.