### PR TITLE
DRILL-8450: Add Data Type Inference to XML Format Plugin

### DIFF
--- a/common/src/main/java/org/apache/drill/common/Typifier.java
+++ b/common/src/main/java/org/apache/drill/common/Typifier.java
@@ -18,6 +18,9 @@
 
 package org.apache.drill.common;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+
 import java.nio.CharBuffer;
 
 import java.time.LocalDate;
@@ -45,6 +48,11 @@ public class Typifier {
       DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SS", defaultLocale),
       DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm:ss a", defaultLocale),
       DateTimeFormatter.ofPattern("M/d/yy H:mm", defaultLocale),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss",  defaultLocale),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX",  defaultLocale),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX",  defaultLocale),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSVV",  defaultLocale),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssVV",  defaultLocale),
       DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss", defaultLocale)));
 
   private static final HashSet<DateTimeFormatter> dateFormats = new HashSet<>(
@@ -87,6 +95,40 @@ public class Typifier {
 
   // If a String contains any of these, try to evaluate it as an equation
   private static final char[] MathCharacters = new char[]{'+', '-', '/', '*', '='};
+
+  /**
+   * This function infers the Drill data type of unknown data.
+   * @param data The input text of unknown data type.
+   * @return A {@link MinorType} of the Drill data type.
+   */
+  public static MinorType typifyToDrill (String data) {
+    Entry<Class, String> result = Typifier.typify(data);
+    String dataType = result.getKey().getSimpleName();
+
+    // If the string is empty, return UNKNOWN
+    if (StringUtils.isEmpty(data)) {
+      return MinorType.VARCHAR;
+    } else if (dataType.equalsIgnoreCase("Float")) {
+      return MinorType.FLOAT4;
+    } else if (dataType.equalsIgnoreCase("Double")) {
+      return MinorType.FLOAT8;
+    } else if (dataType.equalsIgnoreCase("Integer")) {
+      return MinorType.INT;
+    } else if (dataType.equalsIgnoreCase("Boolean")) {
+      return MinorType.BIT;
+    } else if (dataType.equalsIgnoreCase("Long")) {
+      return MinorType.BIGINT;
+    } else if(dataType.equalsIgnoreCase("LocalDateTime")) {
+      return MinorType.TIMESTAMP;
+    } else if (dataType.equalsIgnoreCase("LocalDate")) {
+      return MinorType.DATE;
+    } else if (dataType.equalsIgnoreCase("LocalTime")) {
+      return MinorType.TIME;
+    } else {
+      return MinorType.VARCHAR;
+    }
+  }
+
 
   // default is:
   //   > don't interpret "0" and "1" as true and false

--- a/contrib/format-xml/README.md
+++ b/contrib/format-xml/README.md
@@ -15,12 +15,15 @@ The default configuration is shown below:
   "extensions": [
     "xml"
   ],
+  "allTextMode": true,
   "dataLevel": 2
 }
 ```
 
 ## Data Types
-All fields are read as strings.  Nested fields are read as maps.  Future functionality could include support for lists.
+The XML reader has an `allTextMode` which, when set to `true` reads all data fields as strings.
+When set to `false`, Drill will attempt to infer data types.
+Nested fields are read as maps.  Future functionality could include support for lists.
 
 ## Provided Schema
 The XML Format Reader supports provided inline schemas.  An example query might be:

--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLFormatConfig.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLFormatConfig.java
@@ -36,10 +36,18 @@ public class XMLFormatConfig implements FormatPluginConfig {
   public final List<String> extensions;
   public final int dataLevel;
 
+  @JsonProperty
+  public final boolean allTextMode;
+
   public XMLFormatConfig(@JsonProperty("extensions") List<String> extensions,
-                         @JsonProperty("dataLevel") int dataLevel) {
+                        @JsonProperty("dataLevel") int dataLevel,
+                        @JsonProperty("allTextMode") Boolean allTextMode
+      ) {
     this.extensions = extensions == null ? Collections.singletonList("xml") : ImmutableList.copyOf(extensions);
     this.dataLevel = Math.max(dataLevel, 1);
+
+    // Default to true
+    this.allTextMode = allTextMode == null || allTextMode;
   }
 
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -47,9 +55,14 @@ public class XMLFormatConfig implements FormatPluginConfig {
     return extensions;
   }
 
+  @JsonProperty("allTextMode")
+  public boolean allTextMode() {
+    return allTextMode;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(extensions, dataLevel);
+    return Objects.hash(extensions, dataLevel, allTextMode);
   }
 
   public XMLBatchReader.XMLReaderConfig getReaderConfig(XMLFormatPlugin plugin) {
@@ -66,14 +79,16 @@ public class XMLFormatConfig implements FormatPluginConfig {
     }
     XMLFormatConfig other = (XMLFormatConfig) obj;
     return Objects.equals(extensions, other.extensions)
-      && Objects.equals(dataLevel, other.dataLevel);
+        && Objects.equals(dataLevel, other.dataLevel)
+        && Objects.equals(allTextMode, other.allTextMode);
   }
 
   @Override
   public String toString() {
     return new PlanStringBuilder(this)
-      .field("extensions", extensions)
-      .field("dataLevel", dataLevel)
+        .field("extensions", extensions)
+        .field("dataLevel", dataLevel)
+        .field("allTextMode", allTextMode)
       .toString();
   }
 }

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -88,7 +88,10 @@ public class TestXMLReader extends ClusterTest {
 
   @Test
   public void testAllTextMode() throws Exception {
-    String sql = "SELECT * FROM table(cp.`xml/simple_with_datatypes.xml` (type => 'xml', " +
+    String sql = "SELECT attributes, int_field, bigint_field, float_field, double_field, " +
+        "boolean_field, date_field, time_field, timestamp_field, string_field" +
+        " FROM table(cp.`xml/simple_with_datatypes" +
+        ".xml` (type => 'xml', " +
         "allTextMode => 'false'))";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
     assertEquals(2, results.rowCount());
@@ -101,7 +104,6 @@ public class TestXMLReader extends ClusterTest {
         .addNullable("double_field", MinorType.FLOAT8)
         .addNullable("boolean_field", MinorType.BIT)
         .addNullable("date_field", MinorType.DATE)
-        .addNullable("date2_field", MinorType.DATE)
         .addNullable("time_field", MinorType.VARCHAR)
         .addNullable("timestamp_field", MinorType.TIMESTAMP)
         .addNullable("string_field", MinorType.VARCHAR)
@@ -111,11 +113,10 @@ public class TestXMLReader extends ClusterTest {
 
     RowSet expected = client.rowSetBuilder(expectedSchema)
         .addRow(mapArray(),  1.0, 1000.0, 1.3, 3.3, true, LocalDate.parse("2022-01-01"),
-                    LocalDate.parse("2022-03-02"), "12:04:34", Instant.parse("2022-01-06T12:30" +
+            "12:04:34", Instant.parse("2022-01-06T12:30" +
                 ":30Z"),
             "string")
         .addRow(mapArray(), 2.0, 2000.0, 2.3, 4.3, false, LocalDate.parse("2022-02-01"),
-            LocalDate.parse("2022-03-01"),
             "13:04:34", Instant.parse("2022-03-06T12:30:30Z"), null)
         .build();
 

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -106,7 +106,7 @@ public class TestXMLReader extends ClusterTest {
         .addNullable("timestamp_field", MinorType.TIMESTAMP)
         .addNullable("string_field", MinorType.VARCHAR)
         .buildSchema();
-    
+
     RowSet expected = client.rowSetBuilder(expectedSchema)
         .addRow(mapArray(),  1.0, 1000.0, 1.3, 3.3, true, LocalDate.parse("2022-01-01"),
                     LocalDate.parse("2022-02-03"), "12:04:34", Instant.parse("2022-01-06T12:30" +

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -107,13 +107,15 @@ public class TestXMLReader extends ClusterTest {
         .addNullable("string_field", MinorType.VARCHAR)
         .buildSchema();
 
+    //DateUtility.parseLocalDateTime
+
     RowSet expected = client.rowSetBuilder(expectedSchema)
         .addRow(mapArray(),  1.0, 1000.0, 1.3, 3.3, true, LocalDate.parse("2022-01-01"),
-                    LocalDate.parse("2022-02-03"), "12:04:34", Instant.parse("2022-01-06T12:30" +
+                    LocalDate.parse("2022-03-02"), "12:04:34", Instant.parse("2022-01-06T12:30" +
                 ":30Z"),
             "string")
         .addRow(mapArray(), 2.0, 2000.0, 2.3, 4.3, false, LocalDate.parse("2022-02-01"),
-            LocalDate.parse("2022-01-03"),
+            LocalDate.parse("2022-03-01"),
             "13:04:34", Instant.parse("2022-03-06T12:30:30Z"), null)
         .build();
 
@@ -139,13 +141,17 @@ public class TestXMLReader extends ClusterTest {
       .addNullable("time_field", MinorType.TIME)
       .addNullable("timestamp_field", MinorType.TIMESTAMP)
       .addNullable("string_field", MinorType.VARCHAR)
-      .addNullable("date2_field", MinorType.DATE)
+        .addNullable("date2_field", MinorType.DATE)
       .add("attributes", MinorType.MAP)
       .buildSchema();
 
     RowSet expected = client.rowSetBuilder(expectedSchema)
-      .addRow(1, 1000L, 1.2999999523162842, 3.3, true, LocalDate.parse("2022-01-01"), LocalTime.parse("12:04:34"), Instant.parse("2022-01-06T12:30:30Z"), "string", LocalDate.parse("2022-03-02"), mapArray())
-      .addRow(2, 2000L, 2.299999952316284, 4.3, false, LocalDate.parse("2022-02-01"), LocalTime.parse("13:04:34"), Instant.parse("2022-03-06T12:30:30Z"), null, LocalDate.parse("2022-03-01"), mapArray())
+      .addRow(1, 1000L, 1.2999999523162842, 3.3, true, LocalDate.parse("2022-01-01"),
+          LocalTime.parse("12:04:34"), Instant.parse("2022-01-06T12:30:30Z"), "string",
+          LocalDate.parse("2022-03-02"), mapArray())
+      .addRow(2, 2000L, 2.299999952316284, 4.3, false, LocalDate.parse("2022-02-01"),
+          LocalTime.parse("13:04:34"), Instant.parse("2022-03-06T12:30:30Z"), null,
+          LocalDate.parse("2022-03-01"), mapArray())
       .build();
 
     new RowSetComparison(expected).verifyAndClearAll(results);

--- a/contrib/storage-http/XML_Options.md
+++ b/contrib/storage-http/XML_Options.md
@@ -5,6 +5,11 @@ Drill has a several XML configuration options to allow you to configure how Dril
 XML data often contains a considerable amount of nesting which is not necessarily useful for data analysis. This parameter allows you to set the nesting level
   where the data actually starts.  The levels start at `1`.
 
+## AllTextMode
+Drill's XML reader can infer data types.  Similar to the JSON reader, there is an option called
+`allTextMode` which can be set to `true` to disable data type inference.  This is useful if your
+data has inconsistent schema.
+
 ## Schema Provisioning
 One of the challenges of querying APIs is inconsistent data.  Drill allows you to provide a schema for individual endpoints.  You can do this in one of three ways:
 
@@ -26,6 +31,7 @@ Or,
 ```json
 "xmlOptions": {
   "dataLevel": 2,
+  "allTextMode": true,
   "schema": {
     "type": "tuple_schema",
       "columns": [

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
@@ -47,6 +47,7 @@ public class HttpXMLBatchReader extends HttpBatchReader {
   private final HttpSubScan subScan;
   private final int maxRecords;
   private final int dataLevel;
+  private final boolean allTextMode;
   private InputStream inStream;
   private XMLReader xmlReader;
   private ResultSetLoader resultLoader;
@@ -55,12 +56,17 @@ public class HttpXMLBatchReader extends HttpBatchReader {
     super(subScan);
     this.subScan = subScan;
     this.maxRecords = subScan.maxRecords();
-
     // TODO Remove the XMLDataLevel parameter.  For now, check both
     if (subScan.tableSpec().connectionConfig().xmlOptions() == null) {
       this.dataLevel = subScan.tableSpec().connectionConfig().xmlDataLevel();
     } else {
       this.dataLevel = subScan.tableSpec().connectionConfig().xmlOptions().getDataLevel();
+    }
+
+    if (subScan.tableSpec().connectionConfig().xmlOptions() != null) {
+      this.allTextMode = subScan.tableSpec().connectionConfig().xmlOptions().allTextMode();
+    } else {
+      this.allTextMode = true;
     }
   }
 
@@ -74,6 +80,12 @@ public class HttpXMLBatchReader extends HttpBatchReader {
       this.dataLevel = subScan.tableSpec().connectionConfig().xmlDataLevel();
     } else {
       this.dataLevel = subScan.tableSpec().connectionConfig().xmlOptions().getDataLevel();
+    }
+
+    if (subScan.tableSpec().connectionConfig().xmlOptions() != null) {
+      this.allTextMode = subScan.tableSpec().connectionConfig().xmlOptions().allTextMode();
+    } else {
+      this.allTextMode = true;
     }
   }
 
@@ -115,8 +127,7 @@ public class HttpXMLBatchReader extends HttpBatchReader {
         negotiator.tableSchema(finalSchema, false);
       }
 
-      // TODO Add the all text mode.
-      xmlReader = new XMLReader(inStream, dataLevel, false);
+      xmlReader = new XMLReader(inStream, dataLevel, allTextMode);
       resultLoader = negotiator.build();
 
       if (implicitColumnsAreProjected()) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
@@ -115,7 +115,8 @@ public class HttpXMLBatchReader extends HttpBatchReader {
         negotiator.tableSchema(finalSchema, false);
       }
 
-      xmlReader = new XMLReader(inStream, dataLevel);
+      // TODO Add the all text mode.
+      xmlReader = new XMLReader(inStream, dataLevel, false);
       resultLoader = negotiator.build();
 
       if (implicitColumnsAreProjected()) {

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXmlOptions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXmlOptions.java
@@ -35,14 +35,17 @@ public class HttpXmlOptions {
 
   @JsonProperty
   private final int dataLevel;
-
+  @JsonProperty
+  private final boolean allTextMode;
   @JsonProperty
   private final TupleMetadata schema;
 
   @JsonCreator
   public HttpXmlOptions(@JsonProperty("dataLevel") Integer dataLevel,
+                        @JsonProperty("allTextMode") Boolean allTextMode,
                         @JsonProperty("schema") TupleMetadata schema) {
     this.schema = schema;
+    this.allTextMode = allTextMode == null || allTextMode;
     if (dataLevel == null || dataLevel < 1) {
       this.dataLevel = 1;
     } else {
@@ -53,6 +56,7 @@ public class HttpXmlOptions {
   public HttpXmlOptions(HttpXmlOptionsBuilder builder) {
     this.dataLevel = builder.dataLevel;
     this.schema = builder.schema;
+    this.allTextMode = builder.allTextMode;
   }
 
 
@@ -70,6 +74,10 @@ public class HttpXmlOptions {
     return this.schema;
   }
 
+  @JsonProperty("allTextMode")
+  public boolean allTextMode() {
+    return this.allTextMode;
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -81,18 +89,20 @@ public class HttpXmlOptions {
     }
     HttpXmlOptions that = (HttpXmlOptions) o;
     return Objects.equals(dataLevel, that.dataLevel)
-      && Objects.equals(schema, that.schema);
+        && Objects.equals(allTextMode, that.allTextMode)
+        && Objects.equals(schema, that.schema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(dataLevel, schema);
+    return Objects.hash(dataLevel, schema, allTextMode);
   }
 
   @Override
   public String toString() {
     return new PlanStringBuilder(this)
       .field("dataLevel", dataLevel)
+        .field("allTextMode", allTextMode)
       .field("schema", schema)
       .toString();
   }
@@ -101,10 +111,16 @@ public class HttpXmlOptions {
   public static class HttpXmlOptionsBuilder {
 
     private int dataLevel;
+    private boolean allTextMode;
     private TupleMetadata schema;
 
     public HttpXmlOptions.HttpXmlOptionsBuilder dataLevel(int dataLevel) {
       this.dataLevel = dataLevel;
+      return this;
+    }
+
+    public HttpXmlOptions.HttpXmlOptionsBuilder allTextMode(boolean allTextMode) {
+      this.allTextMode = allTextMode;
       return this;
     }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXmlOptions.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXmlOptions.java
@@ -56,7 +56,7 @@ public class HttpXmlOptions {
   public HttpXmlOptions(HttpXmlOptionsBuilder builder) {
     this.dataLevel = builder.dataLevel;
     this.schema = builder.schema;
-    this.allTextMode = builder.allTextMode;
+    this.allTextMode = builder.allTextMode == null || builder.allTextMode;
   }
 
 
@@ -111,7 +111,7 @@ public class HttpXmlOptions {
   public static class HttpXmlOptionsBuilder {
 
     private int dataLevel;
-    private boolean allTextMode;
+    private Boolean allTextMode;
     private TupleMetadata schema;
 
     public HttpXmlOptions.HttpXmlOptionsBuilder dataLevel(int dataLevel) {

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -135,6 +135,7 @@ public class TestHttpPlugin extends ClusterTest {
 
     HttpXmlOptions nycXmlOptions = HttpXmlOptions.builder()
       .dataLevel(5)
+        .allTextMode(true)
       .build();
 
     HttpApiConfig nycConfig = HttpApiConfig.builder()
@@ -305,6 +306,7 @@ public class TestHttpPlugin extends ClusterTest {
 
     HttpXmlOptions xmlOptions = new HttpXmlOptions.HttpXmlOptionsBuilder()
       .dataLevel(2)
+        .allTextMode(true)
       .build();
 
     TupleMetadata testSchema = new SchemaBuilder()
@@ -319,6 +321,7 @@ public class TestHttpPlugin extends ClusterTest {
 
     HttpXmlOptions xmlOptionsWithSchhema = new HttpXmlOptions.HttpXmlOptionsBuilder()
       .dataLevel(2)
+        .allTextMode(true)
       .schema(testSchema)
       .build();
 
@@ -448,6 +451,7 @@ public class TestHttpPlugin extends ClusterTest {
 
     HttpXmlOptions nycXmlOptions = HttpXmlOptions.builder()
         .dataLevel(5)
+        .allTextMode(true)
         .build();
 
     HttpApiConfig nycConfig = HttpApiConfig.builder()
@@ -618,6 +622,7 @@ public class TestHttpPlugin extends ClusterTest {
 
     HttpXmlOptions xmlOptions = new HttpXmlOptions.HttpXmlOptionsBuilder()
         .dataLevel(2)
+        .allTextMode(true)
         .build();
 
     TupleMetadata testSchema = new SchemaBuilder()


### PR DESCRIPTION
# [DRILL-8450](https://issues.apache.org/jira/browse/DRILL-8450): Add Data Type Inference to XML Format Plugin

## Description

This PR adds data type inference to the XML format plugin.  In similar fashion to other plugins, it adds a new configuration parameter: `allTextMode`, which when set to `true`, reads all data as strings.  The default is `true`.
Note that the inference is limited to doubles, date, timestamps, boolean and strings.

## Documentation
Updated README

## Testing
Added unit test.