### PR TITLE
DRILL-8446: Incorrect use of OperatingSystemMXBean

### DIFF
--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/TestSplunkUserTranslation.java
@@ -79,9 +79,9 @@ public class TestSplunkUserTranslation extends SplunkBaseTest {
       .property(DrillProperties.PASSWORD, TEST_USER_1_PASSWORD)
       .build();
 
-    String sql = "SELECT acceleration_id, action, add_offset, add_timestamp FROM ut_splunk._audit LIMIT 2";
+    String sql = "SELECT acceleration_id, action, add_offset, add_timestamp FROM ut_splunk._audit LIMIT 1";
     RowSet results = client.queryBuilder().sql(sql).rowSet();
-    assertEquals(2, results.rowCount());
+    assertEquals(1, results.rowCount());
     results.clear();
   }
 


### PR DESCRIPTION
# [DRILL-8446](https://issues.apache.org/jira/browse/DRILL-8446):  Incorrect use of OperatingSystemMXBean

## Description

Simplify CpuGaugeSet fixing the non-Sun/Oracle code path in the process.

The com.sun.management internal implementation of OperatingSystemMXBean is used by Drill to report a CPU metric that is not available in the public interface. Even though code to handle non-Sun/Oracle runtimes for the OperatingSystemMXBean was present, it would still cause them to attempt to load a class from com.sun.management causing a NoClassDefFoundError.

## Documentation
N/A

## Testing
Launch Drill and check the affected gauges in 

- OpenJDK 64-Bit Server VM (build 17.0.9+9-Debian-1, mixed mode, sharing)
- IBM J9 VM (build 2.9, JRE 1.8.0 Linux amd64-64-Bit Compressed References 20230817_56476 (JIT enabled, AOT enabled)
