### PR TITLE
DRILL-8482:Assign region throw exception when some region is deployed…

### DIFF
--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
@@ -267,7 +267,7 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
     PriorityQueue<List<HBaseSubScanSpec>> minHeap = new PriorityQueue<>(numSlots, LIST_SIZE_COMPARATOR);
     PriorityQueue<List<HBaseSubScanSpec>> maxHeap = new PriorityQueue<>(numSlots, LIST_SIZE_COMPARATOR_REV);
     for(List<HBaseSubScanSpec> listOfScan : endpointFragmentMapping.values()) {
-      if (listOfScan.size() < minPerEndpointSlot) {
+      if (listOfScan.size() < maxPerEndpointSlot) {
         minHeap.offer(listOfScan);
       } else if (listOfScan.size() > minPerEndpointSlot) {
         maxHeap.offer(listOfScan);


### PR DESCRIPTION
# [DRILL-8482](https://issues.apache.org/jira/browse/DRILL-8482):Assign region throw exception when some region is deployed on affinity node and some on non-affinity node (#2886)

## Description

 Assign region throw exception when some region is deployed on affinity node and some on non-affinity node。

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
  
Refer to unit test cases on [TestHBaseRegionScanAssignments#testHBaseGroupScanAssignmentSomeAfinedAndSomeWithOrphans](https://github.com/apache/drill/issues/2886)
