### PR TITLE
DRILL-8436: Upgrade Hadoop 3.2.4 → 3.3.6

### DIFF
--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -103,6 +103,10 @@
           <groupId>org.apache.hadoop</groupId>
         </exclusion>
         <exclusion>
+          <artifactId>hadoop-hdfs-client</artifactId>
+          <groupId>org.apache.hadoop</groupId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -290,14 +290,6 @@
           <artifactId>jackson-xc</artifactId>
         </exclusion>
         <exclusion>
-          <artifactId>netty-all</artifactId>
-          <groupId>io.netty</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>netty</artifactId>
-          <groupId>io.netty</groupId>
-        </exclusion>
-        <exclusion>
           <groupId>com.zaxxer</groupId>
           <artifactId>HikariCP-java7</artifactId>
         </exclusion>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <phoenix.version>5.1.3</phoenix.version>
-    <!-- Keep the 2.4.2 to reduce dependency conflict -->
+    <!-- Limit the HBase minicluster version to 2.4.x to avoid a dependency conflict. -->
     <hbase.minicluster.version>2.4.17</hbase.minicluster.version>
     <skipTests>false</skipTests>
   </properties>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -29,9 +29,9 @@
   <name>Drill : Contrib : Storage : Phoenix</name>
 
   <properties>
-    <phoenix.version>5.1.2</phoenix.version>
+    <phoenix.version>5.1.3</phoenix.version>
     <!-- Keep the 2.4.2 to reduce dependency conflict -->
-    <hbase.minicluster.version>2.4.2</hbase.minicluster.version>
+    <hbase.minicluster.version>2.4.17</hbase.minicluster.version>
     <skipTests>false</skipTests>
   </properties>
 
@@ -389,7 +389,7 @@
           <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
-            <version>5.1.4</version>
+            <version>5.1.9</version>
             <extensions>true</extensions>
           </plugin>
         </plugins>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -501,32 +501,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-server</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-json</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.reload4j</groupId>
-          <artifactId>reload4j</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -173,12 +173,6 @@
           <artifactId>jetty-http</artifactId>
           <groupId>org.eclipse.jetty</groupId>
         </exclusion>
-        <!--
-        <exclusion>
-          <artifactId>jetty-util</artifactId>
-          <groupId>org.eclipse.jetty</groupId>
-        </exclusion>
-        -->
         <exclusion>
           <artifactId>javax.servlet-api</artifactId>
           <groupId>javax.servlet</groupId>
@@ -447,12 +441,6 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-security</artifactId>
         </exclusion>
-        <!--
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-util</artifactId>
-        </exclusion>
-        -->
       </exclusions>
     </dependency>
     <dependency>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -173,10 +173,12 @@
           <artifactId>jetty-http</artifactId>
           <groupId>org.eclipse.jetty</groupId>
         </exclusion>
+        <!--
         <exclusion>
           <artifactId>jetty-util</artifactId>
           <groupId>org.eclipse.jetty</groupId>
         </exclusion>
+        -->
         <exclusion>
           <artifactId>javax.servlet-api</artifactId>
           <groupId>javax.servlet</groupId>
@@ -445,10 +447,12 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-security</artifactId>
         </exclusion>
+        <!--
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-util</artifactId>
         </exclusion>
+        -->
       </exclusions>
     </dependency>
     <dependency>
@@ -573,6 +577,12 @@
       <artifactId>netty-tcnative</artifactId>
       <classifier>${netty.tcnative.classifier}</classifier>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -111,10 +111,6 @@
           <artifactId>jersey-server</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-json</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.glassfish.jersey.core</groupId>
           <artifactId>jersey-common</artifactId>
         </exclusion>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -103,6 +103,18 @@
           <artifactId>commons-codec</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.glassfish.jersey.core</groupId>
           <artifactId>jersey-common</artifactId>
         </exclusion>
@@ -388,51 +400,52 @@
               <include>*:*</include>
             </includes>
             <excludes>
