### PR TITLE
DRILL-8158: Remove non-reproducible entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -562,7 +562,6 @@
             <includeOnlyProperty>^git\.commit\..*$</includeOnlyProperty>
             <includeOnlyProperty>^git\.dirty$</includeOnlyProperty>
             <includeOnlyProperty>^git\.tags$</includeOnlyProperty>
-            <includeOnlyProperty>^git\.total\.commit\.count$</includeOnlyProperty>
           </includeOnlyProperties>
         </configuration>
       </plugin>


### PR DESCRIPTION
# [DRILL-8158](https://issues.apache.org/jira/browse/DRILL-8158): Remove non-reproducible entry

## Description

Remove git.total.commit.count from the git-commit-id-plugin.

## Documentation

N/A

## Testing

https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/drill/README.md