### PR TITLE
DRILL-8480: Cleanup before finished. 0 out of 1 streams have finished 

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoin.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl.join;
 
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.drill.exec.compile.TemplateClassDefinition;
+import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.ExpandableHyperContainer;
 import org.apache.drill.exec.record.RecordBatch;
@@ -33,7 +34,9 @@ public interface NestedLoopJoin {
   public static TemplateClassDefinition<NestedLoopJoin> TEMPLATE_DEFINITION =
       new TemplateClassDefinition<>(NestedLoopJoin.class, NestedLoopJoinTemplate.class);
 
-  public void setupNestedLoopJoin(FragmentContext context, RecordBatch left,
+  public void setupNestedLoopJoin(FragmentContext context,
+                                  RecordBatch left,
+                                  RecordBatch.IterOutcome leftOutcome,
                                   ExpandableHyperContainer rightContainer,
                                   LinkedList<Integer> rightCounts,
                                   NestedLoopJoinBatch outgoing);
@@ -41,7 +44,7 @@ public interface NestedLoopJoin {
   void setTargetOutputCount(int targetOutputCount);
 
   // Produce output records taking into account join type
-  public int outputRecords(JoinRelType joinType);
+  public int outputRecords(JoinRelType joinType) throws SchemaChangeException;
 
   // Project the record at offset 'leftIndex' in the left input batch into the output container at offset 'outIndex'
   public void emitLeft(int leftIndex, int outIndex);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinBatch.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.drill.common.exceptions.UserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.calcite.rel.core.JoinRelType;
@@ -183,7 +184,7 @@ public class NestedLoopJoinBatch extends AbstractBinaryRecordBatch<NestedLoopJoi
           default:
         }
       }
-      nljWorker.setupNestedLoopJoin(context, left, rightContainer, rightCounts, this);
+      nljWorker.setupNestedLoopJoin(context, left, leftUpstream, rightContainer, rightCounts, this);
       state = BatchState.NOT_FIRST;
     }
 
@@ -193,7 +194,11 @@ public class NestedLoopJoinBatch extends AbstractBinaryRecordBatch<NestedLoopJoi
     nljWorker.setTargetOutputCount(batchMemoryManager.getOutputRowCount());
 
     // invoke the runtime generated method to emit records in the output batch
-    outputRecords = nljWorker.outputRecords(popConfig.getJoinType());
+    try {
+      outputRecords = nljWorker.outputRecords(popConfig.getJoinType());
+    } catch (SchemaChangeException e) {
+      throw UserException.schemaChangeError(e).build(logger);
+    }
 
     // Set the record count
     container.setValueCount(outputRecords);


### PR DESCRIPTION

# [DRILL-8480](https://issues.apache.org/jira/browse/DRILL-8480): Make Nested Loop Join operator properly process empty batches and batches with new schema

## Description
Nested Loop Join operator (`NestedLoopJoinBatch`, `NestedLoopJoin`) unproperly handles batch iteration outcome `OK` with 0 records. Drill design of the processing of batches involves 5 states:
* `NONE` (batch can have only 0 records)
* `OK` (batch can have 0+ records)
* `OK_NEW_SCHEMA` (batch can have 0+ records)
* `NOT_YET` (undefined)
* `EMIT` (batch can have 0+ records)
The Nested Loop Join operator in some circumstances could receive `OK` outcome with 0 records, and instead of requesting the next batch, the operator stops data processing and returns `NONE` outcome to upstream batches(operators) without freeing resources of underlying batches.

**Solution**

Make the Nested Loop Join operator properly handle `OK` and `OK_NEW_SCHEMA` outcomes with 0 records and keep processing until `NONE` and `NOT_YET` outcomes are received.

Make the Nested Loop Join operator keep processing even if `OK_NEW_SCHEMA` outcome is received, but the schema wasn’t changed(yes, I know it sounds wild, but it’s possible and it is expected behavior).


## Documentation
-

## Testing
Manual testing with a file from the Jira ticket [DRILL-8480](https://issues.apache.org/jira/browse/DRILL-8480)