### PR TITLE
DRILL-8488: HashJoinPOP memory leak is caused by  OutOfMemoryException

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/cache/VectorAccessibleSerializable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/cache/VectorAccessibleSerializable.java
@@ -133,7 +133,7 @@ public class VectorAccessibleSerializable extends AbstractStreamSerializable {
         vector.load(metaData, buf);
         buf.release(); // Vector now owns the buffer
         vectorList.add(vector);
-      } catch (OutOfMemoryError oom) {
+      } catch (OutOfMemoryException oom) {
         for (ValueVector valueVector : vectorList) {
           valueVector.clear();
         }


### PR DESCRIPTION
# [DRILL-8488](https://issues.apache.org/jira/browse/DRILL-8488): HashJoinPOP memory leak is caused by  OutOfMemoryException

(Please replace `PR Title` with actual PR Title)

## Description

We should catch the OutOfMemoryException instead of OutOfMemoryError, see buffer method for allacate memory 

```
 public DrillBuf buffer(final int initialRequestSize, BufferManager manager) {
    if (!outcome.isOk()) {
      throw new OutOfMemoryException**(createErrorMsg(this, actualRequestSize, initialRequestSize));
    }
}
```
## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
[drill-8485](https://issues.apache.org/jira/browse/DRILL-8485)
