### PR TITLE
[MINOR UPDATE]: Fix Hadoop 3 impersonation test errors during CI runs

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/BaseTestImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/BaseTestImpersonation.java
@@ -103,6 +103,13 @@ public class BaseTestImpersonation extends ClusterTest {
       // Set the proxyuser settings so that the user who is running the Drillbits/MiniDfs can impersonate other users.
       dfsConf.set(String.format("hadoop.proxyuser.%s.hosts", processUser), "*");
       dfsConf.set(String.format("hadoop.proxyuser.%s.groups", processUser), "*");
+
+      // It isn't clear exactly when or why the following reinitialisation is
+      // needed, but without it the test subclasses of this class may crash
+      // when run in the GitHub CI with Mini DFS stating "Running in secure
+      // mode, but config doesn't have a keytab".
+      dfsConf.set("hadoop.security.authentication", "simple");
+      UserGroupInformation.setConfiguration(dfsConf);
     }
 
     // Start the MiniDfs cluster

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonation.java
@@ -92,6 +92,8 @@ public class TestInboundImpersonation extends BaseTestImpersonation {
             .go();
       }
       adminClient.resetSystem(ExecConstants.IMPERSONATION_POLICIES_KEY);
+    } finally {
+      stopMiniDfsCluster();
     }
   }
 


### PR DESCRIPTION
# [MINOR UPDATE]: Fix Hadoop 3 impersonation test errors during CI runs

## Description

The following changes are made to resolve the "IO Running in secure mode, but config doesn't have a keytab" errors currently plaguing the Hadoop 3 impersonation tests when (and only when) they run in the GitHub CI [1]. 

- Ensure that MiniDFS is using simple auth in BaseTestImpersonation.
- Shut down MiniDFS cluster in TestInboundImpersonation.selectChainedView

These changes are sufficient to fix what I believe is a racy test harness set up / clean up bug that at this time only presents itself in the GitHub CI, and even then only with recent GitHub Runner images.

1. Example: https://github.com/apache/drill/actions/runs/5867741986/job/15909061405

## Documentation
N/A

## Testing
CI runs.
