### PR TITLE
[MINOR UPDATE] upgrade actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     name: Main Build
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/drill'
     timeout-minutes: 150
     strategy:
       matrix:
@@ -43,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -72,18 +73,19 @@ jobs:
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/drill'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       # Caches built protobuf library
       - name: Cache protobufs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/protobuf
           key: ${{ runner.os }}-protobuf

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/drill'
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -27,11 +27,12 @@ jobs:
   publish:
     name: Publish snapshot artifacts
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/drill'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Cache Maven Repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
* node 16 support is being removed so we need to upgrade actions
* also updated jobs to only run for this repo and not for forks
    * currently, if you do a PR, the full build runs in the user's fork and in apache project
    * one of these days, GitHub are going to start capping build credits
    * we can delay this by not running big CI jobs on forks 