### PR TITLE
[MINOR UPDATE] use StandardCharsets

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/DrillFileUtils.java
+++ b/common/src/main/java/org/apache/drill/common/util/DrillFileUtils.java
@@ -21,8 +21,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class DrillFileUtils {
@@ -41,7 +41,7 @@ public class DrillFileUtils {
   }
 
   public static String getResourceAsString(String fileName) throws IOException {
-    return Files.asCharSource(getResourceAsFile(fileName), Charsets.UTF_8).read();
+    return Files.asCharSource(getResourceAsFile(fileName), StandardCharsets.UTF_8).read();
   }
 
   /**

--- a/contrib/format-httpd/src/main/java/org/apache/drill/exec/store/httpd/HttpdLogBatchReader.java
+++ b/contrib/format-httpd/src/main/java/org/apache/drill/exec/store/httpd/HttpdLogBatchReader.java
@@ -31,7 +31,6 @@ import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
-import com.google.common.base.Charsets;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +39,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public class HttpdLogBatchReader implements ManagedReader {
 
@@ -168,7 +168,7 @@ public class HttpdLogBatchReader implements ManagedReader {
         .addContext(e.getMessage())
         .build(logger);
     }
-    reader = new BufferedReader(new InputStreamReader(fsStream, Charsets.UTF_8));
+    reader = new BufferedReader(new InputStreamReader(fsStream, StandardCharsets.UTF_8));
   }
 
   private ScalarWriter addImplicitColumn(String colName, MinorType type) {

--- a/contrib/format-log/src/main/java/org/apache/drill/exec/store/log/LogBatchReader.java
+++ b/contrib/format-log/src/main/java/org/apache/drill/exec/store/log/LogBatchReader.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.TupleWriter;
 import org.apache.drill.exec.vector.accessor.ValueWriter;
-import com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +37,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -193,7 +193,7 @@ public class LogBatchReader implements ManagedReader {
           .addContext(loader.errorContext())
           .build(logger);
     }
-    reader = new BufferedReader(new InputStreamReader(in, Charsets.UTF_8));
+    reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
   }
 
   @Override

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/planner/index/MapRDBStatistics.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -829,7 +828,7 @@ public class MapRDBStatistics implements Statistics {
           // WILDCARD present. This turns the LIKE predicate to RANGE predicate
           byte[] startKey = HConstants.EMPTY_START_ROW;
           byte[] stopKey = HConstants.EMPTY_END_ROW;
-          startKey = prefix.getBytes(Charsets.UTF_8);
+          startKey = prefix.getBytes(StandardCharsets.UTF_8);
           stopKey = startKey.clone();
           boolean isMaxVal = true;
           for (int i = stopKey.length - 1; i >= 0; --i) {
@@ -848,9 +847,9 @@ public class MapRDBStatistics implements Statistics {
           // TODO: This maybe a potential bug since we assume UTF-8 encoding. However, we follow the
           // current DB implementation. See HBaseFilterBuilder.createHBaseScanSpec "like" CASE statement
           RexLiteral startKeyLiteral = builder.makeLiteral(new String(startKey,
-              Charsets.UTF_8));
+              StandardCharsets.UTF_8));
           RexLiteral stopKeyLiteral = builder.makeLiteral(new String(stopKey,
-              Charsets.UTF_8));
+              StandardCharsets.UTF_8));
           if (arg != null) {
             RexNode startPred = builder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
                 arg, startKeyLiteral);

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MapRDBFilterBuilder.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MapRDBFilterBuilder.java
@@ -40,8 +40,6 @@ import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
-import com.google.common.base.Charsets;
-
 public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void, RuntimeException> implements DrillHBaseConstants {
 
   final private BinaryTableGroupScan groupScan;
@@ -295,7 +293,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
             startRow = stopRow = fieldValue;
             compareOp = null;
           } else {
-            startRow = prefix.getBytes(Charsets.UTF_8);
+            startRow = prefix.getBytes(StandardCharsets.UTF_8);
             stopRow = startRow.clone();
             boolean isMaxVal = true;
             for (int i = stopRow.length - 1; i >= 0; --i) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MaprDBCompareFunctionsProcessor.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MaprDBCompareFunctionsProcessor.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.mapr.db.binary;
 
-import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -46,7 +45,7 @@ class MaprDBCompareFunctionsProcessor extends CompareFunctionsProcessor {
       case "UTF8_OB":
       case "UTF8_OBD":
         if (valueArg instanceof ValueExpressions.QuotedString) {
-          int stringLen = ((ValueExpressions.QuotedString) valueArg).value.getBytes(Charsets.UTF_8).length;
+          int stringLen = ((ValueExpressions.QuotedString) valueArg).value.getBytes(StandardCharsets.UTF_8).length;
           ByteBuf bb = newByteBuf(stringLen + 2, true);
           PositionedByteRange br = new SimplePositionedMutableByteRange(bb.array(), 0, stringLen + 2);
           if (encodingType.endsWith("_OBD")) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/udf/mapr/db/DecodeFieldPath.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/udf/mapr/db/DecodeFieldPath.java
@@ -52,7 +52,7 @@ public class DecodeFieldPath implements DrillSimpleFunc {
       sb.append(", ").append(org.ojai.FieldPath.parseFrom(decodedPath).asPathString());
     }
     String outputString = "[" + sb.substring(2) + "]";
-    final byte[] strBytes = outputString.getBytes(StandardCharsets.UTF_8);
+    final byte[] strBytes = outputString.getBytes(java.nio.charset.StandardCharsets.UTF_8);
     buffer.setBytes(0, strBytes);
     buffer.setIndex(0, strBytes.length);
 

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/udf/mapr/db/DecodeFieldPath.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/udf/mapr/db/DecodeFieldPath.java
@@ -52,7 +52,7 @@ public class DecodeFieldPath implements DrillSimpleFunc {
       sb.append(", ").append(org.ojai.FieldPath.parseFrom(decodedPath).asPathString());
     }
     String outputString = "[" + sb.substring(2) + "]";
-    final byte[] strBytes = outputString.getBytes(com.google.common.base.Charsets.UTF_8);
+    final byte[] strBytes = outputString.getBytes(StandardCharsets.UTF_8);
     buffer.setBytes(0, strBytes);
     buffer.setIndex(0, strBytes.length);
 

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsLimitPushdown.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsLimitPushdown.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.oauth.PersistentTokenTable;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
@@ -33,6 +32,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,7 +55,8 @@ public class TestGoogleSheetsLimitPushdown extends ClusterTest {
   @BeforeClass
   public static void init() throws Exception {
 
-    String oauthJson = Files.asCharSource(DrillFileUtils.getResourceAsFile("/tokens/oauth_tokens.json"), Charsets.UTF_8).read();
+    String oauthJson = Files.asCharSource(DrillFileUtils.getResourceAsFile("/tokens/oauth_tokens.json"),
+        StandardCharsets.UTF_8).read();
 
     ObjectMapper mapper = JacksonUtils.createObjectMapper();
     Map<String,String> tokenMap = mapper.readValue(oauthJson, Map.class);

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
@@ -38,6 +38,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsQueries.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
@@ -72,7 +71,7 @@ public class TestGoogleSheetsQueries extends ClusterTest {
   @BeforeClass
   public static void init() throws Exception {
 
-    String oauthJson = Files.asCharSource(DrillFileUtils.getResourceAsFile("/tokens/oauth_tokens.json"), Charsets.UTF_8).read();
+    String oauthJson = Files.asCharSource(DrillFileUtils.getResourceAsFile("/tokens/oauth_tokens.json"), StandardCharsets.UTF_8).read();
 
     ObjectMapper mapper = JacksonUtils.createObjectMapper();
     Map<String,String> tokenMap = mapper.readValue(oauthJson, Map.class);

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsWriter.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsWriter.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
@@ -74,7 +73,7 @@ public class TestGoogleSheetsWriter extends ClusterTest {
     ClusterTest.startCluster(ClusterFixture.builder(dirTestWatcher));
     dirTestWatcher.copyResourceToRoot(Paths.get(""));
 
-    String oauthJson = Files.asCharSource(DrillFileUtils.getResourceAsFile("/tokens/oauth_tokens.json"), Charsets.UTF_8).read();
+    String oauthJson = Files.asCharSource(DrillFileUtils.getResourceAsFile("/tokens/oauth_tokens.json"), StandardCharsets.UTF_8).read();
 
     ObjectMapper mapper = JacksonUtils.createObjectMapper();
     Map<String,String> tokenMap = mapper.readValue(oauthJson, Map.class);

--- a/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsWriter.java
+++ b/contrib/storage-googlesheets/src/test/java/org/apache/drill/exec/store/googlesheets/TestGoogleSheetsWriter.java
@@ -39,6 +39,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/CompareFunctionsProcessor.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/CompareFunctionsProcessor.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,7 +50,6 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.PrefixFilter;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -511,7 +511,7 @@ public class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, Logi
   @Override
   public Boolean visitSchemaPath(SchemaPath path, LogicalExpression valueArg) throws RuntimeException {
     if (valueArg instanceof QuotedString) {
-      this.value = ((QuotedString) valueArg).value.getBytes(Charsets.UTF_8);
+      this.value = ((QuotedString) valueArg).value.getBytes(StandardCharsets.UTF_8);
       this.path = path;
       return true;
     }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseFilterBuilder.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseFilterBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.hbase;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,8 +36,6 @@ import org.apache.hadoop.hbase.filter.NullComparator;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
-
-import com.google.common.base.Charsets;
 
 public class HBaseFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void, RuntimeException> implements DrillHBaseConstants {
 
@@ -290,7 +289,7 @@ public class HBaseFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void,
             startRow = stopRow = fieldValue;
             compareOp = null;
           } else {
-            startRow = prefix.getBytes(Charsets.UTF_8);
+            startRow = prefix.getBytes(StandardCharsets.UTF_8);
             stopRow = startRow.clone();
             boolean isMaxVal = true;
             for (int i = stopRow.length - 1; i >= 0; --i) {

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.hbase;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.test.BaseTestQuery;
@@ -33,7 +34,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class BaseHBaseTest extends BaseTestQuery {
@@ -67,7 +67,7 @@ public class BaseHBaseTest extends BaseTestQuery {
   }
 
   protected String getPlanText(String planFile, String tableName) throws IOException {
-    return Files.asCharSource(DrillFileUtils.getResourceAsFile(planFile), Charsets.UTF_8).read()
+    return Files.asCharSource(DrillFileUtils.getResourceAsFile(planFile), StandardCharsets.UTF_8).read()
         .replaceFirst(
             "\"hbase\\.zookeeper\\.property\\.clientPort\".*:.*\\d+",
             "\"hbase.zookeeper.property.clientPort\" : " + HBaseTestsSuite.getZookeeperPort())

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestOrderedBytesConvertFunctions.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestOrderedBytesConvertFunctions.java
@@ -36,7 +36,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.junit.experimental.categories.Category;
 
@@ -62,7 +61,7 @@ public class TestOrderedBytesConvertFunctions extends BaseTestQuery {
     expression = expression.replace("\\", "\\\\\\\\"); // "\\\\\\\\" => Java => "\\\\" => JsonParser => "\\" => AntlrParser "\"
 
     if (textFileContent == null) {
-      textFileContent = Resources.toString(Resources.getResource(CONVERSION_TEST_PHYSICAL_PLAN), Charsets.UTF_8);
+      textFileContent = Resources.toString(Resources.getResource(CONVERSION_TEST_PHYSICAL_PLAN), StandardCharsets.UTF_8);
     }
     String planString = textFileContent.replace("__CONVERT_EXPRESSION__", expression);
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestHiveUDFs.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.fn.hive;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.test.BaseTestQuery;
@@ -35,7 +36,6 @@ import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.VarCharVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.junit.experimental.categories.Category;
 
@@ -44,7 +44,8 @@ public class TestHiveUDFs extends BaseTestQuery {
 
   @Test
   public void testGenericUDF() throws Throwable {
-    String planString = Resources.toString(Resources.getResource("functions/hive/GenericUDF.json"), Charsets.UTF_8);
+    String planString = Resources.toString(Resources.getResource("functions/hive/GenericUDF.json"),
+        StandardCharsets.UTF_8);
     List<QueryDataBatch> results = testPhysicalWithResults(planString);
 
     RecordBatchLoader batchLoader = new RecordBatchLoader(getAllocator());
@@ -72,22 +73,22 @@ public class TestHiveUDFs extends BaseTestQuery {
       NullableVarCharVector upperNullableStr1V = (NullableVarCharVector) batchLoader.getValueAccessorById(NullableVarCharVector.class, 6).getValueVector();
 
       for (int i=0; i<batchLoader.getRecordCount(); i++) {
-        String in = new String(str1V.getAccessor().get(i), Charsets.UTF_8);
-        String upper = new String(upperStr1V.getAccessor().get(i), Charsets.UTF_8);
+        String in = new String(str1V.getAccessor().get(i), StandardCharsets.UTF_8);
+        String upper = new String(upperStr1V.getAccessor().get(i), StandardCharsets.UTF_8);
         assertTrue(in.toUpperCase().equals(upper));
 
 
-        String concat = new String(concatV.getAccessor().get(i), Charsets.UTF_8);
+        String concat = new String(concatV.getAccessor().get(i), StandardCharsets.UTF_8);
         assertTrue(concat.equals(in+"-"+in));
 
         String nullableStr1 = null;
         if (!nullableStr1V.getAccessor().isNull(i)) {
-          nullableStr1 = new String(nullableStr1V.getAccessor().get(i), Charsets.UTF_8);
+          nullableStr1 = new String(nullableStr1V.getAccessor().get(i), StandardCharsets.UTF_8);
         }
 
         String upperNullableStr1 = null;
         if (!upperNullableStr1V.getAccessor().isNull(i)) {
-          upperNullableStr1 = new String(upperNullableStr1V.getAccessor().get(i), Charsets.UTF_8);
+          upperNullableStr1 = new String(upperNullableStr1V.getAccessor().get(i), StandardCharsets.UTF_8);
         }
 
         assertEquals(nullableStr1 != null, upperNullableStr1 != null);
@@ -103,7 +104,7 @@ public class TestHiveUDFs extends BaseTestQuery {
 
   @Test
   public void testUDF() throws Throwable {
-    String planString = Resources.toString(Resources.getResource("functions/hive/UDF.json"), Charsets.UTF_8);
+    String planString = Resources.toString(Resources.getResource("functions/hive/UDF.json"), StandardCharsets.UTF_8);
     List<QueryDataBatch> results = testPhysicalWithResults(planString);
 
     RecordBatchLoader batchLoader = new RecordBatchLoader(getAllocator());
@@ -128,7 +129,7 @@ public class TestHiveUDFs extends BaseTestQuery {
       NullableFloat8Vector powV = (NullableFloat8Vector) batchLoader.getValueAccessorById(NullableFloat8Vector.class, 4).getValueVector();
 
       for (int i=0; i<batchLoader.getRecordCount(); i++) {
-        String str1 = new String(str1V.getAccessor().get(i), Charsets.UTF_8);
+        String str1 = new String(str1V.getAccessor().get(i), StandardCharsets.UTF_8);
         long str1Length = str1LengthV.getAccessor().get(i);
         assertTrue(str1.length() == str1Length);
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpApiConfig.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpApiConfig.java
@@ -21,13 +21,13 @@ package org.apache.drill.exec.store.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +48,7 @@ public class TestHttpApiConfig {
   @BeforeAll
   public static void setup() throws Exception {
     EXAMPLE_HTTP_API_CONFIG_JSON = Files.asCharSource(
-        DrillFileUtils.getResourceAsFile("/data/exampleHttpApiConfig.json"), Charsets.UTF_8
+        DrillFileUtils.getResourceAsFile("/data/exampleHttpApiConfig.json"), StandardCharsets.UTF_8
     ).read().trim();
 
     EXAMPLE_HEADERS = new HashMap<>();

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpCSVOptions.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpCSVOptions.java
@@ -20,11 +20,12 @@ package org.apache.drill.exec.store.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -41,7 +42,7 @@ public class TestHttpCSVOptions {
   @BeforeAll
   public static void setup() throws Exception {
     CSV_OPTIONS_JSON = Files.asCharSource(
-        DrillFileUtils.getResourceAsFile("/data/csvOptions.json"), Charsets.UTF_8
+        DrillFileUtils.getResourceAsFile("/data/csvOptions.json"), StandardCharsets.UTF_8
     ).read().trim();
   }
 

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -43,6 +43,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
@@ -89,12 +88,12 @@ public class TestHttpPlugin extends ClusterTest {
   public static void setup() throws Exception {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
-    TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.json"), Charsets.UTF_8).read();
-    TEST_MALFORMED_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/malformed.json"), Charsets.UTF_8).read();
-    TEST_CSV_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.csv"), Charsets.UTF_8).read();
-    TEST_XML_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.xml"), Charsets.UTF_8).read();
-    TEST_JSON_RESPONSE_WITH_DATATYPES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response2.json"), Charsets.UTF_8).read();
-    TEST_TSV_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.tsv"), Charsets.UTF_8).read();
+    TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.json"), StandardCharsets.UTF_8).read();
+    TEST_MALFORMED_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/malformed.json"), StandardCharsets.UTF_8).read();
+    TEST_CSV_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.csv"), StandardCharsets.UTF_8).read();
+    TEST_XML_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.xml"), StandardCharsets.UTF_8).read();
+    TEST_JSON_RESPONSE_WITH_DATATYPES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response2.json"), StandardCharsets.UTF_8).read();
+    TEST_TSV_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.tsv"), StandardCharsets.UTF_8).read();
 
     dirTestWatcher.copyResourceToRoot(Paths.get("data/"));
     makeEnhancedLiveConfig();

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFFunctions.java
@@ -39,7 +39,6 @@ import org.apache.drill.exec.store.easy.json.loader.JsonLoaderImpl;
 import org.apache.drill.exec.store.http.udfs.HttpUdfUtils;
 import org.apache.drill.exec.store.http.util.SimpleHttp;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
@@ -50,6 +49,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -83,8 +83,10 @@ public class TestHttpUDFFunctions extends ClusterTest {
       .logger(HttpUdfUtils.class, CURRENT_LOG_LEVEL)
       .build();
     startCluster(ClusterFixture.builder(dirTestWatcher));
-    TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/simple.json"), Charsets.UTF_8).read();
-    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
+    TEST_JSON_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/simple.json"),
+        StandardCharsets.UTF_8).read();
+    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"),
+        StandardCharsets.UTF_8).read();
 
     HttpApiConfig mockGithubWithDuplicateParam = HttpApiConfig.builder()
       .url(String.format("%s/orgs/{org}/repos", DUMMY_URL))

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpUDFWithAliases.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClientFixture;
@@ -44,6 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,7 +69,8 @@ public class TestHttpUDFWithAliases extends ClusterTest {
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
 
-    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
+    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"),
+        StandardCharsets.UTF_8).read();
 
     cluster = ClusterFixture.bareBuilder(dirTestWatcher)
       .configProperty(ExecConstants.USER_AUTHENTICATION_ENABLED, true)

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestOAuthProcess.java
@@ -38,7 +38,6 @@ import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.security.oauth.OAuthTokenCredentials;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
@@ -49,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -75,9 +75,12 @@ public class TestOAuthProcess extends ClusterTest {
 
   @BeforeClass
   public static void setup() throws Exception {
-    ACCESS_TOKEN_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/oauth_access_token_response.json"), Charsets.UTF_8).read();
-    REFRESH_TOKEN_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/token_refresh.json"), Charsets.UTF_8).read();
-    TEST_JSON_RESPONSE_WITH_DATATYPES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response2.json"), Charsets.UTF_8).read();
+    ACCESS_TOKEN_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/oauth_access_token_response.json"),
+        StandardCharsets.UTF_8).read();
+    REFRESH_TOKEN_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/token_refresh.json"),
+        StandardCharsets.UTF_8).read();
+    TEST_JSON_RESPONSE_WITH_DATATYPES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response2.json"),
+        StandardCharsets.UTF_8).read();
 
     ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher)
       .configProperty(ExecConstants.HTTP_ENABLE, true)

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestPagination.java
@@ -31,7 +31,6 @@ import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
@@ -42,6 +41,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -83,35 +83,35 @@ public class TestPagination extends ClusterTest {
   public static void setup() throws Exception {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
-    TEST_CSV_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.csv"), Charsets.UTF_8).read();
-    TEST_CSV_RESPONSE_2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_2.csv"), Charsets.UTF_8).read();
-    TEST_CSV_RESPONSE_3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_3.csv"), Charsets.UTF_8).read();
-    TEST_CSV_RESPONSE_4 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_4.csv"), Charsets.UTF_8).read();
+    TEST_CSV_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response.csv"), StandardCharsets.UTF_8).read();
+    TEST_CSV_RESPONSE_2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_2.csv"), StandardCharsets.UTF_8).read();
+    TEST_CSV_RESPONSE_3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_3.csv"), StandardCharsets.UTF_8).read();
+    TEST_CSV_RESPONSE_4 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_4.csv"), StandardCharsets.UTF_8).read();
 
-    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
-    TEST_JSON_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p2.json"), Charsets.UTF_8).read();
-    TEST_JSON_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p3.json"), Charsets.UTF_8).read();
+    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p2.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p3.json"), StandardCharsets.UTF_8).read();
 
-    TEST_JSON_INDEX_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response1.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response2.json"), Charsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response1.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response2.json"), StandardCharsets.UTF_8).read();
 
-    TEST_JSON_INDEX_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response3.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE4 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response4.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE5 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response5.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE6 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response6.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE7 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response7.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE8 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response8.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE9 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response9.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE10 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response10.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE11 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response11.json"), Charsets.UTF_8).read();
-    TEST_JSON_INDEX_PAGE12 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response12.json"), Charsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response3.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE4 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response4.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE5 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response5.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE6 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response6.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE7 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response7.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE8 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response8.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE9 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response9.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE10 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response10.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE11 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response11.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_INDEX_PAGE12 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/index_response12.json"), StandardCharsets.UTF_8).read();
 
-    TEST_JSON_NESTED_INDEX = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/nested_pagination_fields.json"), Charsets.UTF_8).read();
-    TEST_JSON_NESTED_INDEX2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/nested_pagination_fields2.json"), Charsets.UTF_8).read();
+    TEST_JSON_NESTED_INDEX = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/nested_pagination_fields.json"), StandardCharsets.UTF_8).read();
+    TEST_JSON_NESTED_INDEX2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/nested_pagination_fields2.json"), StandardCharsets.UTF_8).read();
 
-    TEST_XML_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_1.xml"), Charsets.UTF_8).read();
-    TEST_XML_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_2.xml"), Charsets.UTF_8).read();
-    TEST_XML_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_3.xml"), Charsets.UTF_8).read();
+    TEST_XML_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_1.xml"), StandardCharsets.UTF_8).read();
+    TEST_XML_PAGE2 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_2.xml"), StandardCharsets.UTF_8).read();
+    TEST_XML_PAGE3 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response_3.xml"), StandardCharsets.UTF_8).read();
 
     dirTestWatcher.copyResourceToRoot(Paths.get("data/"));
     makeMockConfig(cluster);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestProvidedSchema.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestProvidedSchema.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.security.UsernamePasswordCredentials;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
@@ -43,6 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,8 +60,8 @@ public class TestProvidedSchema extends ClusterTest {
   public static void setup() throws Exception {
     startCluster(ClusterFixture.builder(dirTestWatcher));
 
-    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), Charsets.UTF_8).read();
-    TEST_SCHEMA_CHANGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/schema_change_1.json"), Charsets.UTF_8).read();
+    TEST_JSON_PAGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/p1.json"), StandardCharsets.UTF_8).read();
+    TEST_SCHEMA_CHANGE1 = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/schema_change_1.json"), StandardCharsets.UTF_8).read();
 
     dirTestWatcher.copyResourceToRoot(Paths.get("data/"));
     makeMockConfig(cluster);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestUserTranslationInHttpPlugin.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.security.oauth.OAuthTokenCredentials;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.ClientFixture;
@@ -91,8 +90,8 @@ public class TestUserTranslationInHttpPlugin extends ClusterTest {
 
   @BeforeClass
   public static void setup() throws Exception {
-    TEST_JSON_RESPONSE_WITH_DATATYPES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response2.json"), Charsets.UTF_8).read();
-    ACCESS_TOKEN_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/oauth_access_token_response.json"), Charsets.UTF_8).read();
+    TEST_JSON_RESPONSE_WITH_DATATYPES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/response2.json"), StandardCharsets.UTF_8).read();
+    ACCESS_TOKEN_RESPONSE = Files.asCharSource(DrillFileUtils.getResourceAsFile("/data/oauth_access_token_response.json"), StandardCharsets.UTF_8).read();
 
     ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher)
       .configProperty(ExecConstants.HTTP_ENABLE, true)

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/bson/BsonRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/bson/BsonRecordReader.java
@@ -39,7 +39,6 @@ import org.bson.BsonType;
 import org.joda.time.DateTime;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -264,14 +263,8 @@ public class BsonRecordReader {
   }
 
   private void writeString(String readString, final MapOrListWriterImpl writer, String fieldName, boolean isList) {
-    int length;
-    byte[] strBytes;
-    try {
-      strBytes = readString.getBytes("UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new DrillRuntimeException("Unable to read string value for field: " + fieldName, e);
-    }
-    length = strBytes.length;
+    byte[] strBytes = readString.getBytes(StandardCharsets.UTF_8);
+    int length = strBytes.length;
     ensure(length);
     workBuf.setBytes(0, strBytes);
     final VarCharHolder vh = new VarCharHolder();

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -50,7 +50,6 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -223,7 +222,7 @@ public class MongoRecordReader extends AbstractRecordReader {
           bsonReader.write(writer, new BsonDocumentReader(bsonDocument));
         } else {
           String doc = cursor.next().toJson();
-          jsonReader.setSource(doc.getBytes(Charsets.UTF_8));
+          jsonReader.setSource(doc.getBytes(StandardCharsets.UTF_8));
           jsonReader.write(writer);
         }
         docCount++;

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.mongo;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixBaseTest.java
+++ b/contrib/storage-phoenix/src/test/java/org/apache/drill/exec/store/phoenix/PhoenixBaseTest.java
@@ -264,6 +264,6 @@ public class PhoenixBaseTest extends ClusterTest {
   }
 
   private static Reader getReader(String path) throws Exception {
-    return new InputStreamReader(new FileInputStream(path), "UTF-8");
+    return new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8);
   }
 }

--- a/exec/java-exec/src/main/codegen/includes/vv_imports.ftl
+++ b/exec/java-exec/src/main/codegen/includes/vv_imports.ftl
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.ObjectArrays;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ObjectArrays;
 
 import com.google.common.base.Preconditions;

--- a/exec/java-exec/src/main/codegen/includes/vv_imports.ftl
+++ b/exec/java-exec/src/main/codegen/includes/vv_imports.ftl
@@ -68,6 +68,7 @@ import java.io.Closeable;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/exec/java-exec/src/main/codegen/templates/CastEmptyStringVarTypesToNullableNumeric.java
+++ b/exec/java-exec/src/main/codegen/templates/CastEmptyStringVarTypesToNullableNumeric.java
@@ -21,7 +21,7 @@
     {
     byte[] buf = new byte[in.end - in.start];
     in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-    throw new NumberFormatException(new String(buf, com.google.common.base.Charsets.UTF_8));
+    throw new NumberFormatException(new String(buf, java.nio.charset.StandardCharsets.UTF_8));
     }
 </#macro>
 
@@ -65,7 +65,7 @@ public class CastEmptyString${type.from}To${type.to} implements DrillSimpleFunc{
             out.isSet = 1;
             byte[]buf=new byte[in.end-in.start];
             in.buffer.getBytes(in.start,buf,0,in.end-in.start);
-            out.value=${type.javaType}.parse${type.parse}(new String(buf,com.google.common.base.Charsets.UTF_8));
+            out.value=${type.javaType}.parse${type.parse}(new String(buf, java.nio.charset.StandardCharsets.UTF_8));
         }
     <#elseif type.to=="NullableInt">
         if(<#if type.from == "NullableVarChar" || type.from == "NullableVar16Char" ||

--- a/exec/java-exec/src/main/codegen/templates/CastFunctionsSrcVarLen.java
+++ b/exec/java-exec/src/main/codegen/templates/CastFunctionsSrcVarLen.java
@@ -18,11 +18,11 @@
 <@pp.dropOutputFile />
 
 <#macro doError>
-  { 
+  {
     byte[] buf = new byte[in.end - in.start];
-    in.buffer.getBytes(in.start, buf, 0, in.end - in.start);  
-    throw new NumberFormatException(new String(buf, com.google.common.base.Charsets.UTF_8));
-  }  
+    in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
+    throw new NumberFormatException(new String(buf, java.nio.charset.StandardCharsets.UTF_8));
+  }
 </#macro>
 
 <#list cast.types as type>
@@ -58,16 +58,16 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc{
 
   public void eval() {
     <#if type.to == "Float4" || type.to == "Float8">
-      
+
       byte[] buf = new byte[in.end - in.start];
       in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-    
+
       //TODO: need capture format exception, and issue SQLERR code.
-      out.value = ${type.javaType}.parse${type.parse}(new String(buf, com.google.common.base.Charsets.UTF_8));
-      
+      out.value = ${type.javaType}.parse${type.parse}(new String(buf, java.nio.charset.StandardCharsets.UTF_8));
+
     <#elseif type.to=="Int" >
       out.value = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.varTypesToInt(in.start, in.end, in.buffer);
-    
+
     <#elseif type.to == "BigInt">
       out.value = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.varTypesToLong(in.start, in.end, in.buffer);
     </#if>

--- a/exec/java-exec/src/main/codegen/templates/CastStringTypesToDate.java
+++ b/exec/java-exec/src/main/codegen/templates/CastStringTypesToDate.java
@@ -51,7 +51,7 @@ import io.netty.buffer.DrillBuf;
  */
 @SuppressWarnings("unused")
 <#if type.major == "VarCharDate" || type.major == "VarBinaryDate">
-@FunctionTemplate(names = {"cast${type.to?upper_case}", "${type.alias}"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.NULL_IF_NULL, 
+@FunctionTemplate(names = {"cast${type.to?upper_case}", "${type.alias}"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.NULL_IF_NULL,
   costCategory = FunctionCostCategory.COMPLEX)
 public class Cast${type.from}To${type.to} implements DrillSimpleFunc {
 <#elseif type.major == "NullableVarCharDate">
@@ -64,7 +64,7 @@ public class GCast${type.from}To${type.to} implements DrillSimpleFunc {
 
   @Param ${type.from}Holder in;
   @Output ${type.to}Holder out;
-  
+
   public void setup() { }
 
   public void eval() {
@@ -79,7 +79,7 @@ public class GCast${type.from}To${type.to} implements DrillSimpleFunc {
     <#if type.to != "Date" && type.to != "NullableDate">
     byte[] buf = new byte[in.end - in.start];
     in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-    String input = new String(buf, com.google.common.base.Charsets.UTF_8);
+    String input = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
     </#if>
 
     <#if type.to == "Date" || type.to == "NullableDate">

--- a/exec/java-exec/src/main/codegen/templates/CastStringTypesToInterval.java
+++ b/exec/java-exec/src/main/codegen/templates/CastStringTypesToInterval.java
@@ -80,7 +80,7 @@ public class CastEmptyString${type.from}To${type.to} implements DrillSimpleFunc 
 
     byte[] buf = new byte[in.end - in.start];
     in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-    String input = new String(buf, com.google.common.base.Charsets.UTF_8);
+    String input = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
 
     // Parse the ISO format
     org.joda.time.Period period = org.joda.time.Period.parse(input);

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/DateToCharFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/DateToCharFunctions.java
@@ -63,7 +63,7 @@ public class G${type}ToChar implements DrillSimpleFunc {
         // Get the desired output format and create a DateTimeFormatter
         byte[] buf = new byte[right.end - right.start];
         right.buffer.getBytes(right.start, buf, 0, right.end - right.start);
-        String input = new String(buf, com.google.common.base.Charsets.UTF_8);
+        String input = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
         format = org.joda.time.format.DateTimeFormat.forPattern(input);
     }
 

--- a/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/ToDateTypeFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/DateIntervalFunctionTemplates/ToDateTypeFunctions.java
@@ -59,7 +59,7 @@ public class G${convert.from}To${convert.to} implements DrillSimpleFunc {
     // Get the desired output format
     byte[] buf = new byte[right.end - right.start];
     right.buffer.getBytes(right.start, buf, 0, right.end - right.start);
-    String formatString = new String(buf, com.google.common.base.Charsets.UTF_8);
+    String formatString = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
     format = org.joda.time.format.DateTimeFormat.forPattern(formatString);
   }
 
@@ -75,7 +75,7 @@ public class G${convert.from}To${convert.to} implements DrillSimpleFunc {
     // Get the input
     byte[] buf1 = new byte[left.end - left.start];
     left.buffer.getBytes(left.start, buf1, 0, left.end - left.start);
-    String input = new String(buf1, com.google.common.base.Charsets.UTF_8);
+    String input = new String(buf1, java.nio.charset.StandardCharsets.UTF_8);
 
     <#if convert.to == "Date" || convert.to == "NullableDate">
     out.value = (org.joda.time.DateMidnight.parse(input, format).withZoneRetainFields(org.joda.time.DateTimeZone.UTC)).getMillis();

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastVarCharDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastVarCharDecimal.java
@@ -92,7 +92,7 @@ public class CastEmptyString${type.from}To${type.to} implements DrillSimpleFunc 
 
     byte[] buf = new byte[in.end - in.start];
     in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-    String s = new String(buf, com.google.common.base.Charsets.UTF_8);
+    String s = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
     java.math.BigDecimal bd = new java.math.BigDecimal(s);
 
     org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(bd, precision.value, scale.value);

--- a/exec/java-exec/src/main/codegen/templates/SqlAccessors.java
+++ b/exec/java-exec/src/main/codegen/templates/SqlAccessors.java
@@ -174,7 +174,7 @@ public class ${name}Accessor extends AbstractSqlAccessor {
         return null;
       }
      </#if>
-      return new InputStreamReader(getStream(index), Charsets.UTF_8);
+      return new InputStreamReader(getStream(index), StandardCharsets.UTF_8);
     }
 
     @Override
@@ -184,7 +184,7 @@ public class ${name}Accessor extends AbstractSqlAccessor {
         return null;
       }
      </#if>
-      return new String(getBytes(index), Charsets.UTF_8);
+      return new String(getBytes(index), StandardCharsets.UTF_8);
     }
       <#break>
 
@@ -197,7 +197,7 @@ public class ${name}Accessor extends AbstractSqlAccessor {
         return null;
       }
      </#if>
-      return new InputStreamReader(getStream(index), Charsets.UTF_16);
+      return new InputStreamReader(getStream(index), StandardCharsets.UTF_16);
     }
 
     @Override
@@ -207,7 +207,7 @@ public class ${name}Accessor extends AbstractSqlAccessor {
         return null;
       }
      </#if>
-      return new String(getBytes(index), Charsets.UTF_16);
+      return new String(getBytes(index), StandardCharsets.UTF_16);
     }
       <#break>
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.client;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.util.VectorUtil;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 
@@ -125,7 +124,7 @@ public class QuerySubmitter {
 
       String plan;
       if (queryString == null) {
-        plan = Charsets.UTF_8.decode(ByteBuffer.wrap(Files.readAllBytes(Paths.get(planLocation)))).toString();
+        plan = StandardCharsets.UTF_8.decode(ByteBuffer.wrap(Files.readAllBytes(Paths.get(planLocation)))).toString();
       } else {
         plan = queryString;
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/JDKClassCompiler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/JDKClassCompiler.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.compile;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -75,7 +76,8 @@ class JDKClassCompiler extends AbstractClassCompiler {
   private DrillJavaFileObject doCompile(final ClassNames className, final String sourceCode)
       throws CompileException, IOException, ClassNotFoundException {
     // JavaFileManager should be closed after its usage to release all resources opened by this file manager
-    try (JavaFileManager fileManager = new DrillJavaFileManager(compiler.getStandardFileManager(listener, null, StandardCharsets.UTF_8), classLoader)) {
+    try (JavaFileManager fileManager = new DrillJavaFileManager(
+        compiler.getStandardFileManager(listener, null, StandardCharsets.UTF_8), classLoader)) {
       // Create one Java source file in memory, which will be compiled later.
       DrillJavaFileObject compilationUnit = new DrillJavaFileObject(className.dot, sourceCode);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/JDKClassCompiler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/JDKClassCompiler.java
@@ -32,7 +32,6 @@ import javax.tools.ToolProvider;
 import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
 import org.codehaus.commons.compiler.CompileException;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +75,7 @@ class JDKClassCompiler extends AbstractClassCompiler {
   private DrillJavaFileObject doCompile(final ClassNames className, final String sourceCode)
       throws CompileException, IOException, ClassNotFoundException {
     // JavaFileManager should be closed after its usage to release all resources opened by this file manager
-    try (JavaFileManager fileManager = new DrillJavaFileManager(compiler.getStandardFileManager(listener, null, Charsets.UTF_8), classLoader)) {
+    try (JavaFileManager fileManager = new DrillJavaFileManager(compiler.getStandardFileManager(listener, null, StandardCharsets.UTF_8), classLoader)) {
       // Create one Java source file in memory, which will be compiled later.
       DrillJavaFileObject compilationUnit = new DrillJavaFileObject(className.dot, sourceCode);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/AbstractSqlPatternMatcher.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/AbstractSqlPatternMatcher.java
@@ -21,9 +21,9 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.drill.common.exceptions.UserException;
-import com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +53,7 @@ public abstract class AbstractSqlPatternMatcher implements SqlPatternMatcher {
   public AbstractSqlPatternMatcher(String patternString) {
     this.patternString = patternString;
 
-    CharsetEncoder charsetEncoder = Charsets.UTF_8.newEncoder();
+    CharsetEncoder charsetEncoder = StandardCharsets.UTF_8.newEncoder();
     CharBuffer patternCharBuffer = CharBuffer.wrap(patternString);
 
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MappifyUtility.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MappifyUtility.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.expr.fn.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MappifyUtility.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MappifyUtility.java
@@ -27,7 +27,6 @@ import org.apache.drill.exec.vector.complex.MapUtility;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter;
 
-import com.google.common.base.Charsets;
 
 import io.netty.buffer.DrillBuf;
 
@@ -70,7 +69,7 @@ public class MappifyUtility {
 
       // write "key":"columnname" into the map
       VarCharHolder vh = new VarCharHolder();
-      byte[] b = str.getBytes(Charsets.UTF_8);
+      byte[] b = str.getBytes(StandardCharsets.UTF_8);
       buffer = buffer.reallocIfNeeded(b.length);
       buffer.setBytes(0, b);
       vh.start = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SimpleCastFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SimpleCastFunctions.java
@@ -30,6 +30,8 @@ import org.apache.drill.exec.expr.holders.BigIntHolder;
 import org.apache.drill.exec.expr.holders.BitHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
+import java.nio.charset.StandardCharsets;
+
 
 public class SimpleCastFunctions {
 
@@ -46,7 +48,7 @@ public class SimpleCastFunctions {
     public void eval() {
       byte[] buf = new byte[in.end - in.start];
       in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-      String input = new String(buf, com.google.common.base.Charsets.UTF_8);
+      String input = new String(buf, StandardCharsets.UTF_8);
       out.value = org.apache.drill.common.types.BooleanType.get(input).getNumericValue();
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SimpleCastFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SimpleCastFunctions.java
@@ -30,9 +30,6 @@ import org.apache.drill.exec.expr.holders.BigIntHolder;
 import org.apache.drill.exec.expr.holders.BitHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
-import java.nio.charset.StandardCharsets;
-
-
 public class SimpleCastFunctions {
 
   @FunctionTemplate(names = {"castBIT", "castBOOLEAN"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.NULL_IF_NULL)
@@ -48,7 +45,7 @@ public class SimpleCastFunctions {
     public void eval() {
       byte[] buf = new byte[in.end - in.start];
       in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
-      String input = new String(buf, StandardCharsets.UTF_8);
+      String input = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
       out.value = org.apache.drill.common.types.BooleanType.get(input).getNumericValue();
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctionHelpers.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctionHelpers.java
@@ -86,13 +86,13 @@ public class StringFunctionHelpers {
   private static NumberFormatException nfeL(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    return new NumberFormatException(new String(buf, com.google.common.base.Charsets.UTF_8));
+    return new NumberFormatException(new String(buf, StandardCharsets.UTF_8));
   }
 
   private static NumberFormatException nfeI(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    return new NumberFormatException(new String(buf, com.google.common.base.Charsets.UTF_8));
+    return new NumberFormatException(new String(buf, StandardCharsets.UTF_8));
   }
 
   public static int varTypesToInt(final int start, final int end, DrillBuf buffer) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctionHelpers.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctionHelpers.java
@@ -26,8 +26,6 @@ import org.joda.time.chrono.ISOChronology;
 import io.netty.buffer.DrillBuf;
 import io.netty.util.internal.PlatformDependent;
 
-import java.nio.charset.StandardCharsets;
-
 public class StringFunctionHelpers {
 
   static final int RADIX = 10;
@@ -86,13 +84,13 @@ public class StringFunctionHelpers {
   private static NumberFormatException nfeL(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    return new NumberFormatException(new String(buf, StandardCharsets.UTF_8));
+    return new NumberFormatException(new String(buf, java.nio.charset.StandardCharsets.UTF_8));
   }
 
   private static NumberFormatException nfeI(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    return new NumberFormatException(new String(buf, StandardCharsets.UTF_8));
+    return new NumberFormatException(new String(buf, java.nio.charset.StandardCharsets.UTF_8));
   }
 
   public static int varTypesToInt(final int start, final int end, DrillBuf buffer) {
@@ -191,14 +189,14 @@ public class StringFunctionHelpers {
   public static String toStringFromUTF8(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    String s = new String(buf, StandardCharsets.UTF_8);
+    String s = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
     return s;
   }
 
   public static String toStringFromUTF16(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    return new String(buf, StandardCharsets.UTF_16);
+    return new String(buf, java.nio.charset.StandardCharsets.UTF_16);
   }
 
   private static final ISOChronology CHRONOLOGY = org.joda.time.chrono.ISOChronology.getInstanceUTC();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctionHelpers.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctionHelpers.java
@@ -21,11 +21,12 @@ import static org.apache.drill.exec.memory.BoundsChecking.rangeCheck;
 
 import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
-import com.google.common.base.Charsets;
 import org.joda.time.chrono.ISOChronology;
 
 import io.netty.buffer.DrillBuf;
 import io.netty.util.internal.PlatformDependent;
+
+import java.nio.charset.StandardCharsets;
 
 public class StringFunctionHelpers {
 
@@ -190,14 +191,14 @@ public class StringFunctionHelpers {
   public static String toStringFromUTF8(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    String s = new String(buf, Charsets.UTF_8);
+    String s = new String(buf, StandardCharsets.UTF_8);
     return s;
   }
 
   public static String toStringFromUTF16(int start, int end, DrillBuf buffer) {
     byte[] buf = new byte[end - start];
     buffer.getBytes(start, buf, 0, end - start);
-    return new String(buf, Charsets.UTF_16);
+    return new String(buf, StandardCharsets.UTF_16);
   }
 
   private static final ISOChronology CHRONOLOGY = org.joda.time.chrono.ISOChronology.getInstanceUTC();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -537,7 +537,7 @@ public class StringFunctions{
       } else {
         int arrayIndex = index.value - 1;
         result =
-            com.google.common.collect.Iterables.get(splitter.split(inputString), arrayIndex, "");
+          (String) com.google.common.collect.Iterables.get(splitter.split(inputString), arrayIndex, "");
       }
       byte[] strBytes = result.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -40,7 +40,6 @@ import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
 import javax.inject.Inject;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 public class StringFunctions{
 
@@ -335,7 +334,7 @@ public class StringFunctions{
         org.apache.drill.exec.vector.complex.writer.VarCharWriter varCharWriter = listWriter.varChar();
 
         for(int i = 1; i <= matcher.groupCount(); i++) {
-          final byte[] strBytes = matcher.group(i).getBytes(StandardCharsets.UTF_8);
+          final byte[] strBytes = matcher.group(i).getBytes(java.nio.charset.StandardCharsets.UTF_8);
           buffer = buffer.reallocIfNeeded(strBytes.length);
           buffer.setBytes(0, strBytes);
           varCharWriter.writeVarChar(0, strBytes.length, buffer);
@@ -387,7 +386,7 @@ public class StringFunctions{
       boolean result = matcher.find();
 
       if (result) {
-        byte[] strBytes = matcher.group(index).getBytes(StandardCharsets.UTF_8);
+        byte[] strBytes = matcher.group(index).getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         out.buffer = buffer = buffer.reallocIfNeeded(strBytes.length);
         out.start = 0;
@@ -540,7 +539,7 @@ public class StringFunctions{
         result =
             com.google.common.collect.Iterables.get(splitter.split(inputString), arrayIndex, "");
       }
-      byte[] strBytes = result.getBytes(StandardCharsets.UTF_8);
+      byte[] strBytes = result.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
       out.buffer = buffer = buffer.reallocIfNeeded(strBytes.length);
       out.start = 0;
@@ -628,7 +627,7 @@ public class StringFunctions{
             .split(inputString), arrayIndex), end.value - start.value + 1)
           .iterator();
       }
-      byte[] strBytes = joiner.join(iterator).getBytes(StandardCharsets.UTF_8);
+      byte[] strBytes = joiner.join(iterator).getBytes(java.nio.charset.StandardCharsets.UTF_8);
       out.buffer = buffer = buffer.reallocIfNeeded(strBytes.length);
       out.start = 0;
       out.end = strBytes.length;
@@ -682,7 +681,7 @@ public class StringFunctions{
     @Override
     public void eval() {
       String str = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
-      byte[] result = str.toLowerCase().getBytes(StandardCharsets.UTF_8);
+      byte[] result = str.toLowerCase().getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
       out.buffer = buffer = buffer.reallocIfNeeded(result.length);
       out.start = 0;
@@ -712,7 +711,7 @@ public class StringFunctions{
     @Override
     public void eval() {
       String str = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
-      byte[] result = str.toUpperCase().getBytes(StandardCharsets.UTF_8);
+      byte[] result = str.toUpperCase().getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
       out.buffer = buffer = buffer.reallocIfNeeded(result.length);
       out.start = 0;
@@ -971,7 +970,7 @@ public class StringFunctions{
     public void eval() {
       String source = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
       String result = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.initCap(source);
-      byte[] bytes = result.getBytes(StandardCharsets.UTF_8);
+      byte[] bytes = result.getBytes(java.nio.charset.StandardCharsets.UTF_8);
       out.buffer = buffer = buffer.reallocIfNeeded(bytes.length);
       out.start = 0;
       out.end = bytes.length;
@@ -1600,7 +1599,7 @@ public class StringFunctions{
       list.startList();
       org.apache.drill.exec.vector.complex.writer.VarCharWriter varCharWriter = list.varChar();
       for (Object token : tokens) {
-        final byte[] strBytes = ((String) token).getBytes(StandardCharsets.UTF_8);
+        final byte[] strBytes = ((String) token).getBytes(java.nio.charset.StandardCharsets.UTF_8);
         buffer = buffer.reallocIfNeeded(strBytes.length);
         buffer.setBytes(0, strBytes);
         varCharWriter.writeVarChar(0, strBytes.length, buffer);
@@ -1932,7 +1931,7 @@ public class StringFunctions{
       for (int i = in.start; i < in.end; i++, index++) {
         bytea[index] = in.buffer.getByte(i);
       }
-      final byte[] outBytea = new String(bytea, inCharset).getBytes(StandardCharsets.UTF_8);
+      final byte[] outBytea = new String(bytea, inCharset).getBytes(java.nio.charset.StandardCharsets.UTF_8);
       out.buffer = buffer = buffer.reallocIfNeeded(outBytea.length);
       out.buffer.setBytes(0, outBytea);
       out.start = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -40,6 +40,7 @@ import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
 import javax.inject.Inject;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class StringFunctions{
 
@@ -334,7 +335,7 @@ public class StringFunctions{
         org.apache.drill.exec.vector.complex.writer.VarCharWriter varCharWriter = listWriter.varChar();
 
         for(int i = 1; i <= matcher.groupCount(); i++) {
-          final byte[] strBytes = matcher.group(i).getBytes(com.google.common.base.Charsets.UTF_8);
+          final byte[] strBytes = matcher.group(i).getBytes(StandardCharsets.UTF_8);
           buffer = buffer.reallocIfNeeded(strBytes.length);
           buffer.setBytes(0, strBytes);
           varCharWriter.writeVarChar(0, strBytes.length, buffer);
@@ -386,7 +387,7 @@ public class StringFunctions{
       boolean result = matcher.find();
 
       if (result) {
-        byte[] strBytes = matcher.group(index).getBytes(com.google.common.base.Charsets.UTF_8);
+        byte[] strBytes = matcher.group(index).getBytes(StandardCharsets.UTF_8);
 
         out.buffer = buffer = buffer.reallocIfNeeded(strBytes.length);
         out.start = 0;
@@ -537,9 +538,9 @@ public class StringFunctions{
       } else {
         int arrayIndex = index.value - 1;
         result =
-          (String) com.google.common.collect.Iterables.get(splitter.split(inputString), arrayIndex, "");
+            com.google.common.collect.Iterables.get(splitter.split(inputString), arrayIndex, "");
       }
-      byte[] strBytes = result.getBytes(com.google.common.base.Charsets.UTF_8);
+      byte[] strBytes = result.getBytes(StandardCharsets.UTF_8);
 
       out.buffer = buffer = buffer.reallocIfNeeded(strBytes.length);
       out.start = 0;
@@ -627,8 +628,7 @@ public class StringFunctions{
             .split(inputString), arrayIndex), end.value - start.value + 1)
           .iterator();
       }
-      byte[] strBytes = joiner.join(iterator).getBytes(
-        com.google.common.base.Charsets.UTF_8);
+      byte[] strBytes = joiner.join(iterator).getBytes(StandardCharsets.UTF_8);
       out.buffer = buffer = buffer.reallocIfNeeded(strBytes.length);
       out.start = 0;
       out.end = strBytes.length;
@@ -682,7 +682,7 @@ public class StringFunctions{
     @Override
     public void eval() {
       String str = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
-      byte[] result = str.toLowerCase().getBytes(com.google.common.base.Charsets.UTF_8);
+      byte[] result = str.toLowerCase().getBytes(StandardCharsets.UTF_8);
 
       out.buffer = buffer = buffer.reallocIfNeeded(result.length);
       out.start = 0;
@@ -712,7 +712,7 @@ public class StringFunctions{
     @Override
     public void eval() {
       String str = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
-      byte[] result = str.toUpperCase().getBytes(com.google.common.base.Charsets.UTF_8);
+      byte[] result = str.toUpperCase().getBytes(StandardCharsets.UTF_8);
 
       out.buffer = buffer = buffer.reallocIfNeeded(result.length);
       out.start = 0;
@@ -971,7 +971,7 @@ public class StringFunctions{
     public void eval() {
       String source = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(input.start, input.end, input.buffer);
       String result = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.initCap(source);
-      byte[] bytes = result.getBytes(com.google.common.base.Charsets.UTF_8);
+      byte[] bytes = result.getBytes(StandardCharsets.UTF_8);
       out.buffer = buffer = buffer.reallocIfNeeded(bytes.length);
       out.start = 0;
       out.end = bytes.length;
@@ -1600,7 +1600,7 @@ public class StringFunctions{
       list.startList();
       org.apache.drill.exec.vector.complex.writer.VarCharWriter varCharWriter = list.varChar();
       for (Object token : tokens) {
-        final byte[] strBytes = ((String) token).getBytes(com.google.common.base.Charsets.UTF_8);
+        final byte[] strBytes = ((String) token).getBytes(StandardCharsets.UTF_8);
         buffer = buffer.reallocIfNeeded(strBytes.length);
         buffer.setBytes(0, strBytes);
         varCharWriter.writeVarChar(0, strBytes.length, buffer);
@@ -1932,7 +1932,7 @@ public class StringFunctions{
       for (int i = in.start; i < in.end; i++, index++) {
         bytea[index] = in.buffer.getByte(i);
       }
-      final byte[] outBytea = new String(bytea, inCharset).getBytes(com.google.common.base.Charsets.UTF_8);
+      final byte[] outBytea = new String(bytea, inCharset).getBytes(StandardCharsets.UTF_8);
       out.buffer = buffer = buffer.reallocIfNeeded(outBytea.length);
       out.buffer.setBytes(0, outBytea);
       out.start = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/convert/AbstractConvertFromString.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/convert/AbstractConvertFromString.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.scan.convert;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Function;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/convert/AbstractConvertFromString.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/convert/AbstractConvertFromString.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
-import com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,6 +218,6 @@ public abstract class AbstractConvertFromString extends DirectConverter {
 
   @Override
   public void setBytes(byte[] bytes, int length) {
-    setString(new String(bytes, 0, length, Charsets.UTF_8));
+    setString(new String(bytes, 0, length, StandardCharsets.UTF_8));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.common.util.GuavaUtils;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -122,7 +121,7 @@ public class FileSystemPartitionDescriptor extends AbstractPartitionDescriptor {
           // set null if dirX does not exist for the location.
           ((NullableVarCharVector) vectors[partitionColumnIndex]).getMutator().setNull(record);
         } else {
-          byte[] bytes = (partitionLocation.getPartitionValue(partitionColumnIndex)).getBytes(Charsets.UTF_8);
+          byte[] bytes = (partitionLocation.getPartitionValue(partitionColumnIndex)).getBytes(StandardCharsets.UTF_8);
           ((NullableVarCharVector) vectors[partitionColumnIndex]).getMutator().setSafe(record, bytes, 0, bytes.length);
         }
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/security/HtpasswdFileUserAuthenticator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/security/HtpasswdFileUserAuthenticator.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.rpc.user.security;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.codec.digest.Md5Crypt;
-import org.apache.commons.io.Charsets;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
@@ -29,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.HashMap;
@@ -80,7 +80,7 @@ public class HtpasswdFileUserAuthenticator implements UserAuthenticator {
     if (hash.startsWith("$apr1$")) {
       return hash.equals(Md5Crypt.apr1Crypt(password, hash));
     } else if (hash.startsWith("$1$")) {
-      return hash.equals(Md5Crypt.md5Crypt(password.getBytes(Charsets.UTF_8), hash));
+      return hash.equals(Md5Crypt.md5Crypt(password.getBytes(StandardCharsets.UTF_8), hash));
     } else if (hash.startsWith("{SHA}")) {
       return hash.substring(5).equals(Base64.getEncoder().encodeToString(DigestUtils.sha1(password)));
     } else if (hash.startsWith("$2y$")) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/PluginBootstrapLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/PluginBootstrapLoaderImpl.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.planner.logical.StoragePlugins;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.util.ActionOnFile;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -331,7 +330,7 @@ public class PluginBootstrapLoaderImpl implements PluginBootstrapLoader {
   }
 
   private StoragePlugins getPluginsFromResource(URL resource) throws IOException {
-    String pluginsData = Resources.toString(resource, Charsets.UTF_8);
+    String pluginsData = Resources.toString(resource, StandardCharsets.UTF_8);
     return context.hoconMapper().readValue(pluginsData, StoragePlugins.class);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/PluginBootstrapLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/PluginBootstrapLoaderImpl.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroColumnConverterFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroColumnConverterFactory.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroColumnConverterFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroColumnConverterFactory.java
@@ -38,7 +38,6 @@ import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.accessor.TupleWriter;
 import org.apache.drill.exec.vector.accessor.ValueWriter;
-import com.google.common.base.Charsets;
 import org.joda.time.DateTimeConstants;
 import org.joda.time.Period;
 
@@ -74,7 +73,7 @@ public class AvroColumnConverterFactory extends ColumnConverterFactory {
             binary = utf8.getBytes();
             length = utf8.getByteLength();
           } else {
-            binary = value.toString().getBytes(Charsets.UTF_8);
+            binary = value.toString().getBytes(StandardCharsets.UTF_8);
             length = binary.length;
           }
           writer.setBytes(binary, length);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/HeaderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/HeaderBuilder.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/HeaderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/HeaderBuilder.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.store.easy.text.reader;
 
 import org.apache.drill.common.exceptions.UserException;
-import com.google.common.base.Charsets;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +86,7 @@ public class HeaderBuilder implements TextOutput {
 
   @Override
   public boolean endField() {
-    String header = new String(currentField.array(), 0, currentField.position(), Charsets.UTF_8);
+    String header = new String(currentField.array(), 0, currentField.position(), StandardCharsets.UTF_8);
     header = validateSymbol(header);
     headers.add(header);
     return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextParsingSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextParsingSettings.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.store.easy.text.reader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.easy.text.TextFormatPlugin;
 import org.apache.drill.exec.store.easy.text.TextFormatConfig;
-import com.google.common.base.Charsets;
 
 import java.nio.charset.StandardCharsets;
 
@@ -72,7 +71,7 @@ public class TextParsingSettings {
     byte commentChar = bSafe(config.getComment(), "comment");
     byte quoteChar = bSafe(config.getQuote(), "quote");
     byte quoteEscapeChar = bSafe(config.getEscape(), "escape");
-    byte[] newlineDelim = config.getLineDelimiter().getBytes(Charsets.UTF_8);
+    byte[] newlineDelim = config.getLineDelimiter().getBytes(StandardCharsets.UTF_8);
     if (providedSchema != null) {
       extractHeaders = providedSchema.booleanProperty(
           TextFormatPlugin.HAS_HEADERS_PROP, extractHeaders);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorageEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorageEngine.java
@@ -46,7 +46,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 
@@ -152,7 +151,7 @@ public class MockStorageEngine extends AbstractStoragePlugin {
       }
       MockTableDef mockTableDefn;
       try {
-        String json = Resources.toString(url, Charsets.UTF_8);
+        String json = Resources.toString(url, StandardCharsets.UTF_8);
         final ObjectMapper mapper = JacksonUtils.createObjectMapper();
         mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
         mockTableDefn = mapper.readValue(json, MockTableDef.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorageEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorageEngine.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.mock;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoWriters.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoWriters.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.pojo;
 import io.netty.buffer.DrillBuf;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoWriters.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoWriters.java
@@ -39,7 +39,6 @@ import org.apache.drill.exec.vector.NullableIntVector;
 import org.apache.drill.exec.vector.NullableTimeStampVector;
 import org.apache.drill.exec.vector.NullableVarCharVector;
 
-import com.google.common.base.Charsets;
 import org.apache.drill.exec.vector.VarDecimalVector;
 
 public class PojoWriters {
@@ -204,7 +203,7 @@ public class PojoWriters {
 
     public void writeString(String s, int outboundIndex) {
       holder.isSet = 1;
-      byte[] bytes = s.getBytes(Charsets.UTF_8);
+      byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
       ensureLength(bytes.length);
       data.clear();
       data.writeBytes(bytes);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/EncodedSchemaPathSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/EncodedSchemaPathSet.java
@@ -28,7 +28,7 @@ import org.apache.drill.exec.planner.physical.PlannerSettings;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -71,27 +71,11 @@ public class EncodedSchemaPathSet {
 
 
   private static byte[] encodeUTF(String input) {
-    try {
-      return input.getBytes(UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      throw new DrillRuntimeException(e); // should never come to this
-    }
-  }
-
-  private static String decodeUTF(byte[] input) {
-    try {
-      return new String(input, UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      throw new DrillRuntimeException(e); // should never come to this
-    }
+    return input.getBytes(StandardCharsets.UTF_8);
   }
 
   private static String decodeUTF(byte[] input, int offset, int length) {
-    try {
-      return new String(input, offset, length, UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      throw new DrillRuntimeException(e); // should never come to this
-    }
+    return new String(input, offset, length, StandardCharsets.UTF_8);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.vector.complex.fn.VectorOutput.MapVectorOutput;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -169,7 +168,7 @@ public class JsonReader extends BaseJsonReader {
   }
 
   public void setSource(String data) throws IOException {
-    setSource(data.getBytes(Charsets.UTF_8));
+    setSource(data.getBytes(StandardCharsets.UTF_8));
   }
 
   public void setSource(byte[] bytes) throws IOException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.vector.complex.fn;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.common.exceptions.UserException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/WorkingBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/WorkingBuffer.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import org.apache.drill.exec.expr.holders.VarBinaryHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
-import com.google.common.base.Charsets;
 
 class WorkingBuffer {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WorkingBuffer.class);
@@ -40,7 +39,7 @@ class WorkingBuffer {
   }
 
   public void prepareVarCharHolder(String value, VarCharHolder h) throws IOException {
-    byte[] b = value.getBytes(Charsets.UTF_8);
+    byte[] b = value.getBytes(StandardCharsets.UTF_8);
     ensure(b.length);
     workBuf.setBytes(0, b);
     h.start = 0;
@@ -49,7 +48,7 @@ class WorkingBuffer {
   }
 
   public int prepareVarCharHolder(String value) throws IOException {
-    byte[] b = value.getBytes(Charsets.UTF_8);
+    byte[] b = value.getBytes(StandardCharsets.UTF_8);
     ensure(b.length);
     workBuf.setBytes(0, b);
     return b.length;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/WorkingBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/WorkingBuffer.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.vector.complex.fn;
 import io.netty.buffer.DrillBuf;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.drill.exec.expr.holders.VarBinaryHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -58,7 +58,6 @@ import org.junit.Rule;
 import org.junit.rules.TestRule;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import org.mockito.Matchers;
@@ -155,6 +154,6 @@ public class PlanningBase extends ExecTest {
     if (url == null) {
       throw new IOException(String.format("Unable to find path %s.", resource));
     }
-    return Resources.toString(url, Charsets.UTF_8);
+    return Resources.toString(url, StandardCharsets.UTF_8);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -19,6 +19,7 @@ package org.apache.drill;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.calcite.jdbc.DynamicSchema;
 import org.apache.drill.exec.alias.AliasRegistryProvider;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.drill.common.config.DrillConfig;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
@@ -35,7 +35,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.Files;
 
@@ -51,7 +50,7 @@ public class RunRootExec {
     bit.run();
     DrillbitContext bitContext = bit.getContext();
     PhysicalPlanReader reader = bitContext.getPlanReader();
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(new File(path), Charsets.UTF_8).read());
+    PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(new File(path), StandardCharsets.UTF_8).read());
     FunctionImplementationRegistry registry = bitContext.getFunctionImplementationRegistry();
     FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), null, registry);
     SimpleRootExec exec;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.SlowTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
@@ -32,7 +32,6 @@ import org.apache.drill.exec.vector.BigIntVector;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -84,7 +83,7 @@ public class TestQueriesOnLargeFile extends BaseTestQuery {
   @Test
   public void testMergingReceiver() throws Exception {
     String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile("/largefiles/merging_receiver_large_data.json"),
-        Charsets.UTF_8).read().replace("#{TEST_FILE}", escapeJsonString(dataFile.getPath()));
+        StandardCharsets.UTF_8).read().replace("#{TEST_FILE}", escapeJsonString(dataFile.getPath()));
     List<QueryDataBatch> results = testPhysicalWithResults(plan);
 
     int recordsInOutput = 0;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
@@ -18,6 +18,8 @@
 package org.apache.drill.exec.client;
 
 import static org.junit.Assert.assertFalse;
+
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.exec.DrillSystemTestBase;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
@@ -28,7 +28,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 
@@ -40,7 +39,7 @@ public class DrillClientSystemTest extends DrillSystemTestBase {
   @BeforeClass
   public void setUp() throws Exception {
     this.setUp();
-    plan = Resources.toString(Resources.getResource("simple_plan.json"), Charsets.UTF_8);
+    plan = Resources.toString(Resources.getResource("simple_plan.json"), StandardCharsets.UTF_8);
 
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.mockito.Mockito;
@@ -63,7 +62,7 @@ public class DumpCatTest  extends ExecTest {
       final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
       final PhysicalPlanReader reader = defaultPhysicalPlanReader(c);
-      final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/simple_trace.json"), Charsets.UTF_8).read());
+      final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/simple_trace.json"), StandardCharsets.UTF_8).read());
       final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
       final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
       final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
@@ -21,6 +21,7 @@ import static org.apache.drill.exec.planner.PhysicalPlanReaderTestFactory.defaul
 import static org.junit.Assert.assertTrue;
 
 import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.DrillFileUtils;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunction.java
@@ -35,7 +35,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -52,7 +51,7 @@ public class TestAggregateFunction extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile(planPath), Charsets.UTF_8).read().replace("#{TEST_FILE}", dataPath));
+          Files.asCharSource(DrillFileUtils.getResourceAsFile(planPath), StandardCharsets.UTF_8).read().replace("#{TEST_FILE}", dataPath));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunction.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.fn.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateFunctions.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.fn.impl;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
@@ -51,7 +50,7 @@ public class TestDateFunctions extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-        Files.asCharSource(DrillFileUtils.getResourceAsFile(physicalPlan), Charsets.UTF_8).read()
+        Files.asCharSource(DrillFileUtils.getResourceAsFile(physicalPlan), StandardCharsets.UTF_8).read()
           .replace("#{TEST_FILE}", resourceFile));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateFunctions.java
@@ -35,6 +35,8 @@ import org.joda.time.LocalTime;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctions.java
@@ -41,7 +41,6 @@ import org.apache.drill.exec.vector.Float8Vector;
 import org.apache.drill.exec.vector.IntVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -58,7 +57,7 @@ public class TestMathFunctions extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/simple_math_functions.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/simple_math_functions.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, BitControl.PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctions.java
@@ -46,6 +46,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(OperatorTest.class)
 public class TestMathFunctions extends ExecTest {
   private final DrillConfig c = DrillConfig.create();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMultiInputAdd.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMultiInputAdd.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -51,7 +50,7 @@ public class TestMultiInputAdd extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-        Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/multi_input_add_test.json"), Charsets.UTF_8).read());
+        Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/multi_input_add_test.json"), StandardCharsets.UTF_8).read());
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMultiInputAdd.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMultiInputAdd.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.fn.impl;
 
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;
@@ -50,7 +51,8 @@ public class TestMultiInputAdd extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-        Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/multi_input_add_test.json"), StandardCharsets.UTF_8).read());
+        Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/multi_input_add_test.json"),
+            StandardCharsets.UTF_8).read());
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewAggregateFunctions.java
@@ -35,7 +35,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -56,7 +55,7 @@ public class TestNewAggregateFunctions extends PopUnitTestBase {
       List<QueryDataBatch> results = client.runQuery(
           QueryType.PHYSICAL,
           Files.asCharSource(DrillFileUtils.getResourceAsFile(physicalPlan),
-              Charsets.UTF_8).read().replace("#{TEST_FILE}",
+              StandardCharsets.UTF_8).read().replace("#{TEST_FILE}",
               inputDataFile));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewAggregateFunctions.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.fn.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewMathFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewMathFunctions.java
@@ -51,7 +51,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 import java.io.File;
@@ -90,7 +89,7 @@ public class TestNewMathFunctions extends BaseTestQuery {
     final DrillbitContext bitContext = mockDrillbitContext();
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
-    final String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
+    final String planString = Resources.toString(Resources.getResource(planPath), StandardCharsets.UTF_8);
     if (reader == null) {
       reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewMathFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewMathFunctions.java
@@ -55,6 +55,7 @@ import com.google.common.io.Resources;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestRepeatedFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestRepeatedFunction.java
@@ -46,6 +46,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(OperatorTest.class)
 public class TestRepeatedFunction extends ExecTest {
   private final DrillConfig c = DrillConfig.create();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestRepeatedFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestRepeatedFunction.java
@@ -41,7 +41,6 @@ import org.apache.drill.exec.vector.BitVector;
 import org.apache.drill.exec.vector.IntVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -57,7 +56,7 @@ public class TestRepeatedFunction extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_repeated_1.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_repeated_1.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonationPrivileges.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonationPrivileges.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonationPrivileges.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonationPrivileges.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.impersonation;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.categories.SecurityTest;
 import org.apache.drill.common.util.DrillFileUtils;
@@ -44,7 +43,7 @@ public class TestInboundImpersonationPrivileges extends BaseTestImpersonation {
   static {
     try {
       IMPERSONATION_POLICIES = Files.asCharSource(DrillFileUtils.getResourceAsFile("/inbound_impersonation_policies.json"),
-          Charsets.UTF_8).read();
+          StandardCharsets.UTF_8).read();
     } catch (final IOException e) {
       throw new RuntimeException("Cannot load impersonation policies.", e);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import io.netty.buffer.DrillBuf;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
@@ -56,7 +56,6 @@ import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.test.DrillTest;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
@@ -205,7 +204,7 @@ public class TestAllocators extends DrillTest {
       PhysicalPlanReader planReader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(bitContext,
           storageRegistry);
       PhysicalPlan plan = planReader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(planFile),
-          Charsets.UTF_8).read());
+          StandardCharsets.UTF_8).read());
       List<PhysicalOperator> physicalOperators = plan.getSortedOperators();
       Iterator<PhysicalOperator> physicalOperatorIterator = physicalOperators.iterator();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/config/TestParsePhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/config/TestParsePhysicalPlan.java
@@ -34,6 +34,8 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(PlannerTest.class)
 public class TestParsePhysicalPlan extends ExecTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestParsePhysicalPlan.class);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/config/TestParsePhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/config/TestParsePhysicalPlan.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -49,7 +48,7 @@ public class TestParsePhysicalPlan extends ExecTest {
     PhysicalPlanReader reader = new PhysicalPlanReader(c, scanResult, lpp, CoordinationProtos.DrillbitEndpoint.getDefaultInstance(), null);
     ObjectReader r = lpp.getMapper().reader(PhysicalPlan.class);
     ObjectWriter writer = lpp.getMapper().writer();
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_test1.json"), Charsets.UTF_8).read());
+    PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_test1.json"), StandardCharsets.UTF_8).read());
     plan.unparse(writer);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
@@ -32,7 +32,6 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -51,7 +50,7 @@ public class TestBroadcastExchange extends PopUnitTestBase {
       client.connect();
 
       String physicalPlan = Files.asCharSource(
-              DrillFileUtils.getResourceAsFile("/sender/broadcast_exchange.json"), Charsets.UTF_8).read()
+              DrillFileUtils.getResourceAsFile("/sender/broadcast_exchange.json"), StandardCharsets.UTF_8).read()
               .replace("#{LEFT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_single_batch.left.json").toURI().toString())
               .replace("#{RIGHT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_single_batch.right.json").toURI().toString());
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, physicalPlan);
@@ -79,7 +78,7 @@ public class TestBroadcastExchange extends PopUnitTestBase {
       client.connect();
 
       String physicalPlan = Files.asCharSource(
-          DrillFileUtils.getResourceAsFile("/sender/broadcast_exchange_long_run.json"), Charsets.UTF_8).read();
+          DrillFileUtils.getResourceAsFile("/sender/broadcast_exchange_long_run.json"), StandardCharsets.UTF_8).read();
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, physicalPlan);
       int count = 0;
       for (QueryDataBatch b : results) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
@@ -57,7 +57,6 @@ import org.apache.drill.exec.vector.VarBinaryVector;
 import org.apache.drill.exec.vector.VarCharVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.mockito.Mockito;
@@ -70,7 +69,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastBigInt.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastBigInt.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -107,7 +106,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastInt.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastInt.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -143,7 +142,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastFloat4.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastFloat4.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -180,7 +179,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastFloat8.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastFloat8.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -217,7 +216,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastVarChar.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastVarChar.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -253,7 +252,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastVarBinary.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastVarBinary.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -289,7 +288,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastNested.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastNested.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -326,7 +325,7 @@ public class TestCastFunctions extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastNumException.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastNumException.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(CONFIG);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -354,7 +353,7 @@ public class TestCastFunctions extends PopUnitTestBase {
 
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastVarCharNull.json"), Charsets.UTF_8).read().replace("#{TEST_FILE}", "/jsoninput/input1.json"));
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/testCastVarCharNull.json"), StandardCharsets.UTF_8).read().replace("#{TEST_FILE}", "/jsoninput/input1.json"));
 
       final QueryDataBatch batch = results.get(0);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.common.expression.ExpressionPosition;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastVarCharToBigInt.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastVarCharToBigInt.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 
@@ -50,7 +49,7 @@ public class TestCastVarCharToBigInt extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/test_cast_varchar_to_bigint.json"), Charsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/test_cast_varchar_to_bigint.json"), StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/scan_json_test_cast.json")
             );
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastVarCharToBigInt.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastVarCharToBigInt.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.common.util.DrillFileUtils;
@@ -49,7 +50,8 @@ public class TestCastVarCharToBigInt extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/test_cast_varchar_to_bigint.json"), StandardCharsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/test_cast_varchar_to_bigint.json"),
+                            StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/scan_json_test_cast.json")
             );
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestComparisonFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestComparisonFunctions.java
@@ -37,6 +37,8 @@ import com.google.common.io.Resources;
 
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 public class TestComparisonFunctions extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
   private final String COMPARISON_TEST_PHYSICAL_PLAN = "functions/comparisonTest.json";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestComparisonFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestComparisonFunctions.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.rpc.UserClientConnection;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 import org.mockito.Mockito;
@@ -48,7 +47,7 @@ public class TestComparisonFunctions extends ExecTest {
     final DrillbitContext bitContext = mockDrillbitContext();
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
-    final String planString = Resources.toString(Resources.getResource(COMPARISON_TEST_PHYSICAL_PLAN), Charsets.UTF_8).replaceAll("EXPRESSION", expression);
+    final String planString = Resources.toString(Resources.getResource(COMPARISON_TEST_PHYSICAL_PLAN), StandardCharsets.UTF_8).replaceAll("EXPRESSION", expression);
     if (reader == null) {
       reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
@@ -50,7 +50,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 import io.netty.buffer.DrillBuf;
@@ -530,7 +529,7 @@ public class TestConvertFunctions extends BaseTestQuery {
   @Test // DRILL-2326
   public void testBigIntVarCharReturnTripConvertLogical() throws Exception {
     String logicalPlan = Resources.toString(
-        Resources.getResource(CONVERSION_TEST_LOGICAL_PLAN), Charsets.UTF_8);
+        Resources.getResource(CONVERSION_TEST_LOGICAL_PLAN), StandardCharsets.UTF_8);
 
     List<String> compilers = Arrays.asList(ClassCompilerSelector.CompilerPolicy.JANINO.name(),
       ClassCompilerSelector.CompilerPolicy.JDK.name());
@@ -630,7 +629,7 @@ public class TestConvertFunctions extends BaseTestQuery {
     expression = expression.replace("\\", "\\\\\\\\"); // "\\\\\\\\" => Java => "\\\\" => JsonParser => "\\" => AntlrParser "\"
 
     if (textFileContent == null) {
-      textFileContent = Resources.toString(Resources.getResource(CONVERSION_TEST_PHYSICAL_PLAN), Charsets.UTF_8);
+      textFileContent = Resources.toString(Resources.getResource(CONVERSION_TEST_PHYSICAL_PLAN), StandardCharsets.UTF_8);
     }
     String planString = textFileContent.replace("__CONVERT_EXPRESSION__", expression);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.categories.SlowTest;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -58,7 +57,7 @@ public class TestDecimal extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/cast_simple_decimal.json"), Charsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/cast_simple_decimal.json"), StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/input_simple_decimal.json")
             );
 
@@ -103,7 +102,7 @@ public class TestDecimal extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/cast_float_decimal.json"), Charsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/cast_float_decimal.json"), StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/input_simple_decimal.json")
             );
 
@@ -148,7 +147,7 @@ public class TestDecimal extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/simple_decimal_arithmetic.json"), Charsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/simple_decimal_arithmetic.json"), StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/input_simple_decimal.json")
             );
 
@@ -199,7 +198,7 @@ public class TestDecimal extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/test_decimal_complex.json"), Charsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/test_decimal_complex.json"), StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/input_complex_decimal.json")
             );
 
@@ -242,7 +241,7 @@ public class TestDecimal extends PopUnitTestBase {
             bit.run();
             client.connect();
             List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/test_decimal_sort_complex.json"), Charsets.UTF_8)
+                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/test_decimal_sort_complex.json"), StandardCharsets.UTF_8)
                             .read().replace("#{TEST_FILE}", "/input_sort_complex_decimal.json")
             );
 
@@ -291,7 +290,7 @@ public class TestDecimal extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/simple_decimal_math.json"), Charsets.UTF_8)
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/decimal/simple_decimal_math.json"), StandardCharsets.UTF_8)
               .read().replace("#{TEST_FILE}", "/input_simple_decimal.json")
       );
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
@@ -31,7 +31,6 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -47,7 +46,7 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
          DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange.json"), Charsets.UTF_8).read());
+      List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange.json"), StandardCharsets.UTF_8).read());
       int count = 0;
       for(QueryDataBatch b : results){
         count += b.getHeader().getRowCount();
@@ -68,7 +67,7 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
          DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange_double_entry.json"), Charsets.UTF_8).read());
+      List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange_double_entry.json"), StandardCharsets.UTF_8).read());
       int count = 0;
       for(QueryDataBatch b : results){
         count += b.getHeader().getRowCount();
@@ -88,7 +87,7 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
              DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
           bit1.run();
           client.connect();
-          List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/scan_screen_logical.json"), Charsets.UTF_8).read());
+          List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/scan_screen_logical.json"), StandardCharsets.UTF_8).read());
           int count = 0;
           for (QueryDataBatch b : results) {
             count += b.getHeader().getRowCount();
@@ -110,7 +109,7 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
         bit1.run();
         bit2.run();
         client.connect();
-        List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange_double_entry.json"), Charsets.UTF_8).read());
+        List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange_double_entry.json"), StandardCharsets.UTF_8).read());
         int count = 0;
       for(QueryDataBatch b : results){
         count += b.getHeader().getRowCount();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.SlowTest;
@@ -46,7 +47,8 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
          DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange.json"), StandardCharsets.UTF_8).read());
+      List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_single_exchange.json"),
+          StandardCharsets.UTF_8).read());
       int count = 0;
       for(QueryDataBatch b : results){
         count += b.getHeader().getRowCount();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.vector.NullableBigIntVector;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -112,7 +111,7 @@ public class TestExtractFunctions extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-        Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/extractFrom.json"), Charsets.UTF_8)
+        Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/extractFrom.json"), StandardCharsets.UTF_8)
             .read()
             .replace("#{TEST_TYPE}", fromType)
             .replace("#{TEST_FILE}", testDataFile)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.SlowTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestHashToRandomExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestHashToRandomExchange.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestHashToRandomExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestHashToRandomExchange.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -51,7 +50,7 @@ public class TestHashToRandomExchange extends PopUnitTestBase {
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Files.asCharSource(DrillFileUtils.getResourceAsFile("/sender/hash_exchange.json"),
-              Charsets.UTF_8).read());
+              StandardCharsets.UTF_8).read());
       int count = 0;
       for (QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestImplicitCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestImplicitCastFunctions.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 import org.mockito.Mockito;
@@ -63,7 +62,7 @@ public class TestImplicitCastFunctions extends ExecTest {
     final DrillbitContext bitContext = mockDrillbitContext();
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
-    final String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
+    final String planString = Resources.toString(Resources.getResource(planPath), StandardCharsets.UTF_8);
     if (reader == null) {
       reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestImplicitCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestImplicitCastFunctions.java
@@ -38,6 +38,8 @@ import com.google.common.io.Resources;
 
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 public class TestImplicitCastFunctions extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
   private PhysicalPlanReader reader;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestReverseImplicitCast.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestReverseImplicitCast.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 
@@ -50,7 +51,8 @@ public class TestReverseImplicitCast extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/two_way_implicit_cast.json"), StandardCharsets.UTF_8).read());
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/two_way_implicit_cast.json"),
+              StandardCharsets.UTF_8).read());
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestReverseImplicitCast.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestReverseImplicitCast.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestReverseImplicitCast extends PopUnitTestBase {
@@ -51,7 +50,7 @@ public class TestReverseImplicitCast extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/two_way_implicit_cast.json"), Charsets.UTF_8).read());
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/cast/two_way_implicit_cast.json"), StandardCharsets.UTF_8).read());
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFragmentRun.java
@@ -36,7 +36,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestSimpleFragmentRun extends PopUnitTestBase {
@@ -52,7 +51,7 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
     bit.run();
     client.connect();
     final String path = "/physical_test2.json";
-    final List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile(path), Charsets.UTF_8).read());
+    final List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile(path), StandardCharsets.UTF_8).read());
 
     // look at records
     final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
@@ -116,7 +115,7 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
       bit.run();
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_json_scan_test1.json"), Charsets.UTF_8).read()
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_json_scan_test1.json"), StandardCharsets.UTF_8).read()
               .replace("#{TEST_FILE}", DrillFileUtils.getResourceAsFile("/scan_json_test_1.json").toURI().toString())
       );
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFragmentRun.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.common.util.DrillFileUtils;
@@ -51,7 +52,8 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
     bit.run();
     client.connect();
     final String path = "/physical_test2.json";
-    final List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile(path), StandardCharsets.UTF_8).read());
+    final List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile(path),
+        StandardCharsets.UTF_8).read());
 
     // look at records
     final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFunctions.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -120,7 +121,8 @@ public class TestSimpleFunctions extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testSubstring.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testSubstring.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFunctions.java
@@ -53,7 +53,6 @@ import org.apache.drill.exec.vector.NullableVarBinaryVector;
 import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.sun.codemodel.JClassAlreadyExistsException;
 
@@ -121,7 +120,7 @@ public class TestSimpleFunctions extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testSubstring.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testSubstring.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -154,7 +153,7 @@ public class TestSimpleFunctions extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testSubstringNegative.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testSubstringNegative.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -188,7 +187,7 @@ public class TestSimpleFunctions extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testByteSubstring.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/functions/testByteSubstring.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
@@ -36,7 +36,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 import org.junit.experimental.categories.Category;
@@ -59,7 +58,7 @@ public class TestStringFunctions extends ExecTest {
     int i = 0;
     for (final ValueVector v : exec) {
       if  (v instanceof VarCharVector) {
-        res[i++] = new String( ((VarCharVector) v).getAccessor().get(0), Charsets.UTF_8);
+        res[i++] = new String( ((VarCharVector) v).getAccessor().get(0), StandardCharsets.UTF_8);
       } else {
         res[i++] =  v.getAccessor().getObject(0);
       }
@@ -71,7 +70,7 @@ public class TestStringFunctions extends ExecTest {
     final DrillbitContext bitContext = mockDrillbitContext();
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
-    final String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
+    final String planString = Resources.toString(Resources.getResource(planPath), StandardCharsets.UTF_8);
     if (reader == null) {
       reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
@@ -41,6 +41,8 @@ import com.google.common.io.Resources;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category({UnlikelyTest.class})
 public class TestStringFunctions extends ExecTest {
   private final DrillConfig c = DrillConfig.create();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestUnionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestUnionExchange.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestUnionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestUnionExchange.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -51,7 +50,7 @@ public class TestUnionExchange extends PopUnitTestBase {
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Files.asCharSource(DrillFileUtils.getResourceAsFile("/sender/union_exchange.json"),
-              Charsets.UTF_8).read());
+              StandardCharsets.UTF_8).read());
       int count = 0;
       for (QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAgg.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAgg.java
@@ -46,6 +46,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(OperatorTest.class)
 public class TestAgg extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
@@ -55,7 +57,8 @@ public class TestAgg extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(file), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(file),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAgg.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAgg.java
@@ -41,7 +41,6 @@ import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.exec.vector.NullableBigIntVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -56,7 +55,7 @@ public class TestAgg extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(file), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(file), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
@@ -38,7 +38,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -54,7 +53,7 @@ public class TestSimpleFilter extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/filter/test1.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/filter/test1.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -77,7 +76,7 @@ public class TestSimpleFilter extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/filter/test_sv4.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/filter/test_sv4.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
@@ -43,6 +43,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(OperatorTest.class)
 public class TestSimpleFilter extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
@@ -76,7 +78,8 @@ public class TestSimpleFilter extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/filter/test_sv4.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/filter/test_sv4.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl.join;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
@@ -52,7 +52,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.mockito.Mockito;
@@ -70,7 +69,7 @@ public class TestHashJoin extends PopUnitTestBase {
 
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(physicalPlan), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile(physicalPlan), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -116,7 +115,7 @@ public class TestHashJoin extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hash_join.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hash_join.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE_1}", DrillFileUtils.getResourceAsFile("/build_side_input.json").toURI().toString())
                       .replace("#{TEST_FILE_2}", DrillFileUtils.getResourceAsFile("/probe_side_input.json").toURI().toString()));
 
@@ -157,7 +156,7 @@ public class TestHashJoin extends PopUnitTestBase {
       bit.run();
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hj_exchanges.json"), Charsets.UTF_8).read());
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hj_exchanges.json"), StandardCharsets.UTF_8).read());
 
       int count = 0;
       for (final QueryDataBatch b : results) {
@@ -182,7 +181,7 @@ public class TestHashJoin extends PopUnitTestBase {
       bit.run();
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hj_multi_condition_join.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hj_multi_condition_join.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE_1}", DrillFileUtils.getResourceAsFile("/build_side_input.json").toURI().toString())
                       .replace("#{TEST_FILE_2}", DrillFileUtils.getResourceAsFile("/probe_side_input.json").toURI().toString()));
 
@@ -226,7 +225,7 @@ public class TestHashJoin extends PopUnitTestBase {
       bit.run();
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hj_exchanges1.json"), Charsets.UTF_8).read());
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hj_exchanges1.json"), StandardCharsets.UTF_8).read());
 
       int count = 0;
       for (final QueryDataBatch b : results) {
@@ -250,7 +249,7 @@ public class TestHashJoin extends PopUnitTestBase {
       bit1.run();
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hashJoinExpr.json"), Charsets.UTF_8).read());
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/hashJoinExpr.json"), StandardCharsets.UTF_8).read());
       int count = 0;
       for (final QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
@@ -48,7 +48,6 @@ import org.apache.drill.categories.SlowTest;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
@@ -70,7 +69,7 @@ public class TestMergeJoin extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -122,7 +121,7 @@ public class TestMergeJoin extends PopUnitTestBase {
         new StoragePluginRegistryImpl(bitContext));
     final PhysicalPlan plan = reader.readPhysicalPlan(
         Files.asCharSource(
-            DrillFileUtils.getResourceAsFile("/join/merge_single_batch.json"), Charsets.UTF_8).read()
+            DrillFileUtils.getResourceAsFile("/join/merge_single_batch.json"), StandardCharsets.UTF_8).read()
             .replace("#{LEFT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_single_batch.left.json").toURI().toString())
             .replace("#{RIGHT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_single_batch.right.json").toURI().toString()));
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
@@ -176,7 +175,7 @@ public class TestMergeJoin extends PopUnitTestBase {
         new StoragePluginRegistryImpl(bitContext));
     final PhysicalPlan plan = reader.readPhysicalPlan(
         Files.asCharSource(
-            DrillFileUtils.getResourceAsFile("/join/merge_inner_single_batch.json"), Charsets.UTF_8).read()
+            DrillFileUtils.getResourceAsFile("/join/merge_inner_single_batch.json"), StandardCharsets.UTF_8).read()
             .replace("#{LEFT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_single_batch.left.json").toURI().toString())
             .replace("#{RIGHT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_single_batch.right.json").toURI().toString()));
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
@@ -228,7 +227,7 @@ public class TestMergeJoin extends PopUnitTestBase {
         new StoragePluginRegistryImpl(bitContext));
     final PhysicalPlan plan = reader.readPhysicalPlan(
         Files.asCharSource(
-            DrillFileUtils.getResourceAsFile("/join/merge_multi_batch.json"), Charsets.UTF_8).read()
+            DrillFileUtils.getResourceAsFile("/join/merge_multi_batch.json"), StandardCharsets.UTF_8).read()
             .replace("#{LEFT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_multi_batch.left.json").toURI().toString())
             .replace("#{RIGHT_FILE}", DrillFileUtils.getResourceAsFile("/join/merge_multi_batch.right.json").toURI().toString()));
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
@@ -275,7 +274,7 @@ public class TestMergeJoin extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/join_batchsize.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/join_batchsize.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -301,7 +300,7 @@ public class TestMergeJoin extends PopUnitTestBase {
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_empty_batch.json"),
-                      Charsets.UTF_8).read()
+                      StandardCharsets.UTF_8).read()
                       .replace("${JOIN_TYPE}", "INNER"));
       int count = 0;
       for (final QueryDataBatch b : results) {
@@ -325,7 +324,7 @@ public class TestMergeJoin extends PopUnitTestBase {
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_empty_batch.json"),
-              Charsets.UTF_8).read()
+              StandardCharsets.UTF_8).read()
               .replace("${JOIN_TYPE}", "LEFT"));
       int count = 0;
       for (final QueryDataBatch b : results) {
@@ -349,7 +348,7 @@ public class TestMergeJoin extends PopUnitTestBase {
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_empty_batch.json"),
-                      Charsets.UTF_8).read()
+                      StandardCharsets.UTF_8).read()
                       .replace("${JOIN_TYPE}", "RIGHT"));
       int count = 0;
       for (final QueryDataBatch b : results) {
@@ -372,7 +371,7 @@ public class TestMergeJoin extends PopUnitTestBase {
       bit1.run();
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/mergeJoinExpr.json"), Charsets.UTF_8).read());
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/mergeJoinExpr.json"), StandardCharsets.UTF_8).read());
       int count = 0;
       for (final QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl.join;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinMulCondition.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinMulCondition.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 @Category({SlowTest.class, OperatorTest.class})
@@ -61,7 +60,7 @@ public class TestMergeJoinMulCondition extends PopUnitTestBase {
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/mj_multi_condition.json"),
-              Charsets.UTF_8).read());
+              StandardCharsets.UTF_8).read());
       int count = 0;
       for (QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {
@@ -85,7 +84,7 @@ public class TestMergeJoinMulCondition extends PopUnitTestBase {
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_nullkey.json"), Charsets.UTF_8).read().replace("${JOIN_TYPE}", "INNER"));
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_nullkey.json"), StandardCharsets.UTF_8).read().replace("${JOIN_TYPE}", "INNER"));
       int count = 0;
       for (QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {
@@ -110,7 +109,7 @@ public class TestMergeJoinMulCondition extends PopUnitTestBase {
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_nullkey.json"), Charsets.UTF_8).read().replace("${JOIN_TYPE}", "LEFT"));
+          Files.asCharSource(DrillFileUtils.getResourceAsFile("/join/merge_join_nullkey.json"), StandardCharsets.UTF_8).read().replace("${JOIN_TYPE}", "LEFT"));
       int count = 0;
       for (QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinMulCondition.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinMulCondition.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl.join;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestSimpleLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestSimpleLimit.java
@@ -44,6 +44,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(OperatorTest.class)
 public class TestSimpleLimit extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
@@ -104,7 +106,8 @@ public class TestSimpleLimit extends ExecTest {
 
   private void verifySum(DrillbitContext bitContext, UserClientConnection connection, String testPlan, int expectedCount, long expectedSum) throws Throwable {
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/limit/" + testPlan), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/limit/" + testPlan),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestSimpleLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestSimpleLimit.java
@@ -39,7 +39,6 @@ import org.apache.drill.exec.vector.BigIntVector;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -85,7 +84,7 @@ public class TestSimpleLimit extends ExecTest {
 
   private void verifyLimitCount(DrillbitContext bitContext, UserClientConnection connection, String testPlan, int expectedCount) throws Throwable {
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/limit/" + testPlan), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/limit/" + testPlan), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -105,7 +104,7 @@ public class TestSimpleLimit extends ExecTest {
 
   private void verifySum(DrillbitContext bitContext, UserClientConnection connection, String testPlan, int expectedCount, long expectedSum) throws Throwable {
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/limit/" + testPlan), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/limit/" + testPlan), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -57,7 +56,7 @@ public class TestMergingReceiver extends PopUnitTestBase {
       client.connect();
       final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
         Files.asCharSource(DrillFileUtils.getResourceAsFile("/mergerecv/merging_receiver.json"),
-          Charsets.UTF_8).read());
+          StandardCharsets.UTF_8).read());
       int count = 0;
       final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
       // print the results
@@ -87,7 +86,7 @@ public class TestMergingReceiver extends PopUnitTestBase {
       final List<QueryDataBatch> results =
           client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/mergerecv/multiple_providers.json"),
-                  Charsets.UTF_8).read());
+                  StandardCharsets.UTF_8).read());
       int count = 0;
       final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
       // print the results
@@ -134,7 +133,7 @@ public class TestMergingReceiver extends PopUnitTestBase {
       final List<QueryDataBatch> results =
           client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/mergerecv/empty_batch.json"),
-                  Charsets.UTF_8).read());
+                  StandardCharsets.UTF_8).read());
       int count = 0;
       final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
       // print the results
@@ -163,7 +162,7 @@ public class TestMergingReceiver extends PopUnitTestBase {
       final List<QueryDataBatch> results =
           client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/mergerecv/empty_batch_noschema.json"),
-                  Charsets.UTF_8).read());
+                  StandardCharsets.UTF_8).read());
       int count = 0;
       final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
       // print the results
@@ -192,7 +191,7 @@ public class TestMergingReceiver extends PopUnitTestBase {
       final List<QueryDataBatch> results =
           client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/mergerecv/multiple_providers_empty_batches.json"),
-                  Charsets.UTF_8).read());
+                  StandardCharsets.UTF_8).read());
       int count = 0;
       final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
       // print the results

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl.mergereceiver;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl.orderedpartitioner;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.math.stat.descriptive.moment.Mean;
@@ -70,7 +71,7 @@ public class TestOrderedPartitionExchange extends PopUnitTestBase {
 
     try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
         Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
-        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator());) {
+        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
       bit1.run();
       bit2.run();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
@@ -44,7 +44,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
@@ -78,7 +77,7 @@ public class TestOrderedPartitionExchange extends PopUnitTestBase {
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Files.asCharSource(DrillFileUtils.getResourceAsFile("/sender/ordered_exchange.json"),
-              Charsets.UTF_8).read());
+              StandardCharsets.UTF_8).read());
       int count = 0;
       List<Integer> partitionRecordCounts = Lists.newArrayList();
       for(QueryDataBatch b : results) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
@@ -46,6 +46,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(OperatorTest.class)
 public class TestSimpleProjection extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
@@ -56,7 +58,8 @@ public class TestSimpleProjection extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/project/test1.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/project/test1.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
@@ -41,7 +41,6 @@ import org.apache.drill.exec.util.VectorUtil;
 import org.apache.drill.exec.vector.NullableBigIntVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -57,7 +56,7 @@ public class TestSimpleProjection extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/project/test1.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/project/test1.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanBatchWriters.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanBatchWriters.java
@@ -39,6 +39,8 @@ import org.junit.experimental.categories.Category;
 
 import io.netty.buffer.DrillBuf;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Test of the "legacy" scan batch writers to ensure that the revised
  * set follows the same semantics as the original set.
@@ -77,7 +79,7 @@ public class TestScanBatchWriters extends SubOperatorTest {
       // Write one record (10, "Fred", [100, 110, 120] )
 
       map.integer("a").writeInt(10);
-      byte[] bytes = "Fred".getBytes("UTF-8");
+      byte[] bytes = "Fred".getBytes(StandardCharsets.UTF_8);
       buffer.setBytes(0, bytes, 0, bytes.length);
       map.varChar("b").writeVarChar(0, bytes.length, buffer);
       try (ListWriter list = map.list("c")) {
@@ -91,7 +93,7 @@ public class TestScanBatchWriters extends SubOperatorTest {
 
         writer.setPosition(1);
         map.integer("a").writeInt(20);
-        bytes = "Wilma".getBytes("UTF-8");
+        bytes = "Wilma".getBytes(StandardCharsets.UTF_8);
         buffer.setBytes(0, bytes, 0, bytes.length);
         map.varChar("b").writeVarChar(0, bytes.length, buffer);
         writer.setValueCount(2);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
@@ -47,6 +47,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 @Ignore
 @Category(OperatorTest.class)
 public class TestSimpleSort extends ExecTest {
@@ -58,7 +60,8 @@ public class TestSimpleSort extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/sort/one_key_sort.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/sort/one_key_sort.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.vector.IntVector;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -59,7 +58,7 @@ public class TestSimpleSort extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/sort/one_key_sort.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/sort/one_key_sort.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
@@ -96,7 +95,7 @@ public class TestSimpleSort extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/sort/two_key_sort.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/sort/two_key_sort.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -61,7 +60,7 @@ public class TestTraceMultiRecordBatch extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/multi_record_batch_trace.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/multi_record_batch_trace.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
@@ -42,6 +42,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 /*
  * This test uses a physical plan with the mock scan that generates 100k records.
  * Here we inject the "trace" operator in two locations in the plan.
@@ -60,7 +62,8 @@ public class TestTraceMultiRecordBatch extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/multi_record_batch_trace.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/multi_record_batch_trace.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceOutputDump.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceOutputDump.java
@@ -52,6 +52,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 /*
  * This test uses a simple physical plan with a mock-scan that
  * generates one row. The physical plan also consists of the
@@ -76,7 +78,8 @@ public class TestTraceOutputDump extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/simple_trace.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/simple_trace.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceOutputDump.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceOutputDump.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -77,7 +76,7 @@ public class TestTraceOutputDump extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/simple_trace.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/trace/simple_trace.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
@@ -42,6 +42,8 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+
 // See also TestUnionDistinct for a test that does not need JMockit
 @Category(OperatorTest.class)
 public class TestSimpleUnion extends ExecTest {
@@ -53,7 +55,8 @@ public class TestSimpleUnion extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/union/test1.json"), StandardCharsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/union/test1.json"),
+        StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.rpc.UserClientConnection;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.experimental.categories.Category;
@@ -54,7 +53,7 @@ public class TestSimpleUnion extends ExecTest {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/union/test1.json"), Charsets.UTF_8).read());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/union/test1.json"), StandardCharsets.UTF_8).read());
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestWriter.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -47,7 +48,8 @@ public class TestWriter extends BaseTestQuery {
   public void simpleCsv() throws Exception {
     File testDir = dirTestWatcher.makeRootSubDir(Paths.get("csvtest"));
 
-    String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile("/writer/simple_csv_writer.json"), StandardCharsets.UTF_8).read();
+    String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile("/writer/simple_csv_writer.json"),
+        StandardCharsets.UTF_8).read();
     plan = plan
       .replace(ROOT_DIR_REPLACEMENT, dirTestWatcher.getRootDir().getAbsolutePath())
       .replace(TMP_DIR_REPLACEMENT, dirTestWatcher.getTmpDir().getAbsolutePath())

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestWriter.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.vector.BigIntVector;
 import org.apache.drill.exec.vector.VarCharVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestWriter extends BaseTestQuery {
@@ -48,7 +47,7 @@ public class TestWriter extends BaseTestQuery {
   public void simpleCsv() throws Exception {
     File testDir = dirTestWatcher.makeRootSubDir(Paths.get("csvtest"));
 
-    String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile("/writer/simple_csv_writer.json"), Charsets.UTF_8).read();
+    String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile("/writer/simple_csv_writer.json"), StandardCharsets.UTF_8).read();
     plan = plan
       .replace(ROOT_DIR_REPLACEMENT, dirTestWatcher.getRootDir().getAbsolutePath())
       .replace(TMP_DIR_REPLACEMENT, dirTestWatcher.getTmpDir().getAbsolutePath())

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOverflow.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOverflow.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.accessor.ArrayReader;
 import org.apache.drill.exec.vector.accessor.ScalarReader;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
-import com.google.common.base.Charsets;
 import org.apache.drill.test.SubOperatorTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -302,7 +301,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     rsLoader.startBatch();
     byte[] value = new byte[473];
     Arrays.fill(value, (byte) 'X');
-    String strValue = new String(value, Charsets.UTF_8);
+    String strValue = new String(value, StandardCharsets.UTF_8);
     int valuesPerArray = 13;
     int count = 0;
 
@@ -415,7 +414,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
     byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
-    String strValue = new String(value, Charsets.UTF_8);
+    String strValue = new String(value, StandardCharsets.UTF_8);
 
     int aCount = 3;
     int bCount = 11;
@@ -764,9 +763,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     byte[] tail = new byte[523];
     Arrays.fill(tail, (byte) 'X');
 
-    String expected = new String(head, Charsets.UTF_8);
-    expected += new String(tail, Charsets.UTF_8);
-    expected += new String(tail, Charsets.UTF_8);
+    String expected = new String(head, StandardCharsets.UTF_8);
+    expected += new String(tail, StandardCharsets.UTF_8);
+    expected += new String(tail, StandardCharsets.UTF_8);
 
     int count = 0;
     ScalarWriter colWriter = rootWriter.scalar(0);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOverflow.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOverflow.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.drill.categories.RowSetTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderRepeatedList.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderRepeatedList.java
@@ -43,7 +43,6 @@ import org.apache.drill.exec.vector.accessor.ScalarReader;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.ValueType;
 import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
-import com.google.common.base.Charsets;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
@@ -286,7 +285,7 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     final int strLength = ValueVector.MAX_BUFFER_SIZE / ValueVector.MAX_ROW_COUNT / outerSize / innerSize + 20;
     final byte value[] = new byte[strLength - 6];
     Arrays.fill(value, (byte) 'X');
-    final String strValue = new String(value, Charsets.UTF_8);
+    final String strValue = new String(value, StandardCharsets.UTF_8);
     int rowCount = 0;
     int elementCount = 0;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderRepeatedList.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderRepeatedList.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.resultSet.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.drill.categories.RowSetTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderTorture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderTorture.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.resultSet.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.drill.categories.RowSetTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderTorture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderTorture.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetReader;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import com.google.common.base.Charsets;
 
 /**
  * Runs a worst-case scenario test that combines aspects of all
@@ -86,7 +85,7 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
     public TestSetup() {
       byte s3Bytes[] = new byte[512];
       Arrays.fill(s3Bytes, (byte) 'X');
-      s3Value = new String(s3Bytes, Charsets.UTF_8);
+      s3Value = new String(s3Bytes, StandardCharsets.UTF_8);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderUnions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderUnions.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.drill.common.types.TypeProtos.DataMode;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderUnions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderUnions.java
@@ -67,7 +67,6 @@ import org.apache.drill.exec.physical.rowSet.RowSetReader;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import com.google.common.base.Charsets;
 
 /**
  * Tests the result set loader support for union vectors. Union vectors
@@ -215,7 +214,7 @@ public class TestResultSetLoaderUnions extends SubOperatorTest {
     final int strLength = 600;
     final byte[] value = new byte[strLength - 6];
     Arrays.fill(value, (byte) 'X');
-    final String strValue = new String(value, Charsets.UTF_8);
+    final String strValue = new String(value, StandardCharsets.UTF_8);
     int count = 0;
 
     rsLoader.startBatch();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/TestRowSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/TestRowSet.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -1201,14 +1201,9 @@ public class TestRowSet extends SubOperatorTest {
         .add("b", MinorType.VARCHAR)
         .buildSchema();
 
-    String varCharValue;
-    try {
-      final byte rawValue[] = new byte[512];
-      Arrays.fill(rawValue, (byte) 'X');
-      varCharValue = new String(rawValue, "UTF-8");
-    } catch (final UnsupportedEncodingException e) {
-      throw new IllegalStateException(e);
-    }
+    final byte rawValue[] = new byte[512];
+    Arrays.fill(rawValue, (byte) 'X');
+    String varCharValue = new String(rawValue, StandardCharsets.UTF_8);
 
     final ExtendableRowSet rs = fixture.rowSet(schema);
     final RowSetWriter writer = rs.writer();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/TestVariableWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/TestVariableWidthWriter.java
@@ -32,7 +32,6 @@ import org.apache.drill.exec.vector.accessor.ColumnAccessors.VarCharColumnWriter
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.ValueType;
 import org.apache.drill.exec.vector.accessor.writer.WriterEvents.ColumnWriterListener;
-import com.google.common.base.Charsets;
 import org.apache.drill.test.SubOperatorTest;
 import org.bouncycastle.util.Arrays;
 import org.junit.Test;
@@ -189,7 +188,7 @@ public class TestVariableWidthWriter extends SubOperatorTest {
       for (int i = 1; i < 15; i++) {
         vector.getOffsetVector().getMutator().set(i, 0xdeadbeef);
       }
-      vector.getMutator().setSafe(0, overflowValue.getBytes(Charsets.UTF_8));
+      vector.getMutator().setSafe(0, overflowValue.getBytes(StandardCharsets.UTF_8));
 
       writer.postRollover();
       index.index = 0;
@@ -398,7 +397,7 @@ public class TestVariableWidthWriter extends SubOperatorTest {
   }
 
   private String stringAt(VarCharVector vector, int i) {
-    return new String(vector.getAccessor().get(i), Charsets.UTF_8);
+    return new String(vector.getAccessor().get(i), StandardCharsets.UTF_8);
   }
 
   private VarCharVector allocVector(int size) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/TestVariableWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/TestVariableWidthWriter.java
@@ -37,6 +37,8 @@ import org.bouncycastle.util.Arrays;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.nio.charset.StandardCharsets;
+
 @Category(RowSetTest.class)
 public class TestVariableWidthWriter extends SubOperatorTest {
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.pop;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.apache.drill.common.config.DrillConfig;
@@ -67,7 +68,8 @@ public abstract class PopUnitTestBase  extends ExecTest{
 
   public static Fragment getRootFragment(PhysicalPlanReader reader, String file) throws FragmentSetupException,
       IOException, ForemanSetupException {
-    return getRootFragmentFromPlanString(reader, Files.asCharSource(DrillFileUtils.getResourceAsFile(file), StandardCharsets.UTF_8).read());
+    return getRootFragmentFromPlanString(reader, Files.asCharSource(DrillFileUtils.getResourceAsFile(file),
+        StandardCharsets.UTF_8).read());
   }
 
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
@@ -35,7 +35,6 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.junit.BeforeClass;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public abstract class PopUnitTestBase  extends ExecTest{
@@ -68,7 +67,7 @@ public abstract class PopUnitTestBase  extends ExecTest{
 
   public static Fragment getRootFragment(PhysicalPlanReader reader, String file) throws FragmentSetupException,
       IOException, ForemanSetupException {
-    return getRootFragmentFromPlanString(reader, Files.asCharSource(DrillFileUtils.getResourceAsFile(file), Charsets.UTF_8).read());
+    return getRootFragmentFromPlanString(reader, Files.asCharSource(DrillFileUtils.getResourceAsFile(file), StandardCharsets.UTF_8).read());
   }
 
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/TestInjectionValue.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/TestInjectionValue.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
@@ -52,7 +51,7 @@ public class TestInjectionValue extends ExecTest {
   @Test
   public void testInjected() throws Exception{
     PhysicalPlanReader r = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(config);
-    PhysicalPlan p = r.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_screen.json"), Charsets.UTF_8).read());
+    PhysicalPlan p = r.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_screen.json"), StandardCharsets.UTF_8).read());
 
     List<PhysicalOperator> o = p.getSortedOperators(false);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/TestInjectionValue.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/TestInjectionValue.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.pop;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.categories.PlannerTest;
@@ -51,7 +52,8 @@ public class TestInjectionValue extends ExecTest {
   @Test
   public void testInjected() throws Exception{
     PhysicalPlanReader r = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(config);
-    PhysicalPlan p = r.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_screen.json"), StandardCharsets.UTF_8).read());
+    PhysicalPlan p = r.readPhysicalPlan(Files.asCharSource(DrillFileUtils.getResourceAsFile("/physical_screen.json"),
+        StandardCharsets.UTF_8).read());
 
     List<PhysicalOperator> o = p.getSortedOperators(false);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
@@ -47,7 +47,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
@@ -66,7 +65,7 @@ public class TestRecordIterator extends PopUnitTestBase {
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
 
-    final String planStr = Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/test_recorditerator.json"), Charsets.UTF_8).read();
+    final String planStr = Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/test_recorditerator.json"), StandardCharsets.UTF_8).read();
 
     final PhysicalPlan plan = reader.readPhysicalPlan(planStr);
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
@@ -122,7 +121,7 @@ public class TestRecordIterator extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final String planStr = Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/test_recorditerator.json"), Charsets.UTF_8).read();
+    final String planStr = Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/test_recorditerator.json"), StandardCharsets.UTF_8).read();
 
     final PhysicalPlan plan = reader.readPhysicalPlan(planStr);
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
@@ -51,6 +51,7 @@ import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Category(VectorTest.class)
@@ -121,7 +122,8 @@ public class TestRecordIterator extends PopUnitTestBase {
     final UserClientConnection connection = Mockito.mock(UserClientConnection.class);
 
     final PhysicalPlanReader reader = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(c);
-    final String planStr = Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/test_recorditerator.json"), StandardCharsets.UTF_8).read();
+    final String planStr = Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/test_recorditerator.json"),
+        StandardCharsets.UTF_8).read();
 
     final PhysicalPlan plan = reader.readPhysicalPlan(planStr);
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -56,7 +55,7 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
@@ -90,7 +89,7 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_sort_date.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_sort_date.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
@@ -124,7 +123,7 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_timestamp.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_timestamp.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
@@ -158,7 +157,7 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_interval.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_interval.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_interval.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
@@ -216,7 +215,7 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_all_date_literals.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_all_date_literals.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
@@ -255,7 +254,7 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date_add.json"), Charsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date_add.json"), StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.record.vector;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 
@@ -157,7 +158,8 @@ public class TestDateTypes extends PopUnitTestBase {
       bit.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_interval.json"), StandardCharsets.UTF_8).read()
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_interval.json"),
+                      StandardCharsets.UTF_8).read()
                       .replace("#{TEST_FILE}", "/test_simple_interval.json"));
 
       RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestImplicitFileColumns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestImplicitFileColumns.java
@@ -27,7 +27,6 @@ import org.apache.drill.exec.record.BatchSchemaBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.util.JsonStringArrayList;
 import org.apache.drill.exec.util.Text;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
@@ -62,11 +61,11 @@ public class TestImplicitFileColumns extends BaseTestQuery {
   public static void setup() throws Exception {
     File files = dirTestWatcher.makeRootSubDir(FILES);
     mainFile = new File(files, MAIN_FILE);
-    Files.asCharSink(mainFile, Charsets.UTF_8).write(MAIN);
+    Files.asCharSink(mainFile, StandardCharsets.UTF_8).write(MAIN);
     File nestedFolder = new File(files, NESTED);
     nestedFolder.mkdirs();
     nestedFile = new File(nestedFolder, NESTED_FILE);
-    Files.asCharSink(nestedFile, Charsets.UTF_8).write(NESTED);
+    Files.asCharSink(nestedFile, StandardCharsets.UTF_8).write(NESTED);
 
     dirTestWatcher.copyResourceToRoot(JSON_TBL);
     dirTestWatcher.copyResourceToRoot(PARQUET_TBL);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestImplicitFileColumns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestImplicitFileColumns.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestHeaderBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestHeaderBuilder.java
@@ -26,6 +26,8 @@ import org.apache.drill.test.DrillTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 
 /**
  * Test the mechanism that builds column names from a set of CSV

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestHeaderBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestHeaderBuilder.java
@@ -26,7 +26,6 @@ import org.apache.drill.test.DrillTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 
 /**
  * Test the mechanism that builds column names from a set of CSV
@@ -181,7 +180,7 @@ public class TestHeaderBuilder extends DrillTest {
     if (input == null) {
       return;
     }
-    byte bytes[] = input.getBytes(Charsets.UTF_8);
+    byte bytes[] = input.getBytes(StandardCharsets.UTF_8);
     if (bytes.length == 0) {
       return;
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReader.java
@@ -36,7 +36,6 @@ import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.store.easy.json.JSONRecordReader;
 import org.apache.drill.exec.util.JsonStringHashMap;
 import org.apache.drill.exec.util.Text;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
@@ -151,7 +150,7 @@ public class TestJsonReader extends BaseTestQuery {
     logger.debug("===================");
     logger.debug("source data in json");
     logger.debug("===================");
-    logger.debug(Files.asCharSource(DrillFileUtils.getResourceAsFile(filename), Charsets.UTF_8).read());
+    logger.debug(Files.asCharSource(DrillFileUtils.getResourceAsFile(filename), StandardCharsets.UTF_8).read());
 
     int i = 0;
     for (String query : queries) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderQueries.java
@@ -33,6 +33,7 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.zip.GZIPOutputStream;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderQueries.java
@@ -45,7 +45,6 @@ import org.apache.drill.exec.physical.rowSet.DirectRowSet;
 import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.QueryBuilder.QuerySummary;
@@ -510,7 +509,7 @@ public class TestJsonReaderQueries extends BaseTestJsonReader {
       client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, false);
       String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile(
           "/store/json/project_pushdown_json_physical_plan.json"),
-          Charsets.UTF_8).read();
+          StandardCharsets.UTF_8).read();
 //      client.queryBuilder().physical(plan).printCsv();
       DirectRowSet results = client.queryBuilder().physical(plan).rowSet();
 //      results.print();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
@@ -76,7 +76,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -110,7 +109,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
   }
 
   public String getPlanForFile(String pathFileName, String parquetFileName) throws IOException {
-    return Files.asCharSource(DrillFileUtils.getResourceAsFile(pathFileName), Charsets.UTF_8).read()
+    return Files.asCharSource(DrillFileUtils.getResourceAsFile(pathFileName), StandardCharsets.UTF_8).read()
         .replaceFirst("&REPLACED_IN_PARQUET_TEST&", parquetFileName);
   }
 
@@ -129,7 +128,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     }
 
     final String planText = Files.asCharSource(DrillFileUtils.getResourceAsFile(
-        "parquet/parquet_scan_screen_read_entry_replace.json"), Charsets.UTF_8).read().replaceFirst(
+        "parquet/parquet_scan_screen_read_entry_replace.json"), StandardCharsets.UTF_8).read().replaceFirst(
             "&REPLACED_IN_PARQUET_TEST&", readEntries.toString());
     testParquetFullEngineLocalText(planText, fileName, i, numberRowGroups, recordsPerRowGroup, true);
   }
@@ -182,7 +181,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
   public void testFixedBinary() throws Exception {
     final String readEntries = "\"tmp/drilltest/fixed_binary.parquet\"";
     final String planText = Files.asCharSource(DrillFileUtils.getResourceAsFile(
-        "parquet/parquet_scan_screen_read_entry_replace.json"), Charsets.UTF_8).read()
+        "parquet/parquet_scan_screen_read_entry_replace.json"), StandardCharsets.UTF_8).read()
           .replaceFirst( "&REPLACED_IN_PARQUET_TEST&", readEntries);
     testParquetFullEngineLocalText(planText, fileName, 1, 1, 1000000, false);
   }
@@ -267,7 +266,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
   public void testParquetFullEngineLocalPath(String planFileName, String filename,
       int numberOfTimesRead /* specified in json plan */,
       int numberOfRowGroups, int recordsPerRowGroup) throws Exception {
-    testParquetFullEngineLocalText(Files.asCharSource(DrillFileUtils.getResourceAsFile(planFileName), Charsets.UTF_8).read(), filename,
+    testParquetFullEngineLocalText(Files.asCharSource(DrillFileUtils.getResourceAsFile(planFileName), StandardCharsets.UTF_8).read(), filename,
         numberOfTimesRead, numberOfRowGroups, recordsPerRowGroup, true);
   }
 
@@ -298,7 +297,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
   public void testParquetFullEngineLocalTextDistributed(String planName, String filename,
       int numberOfTimesRead /* specified in json plan */,
       int numberOfRowGroups, int recordsPerRowGroup) throws Exception {
-    String planText = Files.asCharSource(DrillFileUtils.getResourceAsFile(planName), Charsets.UTF_8).read();
+    String planText = Files.asCharSource(DrillFileUtils.getResourceAsFile(planName), StandardCharsets.UTF_8).read();
     testFull(QueryType.PHYSICAL, planText, filename, numberOfTimesRead, numberOfRowGroups, recordsPerRowGroup, true);
   }
 
@@ -326,7 +325,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     TestFileGenerator.populateFieldInfoMap(props);
     final ParquetResultListener resultListener =
         new ParquetResultListener(getAllocator(), props, numberOfTimesRead, true);
-    testWithListener(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile(plan), Charsets.UTF_8).read(), resultListener);
+    testWithListener(QueryType.PHYSICAL, Files.asCharSource(DrillFileUtils.getResourceAsFile(plan), StandardCharsets.UTF_8).read(), resultListener);
     resultListener.getResults();
   }
 
@@ -680,7 +679,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
 
     final ParquetResultListener resultListener = new ParquetResultListener(getAllocator(), props, numberOfTimesRead, testValues);
     final long C = System.nanoTime();
-    String planText = Files.asCharSource(DrillFileUtils.getResourceAsFile(plan), Charsets.UTF_8).read();
+    String planText = Files.asCharSource(DrillFileUtils.getResourceAsFile(plan), StandardCharsets.UTF_8).read();
     // substitute in the string for the read entries, allows reuse of the plan file for several tests
     if (readEntries != null) {
       planText = planText.replaceFirst( "&REPLACED_IN_PARQUET_TEST&", readEntries);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
@@ -27,6 +27,7 @@ import io.netty.buffer.DrillBuf;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetResultListener.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetResultListener.java
@@ -20,7 +20,7 @@ package org.apache.drill.exec.store.parquet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -183,11 +183,7 @@ public class ParquetResultListener implements UserResultsListener {
       if (logger.isDebugEnabled()) {
         Object o = vv.getAccessor().getObject(j);
         if (o instanceof byte[]) {
-          try {
-            o = new String((byte[])o, "UTF-8");
-          } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-          }
+          o = new String((byte[])o, StandardCharsets.UTF_8);
         }
         sb.append(Strings.padStart(o + "", 20, ' ') + " ");
         sb.append(", " + (j % 25 == 0 ? "\n batch:" + batchCounter + " v:" + j + " - " : ""));
@@ -217,22 +213,18 @@ public class ParquetResultListener implements UserResultsListener {
         final ValueVector v = vw.getValueVector();
         Object o = v.getAccessor().getObject(i);
         if (o instanceof byte[]) {
-          try {
-            // TODO - in the dictionary read error test there is some data that does not look correct
-            // the output of our reader matches the values of the parquet-mr cat/head tools (no full comparison was made,
-            // but from a quick check of a few values it looked consistent
-            // this might have gotten corrupted by pig somehow, or maybe this is just how the data is supposed ot look
-            // TODO - check this!!
+          // TODO - in the dictionary read error test there is some data that does not look correct
+          // the output of our reader matches the values of the parquet-mr cat/head tools (no full comparison was made,
+          // but from a quick check of a few values it looked consistent
+          // this might have gotten corrupted by pig somehow, or maybe this is just how the data is supposed ot look
+          // TODO - check this!!
 //              for (int k = 0; k < ((byte[])o).length; k++ ) {
 //                // check that the value at each position is a valid single character ascii value.
 //
 //                if (((byte[])o)[k] > 128) {
 //                }
 //              }
-            o = new String((byte[])o, "UTF-8");
-          } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-          }
+            o = new String((byte[])o, StandardCharsets.UTF_8);
         }
 
         sb.append(Strings.padStart(o + "", 20, ' ') + " ");

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.parquet;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,7 +58,8 @@ public class TestParquetPhysicalPlan extends ExecTest {
          DrillClient client = new DrillClient(config, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(Resources.getResource(fileName),Charsets.UTF_8));
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(
+          Resources.getResource(fileName), StandardCharsets.UTF_8));
       RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
       int count = 0;
       for (QueryDataBatch b : results) {
@@ -128,7 +130,8 @@ public class TestParquetPhysicalPlan extends ExecTest {
       client.connect();
       ParquetResultsListener listener = new ParquetResultsListener();
       Stopwatch watch = Stopwatch.createStarted();
-      client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(Resources.getResource(fileName),Charsets.UTF_8), listener);
+      client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(
+          Resources.getResource(fileName), StandardCharsets.UTF_8), listener);
       client.close();
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
@@ -38,7 +38,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.Resources;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sequencefile/TestSequenceFileReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sequencefile/TestSequenceFileReader.java
@@ -112,7 +112,7 @@ public class TestSequenceFileReader extends ClusterTest {
   private static String byteWritableString(String input) throws Exception {
     final ByteArrayOutputStream bout = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(bout);
-    final BytesWritable writable = new BytesWritable(input.getBytes("UTF-8"));
+    final BytesWritable writable = new BytesWritable(input.getBytes(StandardCharsets.UTF_8));
     writable.write(out);
     return new String(bout.toByteArray());
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
@@ -48,7 +48,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 /*
@@ -109,7 +108,7 @@ public class TestResourceLeak extends DrillTest {
     if (url == null) {
       throw new IOException(String.format("Unable to find path %s.", resource));
     }
-    return Resources.toString(url, Charsets.UTF_8);
+    return Resources.toString(url, StandardCharsets.UTF_8);
   }
 
   @AfterClass

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
@@ -22,6 +22,7 @@ import io.netty.buffer.DrillBuf;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import javax.inject.Inject;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/TestSpoolingBuffer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/TestSpoolingBuffer.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.work.batch;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.drill.test.BaseTestQuery;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/TestSpoolingBuffer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/TestSpoolingBuffer.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestSpoolingBuffer extends BaseTestQuery {
@@ -48,7 +47,7 @@ public class TestSpoolingBuffer extends BaseTestQuery {
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
               Files.asCharSource(DrillFileUtils.getResourceAsFile("/work/batch/multiple_exchange.json"),
-                      Charsets.UTF_8).read());
+                      StandardCharsets.UTF_8).read());
       int count = 0;
       for(QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
@@ -24,7 +24,6 @@ import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.exec.store.StoragePluginRegistry;
-import com.google.common.base.Charsets;
 import org.junit.runner.Description;
 
 /**
@@ -383,14 +382,14 @@ public class BaseDirTestWatcher extends DirTestWatcher {
    */
   public void replaceMetaDataContents(File metaDataFile, File replacePath, String customStringReplacement) {
     try {
-      String metadataFileContents = FileUtils.readFileToString(metaDataFile, Charsets.UTF_8);
+      String metadataFileContents = FileUtils.readFileToString(metaDataFile, StandardCharsets.UTF_8);
 
       if (customStringReplacement != null) {
         metadataFileContents = metadataFileContents.replace("CUSTOM_STRING_REPLACEMENT", customStringReplacement);
       }
 
       metadataFileContents = metadataFileContents.replace("REPLACED_IN_TEST", replacePath.getCanonicalPath());
-      FileUtils.write(metaDataFile, metadataFileContents, Charsets.UTF_8);
+      FileUtils.write(metaDataFile, metadataFileContents, StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new RuntimeException("This should not happen", e);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
@@ -19,6 +19,7 @@ package org.apache.drill.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseTestQuery.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseTestQuery.java
@@ -64,7 +64,6 @@ import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.exec.util.VectorUtil;
 import org.apache.drill.exec.vector.ValueVector;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Resources;
 import org.apache.drill.test.DrillTestWrapper.TestServices;
@@ -456,7 +455,7 @@ public class BaseTestQuery extends ExecTest {
     if (url == null) {
       throw new IOException(String.format("Unable to find path %s.", resource));
     }
-    return Resources.toString(url, Charsets.UTF_8);
+    return Resources.toString(url, StandardCharsets.UTF_8);
   }
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -60,7 +60,6 @@ import org.apache.drill.exec.store.mock.MockStorageEngineConfig;
 import org.apache.drill.common.logical.security.PlainCredentialsProvider;
 import org.apache.drill.exec.store.sys.store.provider.ZookeeperPersistentStoreProvider;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
@@ -706,7 +705,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
       throw new IOException(
           String.format("Unable to find resource %s.", resource));
     }
-    return Resources.toString(url, Charsets.UTF_8);
+    return Resources.toString(url, StandardCharsets.UTF_8);
   }
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/DrillTestWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/DrillTestWrapper.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -777,7 +778,8 @@ public class DrillTestWrapper {
     }
     if (actual instanceof byte[]) {
       throw new Exception("at position " + counter + " column '" + column + "' mismatched values, expected: "
-        + new String((byte[])expected, "UTF-8") + " but received " + new String((byte[])actual, "UTF-8"));
+        + new String((byte[])expected, StandardCharsets.UTF_8) +
+          " but received " + new String((byte[])actual, StandardCharsets.UTF_8));
     }
     if (!expected.equals(actual)) {
       throw new Exception("at position " + counter + " column '" + column + "' mismatched values, expected: "

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcDataTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcDataTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.jdbc.test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -46,7 +47,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -64,8 +64,8 @@ public class JdbcDataTest extends JdbcTestBase {
 
   @BeforeClass
   public static void setupFixtures() throws IOException {
-    MODEL = Resources.toString(Resources.getResource("test-models.json"), Charsets.UTF_8);
-    EXPECTED = Resources.toString(Resources.getResource("donuts-output-data.txt"), Charsets.UTF_8);
+    MODEL = Resources.toString(Resources.getResource("test-models.json"), StandardCharsets.UTF_8);
+    EXPECTED = Resources.toString(Resources.getResource("donuts-output-data.txt"), StandardCharsets.UTF_8);
   }
 
   /**

--- a/exec/vector/src/main/codegen/includes/vv_imports.ftl
+++ b/exec/vector/src/main/codegen/includes/vv_imports.ftl
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.ObjectArrays;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ObjectArrays;
 
 import com.google.common.base.Preconditions;
@@ -65,6 +64,7 @@ import java.io.Closeable;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/exec/vector/src/main/codegen/templates/ColumnAccessors.java
+++ b/exec/vector/src/main/codegen/templates/ColumnAccessors.java
@@ -1,3 +1,5 @@
+import java.nio.charset.StandardCharsets;
+
 <#macro copyright>
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -124,6 +126,7 @@ package org.apache.drill.exec.vector.accessor;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -141,8 +144,6 @@ import org.apache.drill.exec.vector.accessor.reader.VectorAccessor;
 import org.apache.drill.exec.vector.accessor.writer.AbstractFixedWidthWriter.BaseFixedWidthWriter;
 import org.apache.drill.exec.vector.accessor.writer.AbstractFixedWidthWriter.BaseIntWriter;
 import org.apache.drill.exec.vector.accessor.writer.BaseVarWidthWriter;
-
-import com.google.common.base.Charsets;
 
 import io.netty.buffer.DrillBuf;
 
@@ -306,13 +307,13 @@ public class ColumnAccessors {
 
     @Override
     public String getString() {
-      return new String(getBytes(${indexVar}), Charsets.UTF_8);
+      return new String(getBytes(${indexVar}), StandardCharsets.UTF_8);
     }
     <#elseif drillType == "Var16Char">
 
     @Override
     public String getString() {
-      return new String(getBytes(${indexVar}), Charsets.UTF_16);
+      return new String(getBytes(${indexVar}), StandardCharsets.UTF_16);
     }
     <#elseif drillType == "VarDecimal">
 
@@ -431,14 +432,14 @@ public class ColumnAccessors {
 
     @Override
     public final void setString(final String value) {
-      final byte bytes[] = value.getBytes(Charsets.UTF_8);
+      final byte bytes[] = value.getBytes(StandardCharsets.UTF_8);
       setBytes(bytes, bytes.length);
     }
     <#elseif drillType == "Var16Char">
 
     @Override
     public final void setString(final String value) {
-      final byte bytes[] = value.getBytes(Charsets.UTF_16);
+      final byte bytes[] = value.getBytes(StandardCharsets.UTF_16);
       setBytes(bytes, bytes.length);
     }
     <#elseif drillType == "BigInt">
@@ -599,9 +600,9 @@ public class ColumnAccessors {
     <#if drillType == "VarBinary">
       emptyValue = (byte[]) value;
     <#elseif drillType == "VarChar">
-      emptyValue = ((String) value).getBytes(Charsets.UTF_8);
+      emptyValue = ((String) value).getBytes(StandardCharsets.UTF_8);
     <#elseif drillType == "Var16Char">
-      emptyValue = ((String) value).getBytes(Charsets.UTF_16);
+      emptyValue = ((String) value).getBytes(StandardCharsets.UTF_16);
     <#elseif drillType == "VarDecimal">
       final BigDecimal rounded = ((BigDecimal) value).setScale(scale, RoundingMode.HALF_UP);
       DecimalUtility.checkValueOverflow(rounded, precision, scale);

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -513,7 +513,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
     <#case "Var16Char">
     @Override
     public ${friendlyType} getObject(int index) {
-      return new String(get(index), Charsets.UTF_16);
+      return new String(get(index), StandardCharsets.UTF_16);
     }
     <#break>
     <#default>
@@ -767,7 +767,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
      * not including the given current write position. Used by nullable
      * vectors to allow skipping values. The <tt>set()</tt> and
      * <tt>setSafe()</tt> <b>do not</b> fill empties. See DRILL-5529.
-     * 
+     *
      * @param lastWrite
      *          the position of the last valid write: the offset to be copied
      *          forward
@@ -868,11 +868,11 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       boolean even = true;
       <#switch minor.class>
       <#case "Var16Char">
-      java.nio.charset.Charset charset = Charsets.UTF_16;
+      java.nio.charset.Charset charset = StandardCharsets.UTF_16;
       <#break>
       <#case "VarChar">
       <#default>
-      java.nio.charset.Charset charset = Charsets.UTF_8;
+      java.nio.charset.Charset charset = StandardCharsets.UTF_8;
       </#switch>
       byte[] evenValue = "aaaaa".getBytes(charset);
       byte[] oddValue = "bbbbbbbbbb".getBytes(charset);

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueHolderHelper.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueHolderHelper.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.vector;
 import io.netty.buffer.DrillBuf;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,8 +44,6 @@ import org.apache.drill.exec.expr.holders.VarCharHolder;
 import org.apache.drill.exec.expr.holders.VarDecimalHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.util.DecimalUtility;
-
-import com.google.common.base.Charsets;
 
 public class ValueHolderHelper {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ValueHolderHelper.class);
@@ -115,7 +114,7 @@ public class ValueHolderHelper {
   public static VarCharHolder getVarCharHolder(DrillBuf buf, String s){
     VarCharHolder vch = new VarCharHolder();
 
-    byte[] b = s.getBytes(Charsets.UTF_8);
+    byte[] b = s.getBytes(StandardCharsets.UTF_8);
     vch.start = 0;
     vch.end = b.length;
     vch.buffer = buf.reallocIfNeeded(b.length);
@@ -126,7 +125,7 @@ public class ValueHolderHelper {
   public static VarCharHolder getVarCharHolder(BufferAllocator a, String s){
     VarCharHolder vch = new VarCharHolder();
 
-    byte[] b = s.getBytes(Charsets.UTF_8);
+    byte[] b = s.getBytes(StandardCharsets.UTF_8);
     vch.start = 0;
     vch.end = b.length;
     vch.buffer = a.buffer(b.length);

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/VectorPrinter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/VectorPrinter.java
@@ -20,7 +20,8 @@ package org.apache.drill.exec.vector.accessor.impl;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
-import com.google.common.base.Charsets;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Handy tool to visualize string and offset vectors for
@@ -77,6 +78,6 @@ public class VectorPrinter {
   }
 
   public static String stringAt(VarCharVector vector, int i) {
-    return new String(vector.getAccessor().get(i), Charsets.UTF_8);
+    return new String(vector.getAccessor().get(i), StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
The aim is to use Java built-in StandardCharsets.
* replace code calls where we use APIs that pass the charset as a string vale (not all APIs have alternatives that take Charset object inputs)
* replace Guava Charsets with Java built-in StandardCharsets