### PR TITLE
DRILL-8442: Fix DeltaRowGroupScan deserialization

### DIFF
--- a/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/DeltaRowGroupScan.java
+++ b/contrib/format-deltalake/src/main/java/org/apache/drill/exec/store/delta/DeltaRowGroupScan.java
@@ -53,7 +53,7 @@ public class DeltaRowGroupScan extends AbstractParquetRowGroupScan {
   @JsonCreator
   public DeltaRowGroupScan(@JacksonInject StoragePluginRegistry registry,
     @JsonProperty("userName") String userName,
-    @JsonProperty("storage") StoragePluginConfig storageConfig,
+    @JsonProperty("storageConfig") StoragePluginConfig storageConfig,
     @JsonProperty("formatPluginConfig") FormatPluginConfig formatPluginConfig,
     @JsonProperty("rowGroupReadEntries") List<RowGroupReadEntry> rowGroupReadEntries,
     @JsonProperty("columns") List<SchemaPath> columns,
@@ -83,6 +83,11 @@ public class DeltaRowGroupScan extends AbstractParquetRowGroupScan {
     this.formatPlugin = formatPlugin;
     this.formatPluginConfig = formatPlugin.getConfig();
     this.partitions = partitions;
+  }
+
+  @JsonProperty
+  public StoragePluginConfig getStorageConfig() {
+    return formatPlugin.getStorageConfig();
   }
 
   @JsonProperty

--- a/contrib/format-deltalake/src/test/java/org/apache/drill/exec/store/delta/DeltaQueriesTest.java
+++ b/contrib/format-deltalake/src/test/java/org/apache/drill/exec/store/delta/DeltaQueriesTest.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.delta;
 
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.delta.format.DeltaFormatPluginConfig;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
@@ -61,7 +62,8 @@ public class DeltaQueriesTest extends ClusterTest {
 
   @Test
   public void testSerDe() throws Exception {
-    String plan = queryBuilder().sql("select * from dfs.`data-reader-partition-values`").explainJson();
+    client.alterSession(ExecConstants.SLICE_TARGET, 1);
+    String plan = queryBuilder().sql("select * from table(dfs.`data-reader-partition-values` (type => 'delta'))").explainJson();
     long count = queryBuilder().physical(plan).run().recordCount();
     assertEquals(3, count);
   }


### PR DESCRIPTION
# [DRILL-8442](https://issues.apache.org/jira/browse/DRILL-8442): Fix DeltaRowGroupScan deserialization

## Description

(Please describe the change. If more than one ticket is fixed, include a reference to those tickets.)

## Documentation
NA

## Testing
Updated unit test to cover the failing case.

Closes #2810
