### PR TITLE
DRILL-8468: Drill doesn't perform drill.exec.storage.action_on_plugins_override_file action

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -291,16 +291,14 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     try {
       for (ConnectorLocator locator : locators) {
         StoragePlugins locatorPlugins = locator.bootstrapPlugins();
-        if (locatorPlugins != null) {
-          bootstrapPlugins.putAll(locatorPlugins);
-        }
+        bootstrapPlugins.putAll(locatorPlugins);
       }
     } catch (IOException e) {
       throw new IllegalStateException(
           "Failure initializing the plugin store. Drillbit exiting.", e);
     }
     pluginStore.putAll(bootstrapPlugins);
-    locators.stream().forEach(loc -> loc.onUpgrade());
+    locators.forEach(ConnectorLocator::onUpgrade);
   }
 
   /**
@@ -311,9 +309,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     StoragePlugins upgraded = new StoragePlugins();
     for (ConnectorLocator locator : locators) {
       StoragePlugins locatorPlugins = locator.updatedPlugins();
-      if (upgraded != null) {
-        upgraded.putAll(locatorPlugins);
-      }
+      upgraded.putAll(locatorPlugins);
     }
     if (upgraded.isEmpty()) {
       return;
@@ -325,6 +321,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
       }
       pluginStore.put(newPlugin.getKey(), newPlugin.getValue());
     }
+    locators.forEach(ConnectorLocator::onUpgrade);
   }
 
   /**


### PR DESCRIPTION
# [DRILL-8468](https://issues.apache.org/jira/browse/DRILL-8468): Drill doesn't perform drill.exec.storage.action_on_plugins_override_file action

## Description

The issue is caused by plugin registry refactoring: https://github.com/apache/drill/pull/1988
After this change, `drill.exec.storage.action_on_plugins_override_file` doesn't work as described in our documentation: https://drill.apache.org/docs/configuring-storage-plugins/#configuring-storage-plugins-with-the-storage-plugins-overrideconf-file

`storage-plugins-override.conf` is neither removed nor renamed on Drill restart.

## Documentation
No updates

## Testing
Manual
