### PR TITLE
[MINOR UPDATE]: Improve the Github CI memory constraint workarounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,18 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
+      - name: Set up swap space
+        # Linux Action Runners come with 7GB of RAM which isn't quite enoough
+        # to run the test suite. Two workarounds are used below: a swap file is
+        # added to the Runner and memory hungry tests are run separately.
+        run: |
+          sudo sh -c "
+            fallocate -l 2G /tmp/swapfile
+            chmod 0600 /tmp/swapfile
+            mkswap /tmp/swapfile
+            swapon /tmp/swapfile
+          "
       - name: Build and test
-        # The total GitHub Actions memory is 7000Mb. But GitHub CI requires some memory for the container to perform tests
         run: |
           MAVEN_OPTS="-XX:+UseG1GC"
           sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
@@ -62,6 +72,9 @@ jobs:
           mvn -P${{ matrix.profile }} test -pl org.apache.drill.exec:drill-java-exec \
           -Dgroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      - name: Remove swap space
+        run : |
+          sudo swapoff /tmp/swapfile
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,11 @@ jobs:
           "
       - name: Build and test
         run: |
-          MAVEN_OPTS="-XX:+UseG1GC"
-          sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
           mvn -P${{ matrix.profile }} install --batch-mode --no-transfer-progress \
           -DexcludedGroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Test Specific Categories # EasyOutOfMemory
         run: |
-          sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches' && \
           mvn -P${{ matrix.profile }} test -pl org.apache.drill.exec:drill-java-exec \
           -Dgroups=org.apache.drill.categories.EasyOutOfMemory \
           -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
     <javax.validation.api>2.0.1.Final</javax.validation.api>
     <asm.version>9.5</asm.version>
     <excludedGroups />
-    <memoryMb>2500</memoryMb>
-    <directMemoryMb>4500</directMemoryMb>
+    <memoryMb>2560</memoryMb>
+    <directMemoryMb>2560</directMemoryMb>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>
     <docker.repository>apache/drill</docker.repository>


### PR DESCRIPTION
# [MINOR UPDATE]: Improve the Github CI memory constraint workarounds

## Description

1. Add a 2GB swap file when setting up the Actions Runner.
2. Remove /proc/sys/vm/drop_caches [snake oil](https://www.linuxatemyram.com/).
3. Tune the heap and direct memory limits applied to the test suite.

## Documentation
Improve the comments in the CI workflow yaml.

## Testing
Full CI run.
