### PR TITLE
DRILL-8479: Merge Join Leak When Depleting Incoming Batches Throw Exception

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
@@ -297,7 +297,14 @@ public class MergeJoinBatch extends AbstractBinaryRecordBatch<MergeJoinPOP> {
       batchMemoryManager.getAvgOutputRowWidth(), batchMemoryManager.getTotalOutputRecords());
 
     super.close();
-    leftIterator.close();
+    try {
+      leftIterator.close();
+    } catch (Exception e) {
+      rightIterator.close();
+      throw UserException.executionError(e)
+          .message("Failed to close Iterator.")
+          .build(logger);
+    }
     rightIterator.close();
   }
 


### PR DESCRIPTION
# [DRILL-8479](https://issues.apache.org/jira/browse/DRILL-8479):  Merge Join Leak When Depleting Incoming Batches Throw Exception

## Description

when fragment failed, it call close() from MergeJoinBatch. but if  leftIterator.close() throw exception, we could not call  rightIterator.close() to release memory。

Relates to: (#2876)

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing

The test method is the same with link, only one parameter needs to be modified,
set planner.enable_hashjoin =false  to  ensure use mergejoin operator
link
[DRILL-8478](https://github.com/apache/drill/pull/2875): HashPartition memory leak when it allocate memory exception with OutOfMemoryException (#2874) 


