### PR TITLE
[DRILL-8459]: Bump Avro to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <javassist.version>3.29.2-GA</javassist.version>
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>
-    <avro.version>1.11.2</avro.version>
+    <avro.version>1.11.3</avro.version>
     <metrics.version>4.2.19</metrics.version>
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jersey.version>2.40</jersey.version>


### PR DESCRIPTION
# [DRILL-8459](https://issues.apache.org/jira/browse/DRILL-8459): bump avro to 1.11.3

## Description

CVE issue

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
