### PR TITLE
DRILL-8495: HTTP Caching Not Saving Pages

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -1013,7 +1013,7 @@ public class SimpleHttp implements AutoCloseable {
 
   /**
    *
-   * @param url
+   * @param url The input URL
    * @return an input stream which the caller is responsible for closing.
    */
   public static InputStream getRequestAndStreamResponse(String url) {
@@ -1029,9 +1029,9 @@ public class SimpleHttp implements AutoCloseable {
 
   /**
    *
-   * @param url
+   * @param url The input URL
    * @return response body which the caller is responsible for closing.
-   * @throws IOException
+   * @throws IOException If anything goes wrong, throws an IOException
    */
   public static ResponseBody makeSimpleGetRequest(String url) throws IOException {
     Request.Builder requestBuilder = new Request.Builder()
@@ -1047,14 +1047,9 @@ public class SimpleHttp implements AutoCloseable {
 
   @Override
   public void close() {
-    Cache cache;
     try {
-      cache = client.cache();
-      if (cache != null) {
-        cache.close();
-      }
       client.connectionPool().evictAll();
-    } catch (IOException e) {
+    } catch (Exception e) {
       logger.warn("Error closing cache. {}", e.getMessage());
     }
   }


### PR DESCRIPTION
# [DRILL-8495](https://issues.apache.org/jira/browse/DRILL-8495): HTTP Caching Not Saving Pages

## Description
A minor bug was introduced in [DRILL-8329](https://github.com/apache/drill/pull/2669) which caused the cache in the HTTP storage plugin to be deleted after every query.  This minor update fixes that bug.

## Documentation
No user facing changes.

## Testing
Tested manually. 