### PR TITLE
[MINOR UPDATE] update commons-compress due to CVEs

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -52,7 +52,12 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>4.2.1</version>
+      <version>4.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons.compress.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <commons.cli.version>1.4</commons.cli.version>
     <commons.codec.version>1.16.0</commons.codec.version>
     <commons.collections.version>4.4</commons.collections.version>
-    <commons.compress.version>1.25.0</commons.compress.version>
+    <commons.compress.version>1.26.1</commons.compress.version>
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.io.version>2.15.0</commons.io.version>
     <commons.lang3.version>3.10</commons.lang3.version>


### PR DESCRIPTION
Updating due to 2 CVEs in commons-compress

https://mvnrepository.com/artifact/org.apache.commons/commons-compress

I released a new version of excel-streaming-reader that was built with the new version of commons-compress.