-              <exclude>io.protostuff:*</exclude>
-              <exclude>org.pentaho:*</exclude>
-              <exclude>org.msgpack:*</exclude>
-              <exclude>xerces:*</exclude>
-              <exclude>xalan:*</exclude>
-              <exclude>org.apache.avro:*</exclude>
-              <exclude>org.mongodb:*</exclude>
-              <exclude>com.googlecode.json-simple:*</exclude>
-              <exclude>dom4j:*</exclude>
-              <exclude>org.hibernate:*</exclude>
               <exclude>antlr:*</exclude>
+              <exclude>com.beust:*</exclude>
               <exclude>com.dropbox.*</exclude>
               <exclude>com.github.stefanbirkner</exclude>
-              <exclude>org.ow2.asm:*</exclude>
-              <exclude>com.univocity:*</exclude>
-              <exclude>com.twitter:*</exclude>
-              <exclude>org.apache.parquet:*</exclude>
-              <exclude>javax.inject:*</exclude>
-              <exclude>com.beust:*</exclude>
-              <exclude>jline:*</exclude>
-              <exclude>org.xerial.snappy:*</exclude>
-              <exclude>org.apache.avro:*</exclude>
-              <exclude>org.tukaani:*</exclude>
-              <exclude>org.apache.velocity:*</exclude>
-              <exclude>net.hydromatic:linq4j</exclude>
-              <exclude>org.eclipse.jetty:*</exclude>
-              <exclude>org.slf4j:jul-to-slf4j</exclude>
-              <exclude>org.hamcrest:hamcrest-core</exclude>
-              <exclude>org.mockito:mockito-core</exclude>
-              <exclude>org.objenesis:objenesis</exclude>
-              <exclude>org.eclipse.jetty:*</exclude>
-              <exclude>javax.xml.bind:jaxb-api</exclude>
-              <exclude>javax.xml.stream:stax-api</exclude>
-              <exclude>javax.activation:activation</exclude>
-              <exclude>commons-cli:commons-cli</exclude>
-              <exclude>org.apache.commons:commons-collections4</exclude>
-              <exclude>commons-io:commons-io</exclude>
+              <exclude>com.google.code.findbugs:jsr305:*</exclude>
+              <exclude>com.googlecode.json-simple:*</exclude>
               <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
-              <exclude>com.google.code.findbugs:jsr305:*</exclude>
-              <exclude>dnsjava:dnsjava:jar:*</exclude>
-              <exclude>io.netty:netty-tcnative:jar:*</exclude>
-              <exclude>io.netty:netty-tcnative-classes:jar:*</exclude>
+              <exclude>commons-cli:commons-cli</exclude>
+              <exclude>commons-io:commons-io</exclude>
               <exclude>com.nimbusds:*</exclude>
+              <exclude>com.twitter:*</exclude>
+              <exclude>com.univocity:*</exclude>
+              <exclude>dnsjava:dnsjava:jar:*</exclude>
+              <exclude>dom4j:*</exclude>
+              <exclude>io.netty:netty-tcnative-classes:jar:*</exclude>
+              <exclude>io.netty:netty-tcnative:jar:*</exclude>
+              <exclude>io.protostuff:*</exclude>
+              <exclude>javax.activation:activation</exclude>
+              <exclude>javax.inject:*</exclude>
+              <exclude>javax.xml.bind:jaxb-api</exclude>
+              <exclude>javax.xml.stream:stax-api</exclude>
+              <exclude>jline:*</exclude>
+              <exclude>net.hydromatic:linq4j</exclude>
+              <exclude>org.apache.avro:*</exclude>
+              <exclude>org.apache.avro:*</exclude>
+              <exclude>org.apache.commons:commons-collections4</exclude>
+              <exclude>org.apache.hadoop:hadoop-yarn-client</exclude>
+              <exclude>org.apache.parquet:*</exclude>
+              <exclude>org.apache.velocity:*</exclude>
               <exclude>org.apache.yetus:*</exclude>
