### PR TITLE
DRILL-8495: Tried to remove unmanaged buffer

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/HiveDefaultRecordReader.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/HiveDefaultRecordReader.java
@@ -168,7 +168,7 @@ public class HiveDefaultRecordReader extends AbstractRecordReader {
   protected boolean empty;
 
   /**
-   * Buffer used for population of partition vectors  and to fill in data into vectors via writers
+   * Buffer used for population of partition vectors
    */
   private final DrillBuf drillBuf;
 
@@ -333,7 +333,7 @@ public class HiveDefaultRecordReader extends AbstractRecordReader {
       this.selectedStructFieldRefs = new StructField[selectedColumnNames.size()];
       this.columnValueWriters = new HiveValueWriter[selectedColumnNames.size()];
       this.outputWriter = new VectorContainerWriter(output, /*enabled union*/ false);
-      HiveValueWriterFactory hiveColumnValueWriterFactory = new HiveValueWriterFactory(drillBuf, outputWriter.getWriter());
+      HiveValueWriterFactory hiveColumnValueWriterFactory = new HiveValueWriterFactory(fragmentContext.getManagedBufferManager(), outputWriter.getWriter());
       for (int refIdx = 0; refIdx < selectedStructFieldRefs.length; refIdx++) {
         String columnName = selectedColumnNames.get(refIdx);
         StructField fieldRef = finalObjInspector.getStructFieldRef(columnName);

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/HiveDefaultRecordReader.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/HiveDefaultRecordReader.java
@@ -238,7 +238,7 @@ public class HiveDefaultRecordReader extends AbstractRecordReader {
     this.proxyUserGroupInfo = proxyUgi;
     this.empty = inputSplits == null || inputSplits.isEmpty();
     this.inputSplitsIterator = empty ? Collections.emptyIterator() : inputSplits.iterator();
-    this.drillBuf = context.getManagedBuffer().reallocIfNeeded(256);
+    this.drillBuf = context.getManagedBuffer();
     this.partitionVectors = new ValueVector[0];
     this.partitionValues = new Object[0];
     setColumns(projectedColumns);

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/HiveValueWriterFactory.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/HiveValueWriterFactory.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import io.netty.buffer.DrillBuf;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ops.BufferManager;
 import org.apache.drill.exec.store.hive.writers.complex.HiveListWriter;

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/HiveValueWriterFactory.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/HiveValueWriterFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import io.netty.buffer.DrillBuf;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ops.BufferManager;
 import org.apache.drill.exec.store.hive.writers.complex.HiveListWriter;
 import org.apache.drill.exec.store.hive.writers.complex.HiveMapWriter;
 import org.apache.drill.exec.store.hive.writers.complex.HiveStructWriter;
@@ -97,18 +98,18 @@ public final class HiveValueWriterFactory {
   private static final Logger logger = LoggerFactory.getLogger(HiveValueWriterFactory.class);
 
   /**
-   * Buffer shared across created Hive writers. May be used by writer for reading data
-   * to buffer than from buffer to vector.
+   * Buffer manager used to create buffers for Hive writers for reading data
+   * to buffer than from buffer to vector if needed.
    */
-  private final DrillBuf drillBuf;
+  private final BufferManager bufferManager;
 
   /**
    * Used to manage and create column writers.
    */
   private final SingleMapWriter rootWriter;
 
-  public HiveValueWriterFactory(DrillBuf drillBuf, SingleMapWriter rootWriter) {
-    this.drillBuf = drillBuf;
+  public HiveValueWriterFactory(BufferManager bufferManager, SingleMapWriter rootWriter) {
+    this.bufferManager = bufferManager;
     this.rootWriter = rootWriter;
   }
 
@@ -200,7 +201,7 @@ public final class HiveValueWriterFactory {
       case BINARY: {
         VarBinaryWriter writer = extractWriter(name, parentWriter,
             MapWriter::varBinary, ListWriter::varBinary, UnionVectorWriter::varBinary);
-        return new HiveBinaryWriter((BinaryObjectInspector) inspector, writer, drillBuf);
+        return new HiveBinaryWriter((BinaryObjectInspector) inspector, writer, bufferManager.getManagedBuffer());
       }
       case BOOLEAN: {
         BitWriter writer = extractWriter(name, parentWriter,
@@ -240,12 +241,12 @@ public final class HiveValueWriterFactory {
       case STRING: {
         VarCharWriter writer = extractWriter(name, parentWriter,
             MapWriter::varChar, ListWriter::varChar, UnionVectorWriter::varChar);
-        return new HiveStringWriter((StringObjectInspector) inspector, writer, drillBuf);
+        return new HiveStringWriter((StringObjectInspector) inspector, writer, bufferManager.getManagedBuffer());
       }
       case VARCHAR: {
         VarCharWriter writer = extractWriter(name, parentWriter,
             MapWriter::varChar, ListWriter::varChar, UnionVectorWriter::varChar);
-        return new HiveVarCharWriter((HiveVarcharObjectInspector) inspector, writer, drillBuf);
+        return new HiveVarCharWriter((HiveVarcharObjectInspector) inspector, writer, bufferManager.getManagedBuffer());
       }
       case TIMESTAMP: {
         TimeStampWriter writer = extractWriter(name, parentWriter,
@@ -260,7 +261,7 @@ public final class HiveValueWriterFactory {
       case CHAR: {
         VarCharWriter writer = extractWriter(name, parentWriter,
             MapWriter::varChar, ListWriter::varChar, UnionVectorWriter::varChar);
-        return new HiveCharWriter((HiveCharObjectInspector) inspector, writer, drillBuf);
+        return new HiveCharWriter((HiveCharObjectInspector) inspector, writer, bufferManager.getManagedBuffer());
       }
       case DECIMAL: {
         DecimalTypeInfo decimalType = (DecimalTypeInfo) typeInfo;

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -30,8 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Strings;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.drill.PlanTestBase;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.hive;
 
+import static com.google.common.base.Strings.repeat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Strings;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.drill.PlanTestBase;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
@@ -460,6 +463,24 @@ public class TestHiveStorage extends HiveTestBase {
       .sqlQuery("select name from hive.`table_with_empty_parquet` where id = 1")
       .expectsEmptyResultSet()
       .go();
+  }
+
+  @Test // see DRILL-8495
+  public void testReadingHiveDataBiggerThan256Bytes() throws Exception {
+    testBuilder()
+        .sqlQuery("select * from hive.`256_bytes_plus_table`")
+        .unOrdered()
+        .baselineColumns(
+            "char_col",
+            "varchar_col",
+            "binary_col",
+            "string_col")
+        .baselineValues(
+            repeat("A", 255),
+            repeat("B", 1200),
+            repeat("C", 320).getBytes(),
+            repeat("D", 2200))
+        .go();
   }
 
   private void verifyColumnsMetadata(List<UserProtos.ResultColumnMetadata> columnsList, Map<String, Integer> expectedResult) {

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestInfoSchemaOnHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestInfoSchemaOnHiveStorage.java
@@ -56,6 +56,7 @@ public class TestInfoSchemaOnHiveStorage extends HiveTestBase {
         .baselineValues("hive.default", "hive_view_m")
         .baselineValues("hive.default", "view_over_hive_view")
         .baselineValues("hive.default", "table_with_empty_parquet")
+        .baselineValues("hive.default", "256_bytes_plus_table")
         .go();
 
     testBuilder()
@@ -268,6 +269,7 @@ public class TestInfoSchemaOnHiveStorage extends HiveTestBase {
         .baselineValues("DRILL", "hive.default", "hive_view_m", "TABLE")
         .baselineValues("DRILL", "hive.default", "view_over_hive_view", "VIEW")
         .baselineValues("DRILL", "hive.default", "table_with_empty_parquet", "TABLE")
+        .baselineValues("DRILL", "hive.default", "256_bytes_plus_table", "TABLE")
         .baselineValues("DRILL", "hive.skipper", "kv_text_small", "TABLE")
         .baselineValues("DRILL", "hive.skipper", "kv_text_large", "TABLE")
         .baselineValues("DRILL", "hive.skipper", "kv_incorrect_skip_header", "TABLE")


### PR DESCRIPTION
# [DRILL-8495](https://issues.apache.org/jira/browse/DRILL-8495): Tried to remove unmanaged buffer

The root cause of the issue is that multiple HiveWriters use the same `DrillBuf` and during execution they may reallocate the buffer if size of the buffer is not enough for a value (256 bytes+). Since `drillBuf.reallocIfNeeded(int size)` returns a new instance of `DrillBuf`, all other writers still have a reference for the old one buffer, which after `drillBuf.reallocIfNeeded(int size)` execution is unmanaged now.

## Description

`HiveValueWriterFactory` now creates a unique `DrillBif` for each writer. 

HiveWriters are actually used one-by-one and we could utilize a single buffer for all the writers. To do this, I could create a class holder for `DrillBuf`, so each writer has a reference for the same holder, where will be stored a new buffer from every `drillBuf.reallocIfNeeded(int size)` call. But I thought that such logic looked slightly confusing and I decided just to let each HiveWriter use its own buffer.

## Documentation
\-

## Testing
Add a new unit test to query a Hive table with variable-length values of Binary, VarChar, Char and String types.
