### PR TITLE
[MINOR UPDATE] replace deprecate method use in jackson

### DIFF
--- a/logical/src/main/java/org/apache/drill/common/util/AbstractDynamicBean.java
+++ b/logical/src/main/java/org/apache/drill/common/util/AbstractDynamicBean.java
@@ -41,11 +41,11 @@ public abstract class AbstractDynamicBean {
 
   private static volatile ObjectMapper MAPPER;
 
-  private ObjectNode objectNode = new ObjectNode(null);
+  private final ObjectNode objectNode = new ObjectNode(null);
 
   @JsonAnySetter
   public void _anySetter(String name, JsonNode value){
-    objectNode.put(name, value);
+    objectNode.replace(name, value);
   }
 
   @JsonAnyGetter


### PR DESCRIPTION
# Description
`put(String propertyName, JsonNode value)` is deprcated in 2.4 version. It's recommended to replace it.

