### PR TITLE
DRILL-8470: Bump MongoDB Driver to Latest Version

### DIFF
--- a/contrib/format-deltalake/pom.xml
+++ b/contrib/format-deltalake/pom.xml
@@ -40,12 +40,12 @@
     <dependency>
       <groupId>io.delta</groupId>
       <artifactId>delta-storage</artifactId>
-      <version>2.1.0</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.delta</groupId>
       <artifactId>delta-standalone_2.13</artifactId>
-      <version>0.5.0</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/contrib/format-image/pom.xml
+++ b/contrib/format-image/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.drewnoakes</groupId>
       <artifactId>metadata-extractor</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/format-image/src/test/resources/image/jpeg.json
+++ b/contrib/format-image/src/test/resources/image/jpeg.json
@@ -2,11 +2,11 @@
   "Format" : "JPEG",
   "PixelWidth" : "600",
   "PixelHeight" : "400",
-  "BitsPerPixel" : "24",
+  "Orientation" : "Top, left side (Horizontal / normal)",
   "DPIWidth" : "300",
   "DPIHeight" : "300",
-  "Orientation" : "Top, left side (Horizontal / normal)",
   "ColorMode" : "RGB",
+  "BitsPerPixel" : "24",
   "HasAlpha" : "false",
   "Duration" : "00:00:00",
   "VideoCodec" : "Unknown",
@@ -87,7 +87,7 @@
     "XResolution" : "72 dots per inch",
     "YResolution" : "72 dots per inch",
     "ResolutionUnit" : "Inch",
-    "ThumbnailOffset" : "1038 bytes",
+    "ThumbnailOffset" : "1044 bytes",
     "ThumbnailLength" : "3662 bytes"
   },
   "XMP" : {

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <aircompressor.version>0.25</aircompressor.version>
     <iceberg.version>0.12.1</iceberg.version>
     <univocity-parsers.version>2.8.3</univocity-parsers.version>
-    <mongo.version>4.3.3</mongo.version>
+    <mongo.version>4.11.1</mongo.version>
     <swagger.version>2.1.12</swagger.version>
     <junit.args />
   </properties>


### PR DESCRIPTION
# [DRILL-8470](https://issues.apache.org/jira/browse/DRILL-XXXX): Bump MongoDB Driver to Latest Version

## Description
Update the mongoDB Java driver to the latest version..

This PR also includes: 
* [DRILL-8471](https://issues.apache.org/jira/browse/DRILL-8471):  Bump DeltaLake Driver to 3.0.0
* [DRILL-8742](https://issues.apache.org/jira/browse/DRILL-8472): Bump Image Metadata Library to Latest Version

## Documentation
N/A

## Testing
Ran unit tests.