### PR TITLE
chore(deps): Update Yauaa to 7.19.2

### DIFF
--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -80,12 +80,6 @@
       <groupId>nl.basjes.parse.useragent</groupId>
       <artifactId>yauaa</artifactId>
       <version>${yauaa.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.github.ben-manes.caffeine</groupId>
-          <artifactId>caffeine</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
@@ -54,8 +54,6 @@ public class UserAgentAnalyzerProvider {
     private static final UserAgentAnalyzer INSTANCE = UserAgentAnalyzer.newBuilder()
             .dropTests()
             .hideMatcherLoadStats()
-            // Caffeine is a Java 11+ library.
-            .useJava8CompatibleCaching()
             .immediateInitialization()
             .build();
   }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
@@ -157,7 +157,7 @@ public class TestUserAgentFunctions extends ClusterTest {
   @Test
   public void testNullUserAgent() throws Exception {
     // If a null value is provided then the UserAgentAnalyzer will classify this as a Hacker because all requests normally have a User-Agent.
-    UserAgentAnalyzer analyzer = UserAgentAnalyzer.newBuilder().showMinimalVersion().withoutCache().dropTests().immediateInitialization().build();
+    UserAgentAnalyzer analyzer = UserAgentAnalyzer.newBuilder().showMinimalVersion().withoutCache().withoutClientHintsCache().dropTests().immediateInitialization().build();
     Map<String, String> expected = analyzer.parse((String)null).toMap(analyzer.getAllPossibleFieldNamesSorted());
 
     Map<String, Text> expectedRecord = new TreeMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <httpdlog-parser.version>5.8</httpdlog-parser.version>
-    <yauaa.version>7.9.0</yauaa.version>
+    <yauaa.version>7.19.2</yauaa.version>
     <log4j.version>2.19.0</log4j.version>
     <aircompressor.version>0.20</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>


### PR DESCRIPTION
Updating Yauaa to latest version + fixing a bug in the caching in a test.
See https://github.com/apache/drill/pull/2807/

@cgivre 
I did 2 things here:
- Update Yauaa and use the built in selection mechanism to the caching.
- Fix a bug in the test that still used the Client Hints caching.

Let's see what the CI build thinks of this.