### PR TITLE
DRILL-8449: fix typo in width property in FreeMarker templates

### DIFF
--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -91,7 +91,7 @@
   </div>
   <#include "*/alertModals.ftl">
   <div class="table-responsive">
-    <table id='optionsTbl' class="table table-striped table-condensed display sortable" style="table-layout: auto; width=100%;">
+    <table id='optionsTbl' class="table table-striped table-condensed display sortable" style="table-layout: auto; width: 100%;">
       <thead>
         <tr>
           <th style="width:30%">OPTION</th>

--- a/exec/java-exec/src/main/resources/rest/query/result.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/result.ftl
@@ -69,7 +69,7 @@
       <p class="lead">No result found.</p>
     </div>
   <#else>
-    <table id="result" class="table table-striped table-bordered table-condensed" style="table-layout: auto; width=100%; white-space: pre;">
+    <table id="result" class="table table-striped table-bordered table-condensed" style="table-layout: auto; width: 100%; white-space: pre;">
       <thead>
         <tr>
           <#list model.getColumns() as value>


### PR DESCRIPTION
# [DRILL-8449](https://issues.apache.org/jira/browse/DRILL-8449): Typo in FreeMarker templates

## Description

CSS-based properties use a colon(`:`) to assign values. The `result.ftl` and `options.ftl` have the property `width` with an equal sign(`=`) instead of a colon(`:`).

This typo makes a query result table has an incorrect display.

Steps to reproduce:
1. Execute example query: `select full_name from cp.`employee.json` limit 1`;
2. Push the "Column visibility" button, toggle "full_name" column visibility off, and turn it back on.


## Documentation
None requerid

## Testing
Visual test of UI
