### PR TITLE
DRILL-8460: Upgrade ZooKeeper 3.5.7 → 3.5.10 and Curator 5.2.0 → 5.5.0

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -882,7 +882,7 @@
     <profile>
       <id>hadoop-2</id>
       <properties>
-        <jdbc-all-jar.maxsize>54100000</jdbc-all-jar.maxsize>
+        <jdbc-all-jar.maxsize>54300000</jdbc-all-jar.maxsize>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,14 @@
     <janino.version>3.1.8</janino.version>
     <sqlline.version>1.12.0</sqlline.version>
     <jackson.version>2.14.3</jackson.version>
-    <zookeeper.version>3.5.7</zookeeper.version>
+    <zookeeper.version>3.5.10</zookeeper.version>
     <kerby.version>1.0.0</kerby.version>
     <findbugs.version>3.0.5</findbugs.version>
     <netty.tcnative.classifier />
     <commons.io.version>2.15.0</commons.io.version>
     <commons.collections.version>4.4</commons.collections.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <curator.version>5.2.0</curator.version>
+    <curator.version>5.5.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
     <logback.version>1.3.14</logback.version>


### PR DESCRIPTION
# [DRILL-8460](https://issues.apache.org/jira/browse/DRILL-8460): Upgrade ZooKeeper 3.5.7 → 3.5.10 and Curator 5.2.0 → 5.5.0

## Description

Note that the initial attempt to upgrade ZooKeeper to 3.7.2 for this ticket led to test failures and so to keep this upgrade backportable the upgrade is limited to 3.5.10.

## Documentation
N/A

## Testing
Unit tests pass.