+              <exclude>org.eclipse.jetty:*</exclude>
+              <exclude>org.eclipse.jetty.websocket:*</exclude>
+              <exclude>org.hamcrest:hamcrest-core</exclude>
+              <exclude>org.hibernate:*</exclude>
+              <exclude>org.mockito:mockito-core</exclude>
+              <exclude>org.mongodb:*</exclude>
+              <exclude>org.msgpack:*</exclude>
+              <exclude>org.objenesis:objenesis</exclude>
+              <exclude>org.ow2.asm:*</exclude>
+              <exclude>org.pentaho:*</exclude>
+              <exclude>org.slf4j:jul-to-slf4j</exclude>
+              <exclude>org.tukaani:*</exclude>
+              <exclude>org.xerial.snappy:*</exclude>
+              <exclude>xalan:*</exclude>
+              <exclude>xerces:*</exclude>
             </excludes>
           </artifactSet>
           <relocations>
@@ -679,65 +692,65 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>**/logback.xml</exclude>
-                <exclude>**/LICENSE.txt</exclude>
-                <exclude>**/*.java</exclude>
-                <exclude>META-INF/ASL2.0</exclude>
-                <exclude>META-INF/NOTICE.txt</exclude>
-                <exclude>META-INF/drill-module-scan/**</exclude>
-                <exclude>META-INF/jboss-beans.xml</exclude>
-                <exclude>META-INF/license/**</exclude>
-                <exclude>META-INF/maven/**</exclude>
-                <exclude>META-INF/native/**</exclude>
-                <exclude>META-INF/services/com.fasterxml.*</exclude>
-                <exclude>META-INF/services/javax.ws.*</exclude>
-                <exclude>META-INF/**/*.properties</exclude>
-                <exclude>**/org.codehaus.commons.compiler.properties</exclude>
-                <exclude>module-info.class</exclude>
-                <exclude>**/*.SF</exclude>
-                <exclude>**/*.RSA</exclude>
-                <exclude>**/*.DSA</exclude>
-                <exclude>javax/*</exclude>
-                <exclude>javax/activation/**</exclude>
-                <exclude>javax/annotation-api/**</exclude>
-                <exclude>javax/inject/**</exclude>
-                <exclude>javax/servlet-api/**</exclude>
-                <exclude>javax/json/**</exclude>
-                <exclude>javax/ws/**</exclude>
-                <exclude>rest/**</exclude>
-                <exclude>*.tokens</exclude>
-                <exclude>codegen/**</exclude>
                 <exclude>bootstrap-storage-plugins.json</exclude>
-                <exclude>org/apache/parquet</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/escape/**</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/eventbus/**</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/html/**</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/net/**</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/xml/**</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/io/BaseEncoding*</exclude>
-                <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                <exclude>codegen/**</exclude>
+                <exclude>com/google/common/cache</exclude>
+                <exclude>com/google/common/collect/Standard*</exclude>
+                <exclude>com/google/common/collect/Tree*</exclude>
                 <exclude>com/google/common/math</exclude>
                 <exclude>com/google/common/net</exclude>
                 <exclude>com/google/common/primitives</exclude>
                 <exclude>com/google/common/reflect</exclude>
                 <exclude>com/google/common/util</exclude>
-                <exclude>com/google/common/cache</exclude>
-                <exclude>com/google/common/collect/Tree*</exclude>
-                <exclude>com/google/common/collect/Standard*</exclude>
+                <exclude>com/jcraft/**</exclude>
+                <exclude>**/*.DSA</exclude>
+                <exclude>hello/**</exclude>
+                <exclude>**/*.java</exclude>
+                <exclude>javax/activation/**</exclude>
+                <exclude>javax/annotation-api/**</exclude>
+                <exclude>javax/*</exclude>
+                <exclude>javax/inject/**</exclude>
+                <exclude>javax/json/**</exclude>
+                <exclude>javax/servlet/**</exclude>
+                <exclude>javax/ws/**</exclude>
+                <exclude>**/LICENSE.txt</exclude>
+                <exclude>**/logback.xml</exclude>
+                <exclude>**/mapr/**</exclude>
+                <exclude>META-INF/ASL2.0</exclude>
+                <exclude>META-INF/drill-module-scan/**</exclude>
+                <exclude>META-INF/jboss-beans.xml</exclude>
+                <exclude>META-INF/license/**</exclude>
+                <exclude>META-INF/maven/**</exclude>
+                <exclude>META-INF/native/**</exclude>
+                <exclude>META-INF/NOTICE.txt</exclude>
+                <exclude>META-INF/**/*.properties</exclude>
+                <exclude>META-INF/services/com.fasterxml.*</exclude>
+                <exclude>META-INF/services/javax.ws.*</exclude>
+                <exclude>module-info.class</exclude>
+                <exclude>org/apache/commons/pool2/**</exclude>
+                <exclude>org/apache/directory/**</exclude>
+                <exclude>org/apache/drill/exec/compile/**</exclude>
                 <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
                 <exclude>org/apache/drill/exec/expr/fn/**</exclude>
-                <exclude>org/apache/drill/exec/proto/beans/**</exclude>
-                <exclude>org/apache/drill/exec/compile/**</exclude>
-                <exclude>org/apache/drill/exec/planner/**</exclude>
                 <exclude>org/apache/drill/exec/physical/**</exclude>
-                <exclude>org/apache/drill/exec/store/**</exclude>
-                <exclude>org/apache/drill/exec/server/rest/**</exclude>
-                <exclude>org/apache/drill/exec/rpc/data/**</exclude>
+                <exclude>org/apache/drill/exec/planner/**</exclude>
+                <exclude>org/apache/drill/exec/proto/beans/**</exclude>
                 <exclude>org/apache/drill/exec/rpc/control/**</exclude>
+                <exclude>org/apache/drill/exec/rpc/data/**</exclude>
+                <exclude>org/apache/drill/exec/server/rest/**</exclude>
+                <exclude>org/apache/drill/exec/store/**</exclude>
                 <exclude>org/apache/drill/exec/work/**</exclude>
+                <exclude>org/apache/drill/metastore/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/escape/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/eventbus/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/html/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/io/BaseEncoding*</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/net/**</exclude>
+                <exclude>org/apache/drill/shaded/guava/com/google/common/xml/**</exclude>
                 <exclude>org/apache/hadoop/crypto/**</exclude>
                 <exclude>org/apache/hadoop/ha/**</exclude>
                 <exclude>org/apache/hadoop/http/**</exclude>
@@ -745,20 +758,19 @@
                 <exclude>org/apache/hadoop/jmx/**</exclude>
                 <exclude>org/apache/hadoop/log/**</exclude>
                 <exclude>org/apache/hadoop/metrics/**</exclude>
-                <exclude>org/apache/hadoop/net/**</exclude>
                 <exclude>org/apache/hadoop/record/**</exclude>
                 <exclude>org/apache/hadoop/service/**</exclude>
-                <exclude>org/apache/hadoop/tracing/**</exclude>
                 <exclude>org/apache/hadoop/tools/**</exclude>
+                <exclude>org/apache/hadoop/tracing/**</exclude>
                 <exclude>org/apache/hadoop/yarn/**</exclude>
-                <exclude>org/apache/commons/pool2/**</exclude>
                 <exclude>org/apache/http/**</exclude>
-                <exclude>org/apache/directory/**</exclude>
-                <exclude>org/apache/drill/metastore/**</exclude>
-                <exclude>com/jcraft/**</exclude>
-                <exclude>**/mapr/**</exclude>
+                <exclude>org/apache/parquet</exclude>
+                <exclude>**/org.codehaus.commons.compiler.properties</exclude>
                 <exclude>org/yaml/**</exclude>
-                <exclude>hello/**</exclude>
+                <exclude>rest/**</exclude>
+                <exclude>**/*.RSA</exclude>
+                <exclude>**/*.SF</exclude>
+                <exclude>*.tokens</exclude>
                 <exclude>webapps/**</exclude>
               </excludes>
             </filter>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -343,7 +343,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <goals>

--- a/exec/jdbc-all/src/main/resources/core-site.xml
+++ b/exec/jdbc-all/src/main/resources/core-site.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+<!--
+This file is bundled with the Drill JDBC driver in order to accommodate the
+relocation of org.apache.hadoop to oadd.org.apache.hadoop that is specified
+in exec/jdbc-all/pom.xml. The fully qualified class names in core-default.xml
+in hadoop-common.jar are not updated by the Maven shade plugin so we override
+them here.
+-->
+<property>
+  <name>hadoop.security.group.mapping</name>
+  <value>oadd.org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback</value>
+</property>
+
+<property>
+  <name>hadoop.security.resolver.impl</name>
+  <value>oadd.org.apache.hadoop.net.DNSDomainNameResolver</value>
+</property>
+</configuration>

--- a/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
+++ b/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
@@ -45,6 +45,9 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+// Note: this test cannot be run under surefire (or in IDEs). Execute
+// `mvn integration-test` in this module's directory to run it locally. See the
+// maven-failsafe-plugin config in this module's pom.xml for more information.
 public class ITTestShadedJar extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ITTestShadedJar.class);
 

--- a/exec/jdbc-all/src/test/resources/core-site.xml
+++ b/exec/jdbc-all/src/test/resources/core-site.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+<!--
+Reverts the relocated class names in src/main/resources/core-site.xml for the
+ITTestShadedJar.java test.
+-->
+<property>
+  <name>hadoop.security.group.mapping</name>
+  <value>org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback</value>
+</property>
+
+<property>
+  <name>hadoop.security.resolver.impl</name>
+  <value>org.apache.hadoop.net.DNSDomainNameResolver</value>
+</property>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
       for example parquet-hadoop-bundle and derby dependencies.
     -->
     <hive.version>3.1.3</hive.version>
-    <hadoop.version>3.2.4</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <hbase.version>2.5.5-hadoop3</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.30</freemarker.version>
@@ -1443,16 +1443,8 @@
             <groupId>org.slf4j</groupId>
           </exclusion>
           <exclusion>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.google.protobuf</groupId>
@@ -2555,6 +2547,10 @@
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP-java7</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.jline</groupId>
+                <artifactId>jline</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -2610,6 +2606,10 @@
               <exclusion>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.jline</groupId>
+                <artifactId>jline</artifactId>
               </exclusion>
             </exclusions>
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2162,12 +2162,16 @@
                 <artifactId>jersey-server</artifactId>
               </exclusion>
               <exclusion>
-                <groupId>com.sun.jersey</groupId>
+                <groupId>com.github.pjfanning</groupId>
                 <artifactId>jersey-json</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>com.sun.jersey</groupId>
                 <artifactId>jersey-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-servlet</artifactId>
               </exclusion>
               <exclusion>
                 <artifactId>core</artifactId>
@@ -2329,7 +2333,7 @@
                 <artifactId>jersey-server</artifactId>
               </exclusion>
               <exclusion>
-                <groupId>com.sun.jersey</groupId>
+                <groupId>com.github.pjfanning</groupId>
                 <artifactId>jersey-json</artifactId>
               </exclusion>
               <exclusion>
@@ -2412,8 +2416,20 @@
             <classifier>tests</classifier>
             <exclusions>
               <exclusion>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+              </exclusion>
+              <exclusion>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-core</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>org.eclipse.jetty</groupId>
@@ -2430,10 +2446,6 @@
               <exclusion>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-core</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>org.codehaus.jackson</groupId>
@@ -2516,7 +2528,7 @@
                 <artifactId>jersey-server</artifactId>
               </exclusion>
               <exclusion>
-                <groupId>com.sun.jersey</groupId>
+                <groupId>com.github.pjfanning</groupId>
                 <artifactId>jersey-json</artifactId>
               </exclusion>
               <exclusion>
@@ -2568,7 +2580,7 @@
                 <artifactId>jersey-server</artifactId>
               </exclusion>
               <exclusion>
-                <groupId>com.sun.jersey</groupId>
+                <groupId>com.github.pjfanning</groupId>
                 <artifactId>jersey-json</artifactId>
               </exclusion>
               <exclusion>
@@ -4283,8 +4295,24 @@
             <scope>test</scope>
             <exclusions>
               <exclusion>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+              </exclusion>
+              <exclusion>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-core</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-server</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-json</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
# [DRILL-8436](https://issues.apache.org/jira/browse/DRILL-8436): Upgrade Hadoop 3.2.4 → 3.3.6

## Description

Hadoop is upgraded to 3.3.6.

## Documentation

N/A

## Testing

Existing unit tests, manual testing of Drill HTTP services. Manual testing Drill JDBC driver.

Rebased onto #2823.