### PR TITLE
[MINOR UPDATE] Upgrade Zookeeper JAR Due to CVEs

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -33,7 +33,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>54000000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>55000000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <xerces.version>2.12.2</xerces.version>
     <yauaa.version>7.19.2</yauaa.version>
-    <zookeeper.version>3.5.10</zookeeper.version>
+    <zookeeper.version>3.8.4</zookeeper.version>
   </properties>
 
   <scm>
@@ -1441,6 +1441,16 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>${zookeeper.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade due to CVE
https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper

Unfortunately, Zookeeper 3.8 and 3.9 leak their logback dependencies.