### PR TITLE
DRILL-8460: Upgrade Zookeeper Jar to 3.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <janino.version>3.1.8</janino.version>
     <sqlline.version>1.12.0</sqlline.version>
     <jackson.version>2.14.3</jackson.version>
-    <zookeeper.version>3.5.7</zookeeper.version>
+    <zookeeper.version>3.7.2</zookeeper.version>
     <kerby.version>1.0.0</kerby.version>
     <findbugs.version>3.0.5</findbugs.version>
     <netty.tcnative.classifier />


### PR DESCRIPTION
# [DRILL-8460](https://issues.apache.org/jira/browse/DRILL-8460): Upgrade Zookeeper Jar to 3.7.2

## Description

CVE issue

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
