### PR TITLE
DRILL-8486: ParquetDecodingException: could not read bytes at offset 

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenEntryReader.java
@@ -43,7 +43,7 @@ final class VarLenEntryReader extends VarLenAbstractPageEntryReader {
     if (bulkProcess()) {
       return getEntryBulk(valuesToRead);
     }
-    return getEntrySingle(valuesToRead);
+    return getEntrySingle();
   }
 
   private final VarLenColumnBulkEntry getEntryBulk(int valuesToRead) {
@@ -92,7 +92,7 @@ final class VarLenEntryReader extends VarLenAbstractPageEntryReader {
     // We're here either because a) the Parquet metadata is wrong (advertises more values than the real count)
     // or the first value being processed ended up to be too long for the buffer.
     if (numValues == 0) {
-      return getEntrySingle(valuesToRead);
+      return getEntrySingle();
     }
 
     // Update the page data buffer offset
@@ -109,7 +109,7 @@ final class VarLenEntryReader extends VarLenAbstractPageEntryReader {
     return entry;
   }
 
-  private final VarLenColumnBulkEntry getEntrySingle(int valuesToRead) {
+  private VarLenColumnBulkEntry getEntrySingle() {
 
     if (remainingPageData() < 4) {
       final String message = String.format("Invalid Parquet page metadata; cannot process advertised page count..");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableEntryReader.java
@@ -45,7 +45,7 @@ final class VarLenNullableEntryReader extends VarLenAbstractPageEntryReader {
     if (bulkProcess()) {
       return getEntryBulk(valuesToRead);
     }
-    return getEntrySingle(valuesToRead);
+    return getEntrySingle();
   }
 
   VarLenColumnBulkEntry getEntryBulk(int valuesToRead) {
@@ -108,7 +108,7 @@ final class VarLenNullableEntryReader extends VarLenAbstractPageEntryReader {
     // We're here either because a) the Parquet metadata is wrong (advertises more values than the real count)
     // or the first value being processed ended up to be too long for the buffer.
     if (numValues == 0) {
-      return getEntrySingle(valuesToRead);
+      return getEntrySingle();
     }
 
     // Update the page data buffer offset
@@ -126,7 +126,7 @@ final class VarLenNullableEntryReader extends VarLenAbstractPageEntryReader {
     return entry;
   }
 
-  VarLenColumnBulkEntry getEntrySingle(int valuesToRead) {
+  VarLenColumnBulkEntry getEntrySingle() {
 
     // Initialize the reader if needed
     pageInfo.definitionLevels.readFirstIntegerIfNeeded();


### PR DESCRIPTION
# [DRILL-8486](https://issues.apache.org/jira/browse/DRILL-8486): fix handling of long variable length entries during bulk parquet reading

## Description

Drill, during a bulk reading of a parquet file, unproperly handles a long value of parquet file entry. Drill reads the value, but after he finds that he can’t handle the value in the current batch, he just moves on, without persisting the read value. Since the value wasn’t pushed back to the reader object, the total read and left-to-read records counts are now in unproper state which causes data reading to fail in the future.

This issue hasn’t been faced before, because the conditions to get into this state are rare.

**Solution**

Push back the value to the reader object to read it in the next iteration, if the current batch can’t hold it.

## Documentation
 \-

## Testing
Manual testing with a parquet file from the Jira ticket: [DRILL-8486](https://issues.apache.org/jira/browse/DRILL-8486). It's hard to reproduce this particular issue with random data.
