### PR TITLE
DRILL-8461: Prevent XXE Attacks in XML Format Plugin

### DIFF
--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLReader.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLReader.java
@@ -100,6 +100,9 @@ public class XMLReader implements Closeable {
   public XMLReader(InputStream fsStream, int dataLevel, boolean allTextMode) throws XMLStreamException {
     this.fsStream = fsStream;
     XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+
+    // This property prevents XXE attacks by disallowing DTD.
+    inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
     reader = inputFactory.createXMLEventReader(fsStream);
     fieldNameStack = new Stack<>();
     rowWriterStack = new Stack<>();

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -19,6 +19,8 @@
 package org.apache.drill.exec.store.xml;
 
 import org.apache.drill.categories.RowSetTest;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;
@@ -41,6 +43,8 @@ import static org.apache.drill.test.rowSet.RowSetUtilities.mapArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.objArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Category(RowSetTest.class)
 public class TestXMLReader extends ClusterTest {
@@ -84,6 +88,17 @@ public class TestXMLReader extends ClusterTest {
       .build();
 
     new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testXXE() throws Exception {
+    String sql = "SELECT * FROM cp.`xml/bad.xml`";
+    try {
+      client.queryBuilder().sql(sql).rowSet();
+      fail();
+    } catch (UserException e) {
+       assertTrue(e.getMessage().contains("DATA_READ ERROR: Error parsing XML file"));
+    }
   }
 
   @Test

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.store.xml;
 
 import org.apache.drill.categories.RowSetTest;
 import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;

--- a/contrib/format-xml/src/test/resources/xml/bad.xml
+++ b/contrib/format-xml/src/test/resources/xml/bad.xml
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE foo [
         <!ELEMENT foo ANY >

--- a/contrib/format-xml/src/test/resources/xml/bad.xml
+++ b/contrib/format-xml/src/test/resources/xml/bad.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE foo [
+        <!ELEMENT foo ANY >
+        <!ENTITY xxe SYSTEM "/etc/passwd" >]
+        >
+<creds>
+    <user>&xxe;</user>
+    <pass>mypass</pass>
+</creds>


### PR DESCRIPTION
# [DRILL-8461](https://issues.apache.org/jira/browse/DRILL-8461):  Prevent XXE Attacks in XML Format Plugin

## Description
Drill's XML reader would allow a maliciously crafted XML file to perform an XML eXternal Entity injection (XXE)  attack.  This fix disables DTD parsing in the XML format plugin and prevents XXE attacks.

## Documentation
No user facing changes.

## Testing
Added unit test and tested manually.