### PR TITLE
DRILL-8490: Sender operator fake memory leak result to sql failed  and memory statistics error when ChannelClosedException

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/AccountingDataTunnel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/AccountingDataTunnel.java
@@ -43,6 +43,7 @@ public class AccountingDataTunnel {
 
   public void sendRecordBatch(FragmentWritableBatch batch) {
     sendingAccountor.increment();
+    sendingAccountor.incrementComplete();
     tunnel.sendRecordBatch(statusHandler, batch);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/DataTunnelStatusHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/DataTunnelStatusHandler.java
@@ -62,4 +62,9 @@ public class DataTunnelStatusHandler implements RpcOutcomeListener<BitData.AckWi
     sendingAccountor.decrement();
     consumer.interrupt(e);
   }
+
+  @Override
+  public void complete() {
+    sendingAccountor.decrementComplete();
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataTunnel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataTunnel.java
@@ -84,7 +84,7 @@ public class DataTunnel {
       }
 
       outcomeListener.interrupted(e);
-
+      outcomeListener.complete();
       // Preserve evidence that the interruption occurred so that code higher up on the call stack can learn of the
       // interruption and respond to it if it wants to.
       Thread.currentThread().interrupt();
@@ -140,6 +140,11 @@ public class DataTunnel {
     public void interrupted(InterruptedException e) {
       sendingSemaphore.release();
       inner.interrupted(e);
+    }
+
+    @Override
+    public void complete() {
+      inner.complete();
     }
   }
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/AbstractRemoteConnection.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/AbstractRemoteConnection.java
@@ -77,7 +77,7 @@ public abstract class AbstractRemoteConnection implements RemoteConnection, Encr
       return true;
     } catch (final InterruptedException e) {
       listener.interrupted(e);
-
+      listener.complete();
       // Preserve evidence that the interruption occurred so that code higher up
       // on the call stack can learn of the
       // interruption and respond to it if it wants to.

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RequestIdMap.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RequestIdMap.java
@@ -115,6 +115,7 @@ class RequestIdMap {
 
     @Override
     public void operationComplete(ChannelFuture future) throws Exception {
+      handler.complete();
       if (!future.isSuccess()) {
         try {
           removeFromMap(coordinationId);

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -120,6 +120,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
       completed = true;
     } catch (Exception | AssertionError e) {
       listener.failed(new RpcException("Failure sending message.", e));
+      listener.complete();
     } finally {
 
       if (!completed) {

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcOutcomeListener.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcOutcomeListener.java
@@ -34,4 +34,10 @@ public interface RpcOutcomeListener<V> {
    * is cancelled due to query cancellations or failures.
    */
   void interrupted(final InterruptedException e);
+
+  /**
+   * Called when an operator complete for waiting msg release
+   */
+  default void complete() {
+  }
 }


### PR DESCRIPTION
# [DRILL-8490](https://issues.apache.org/jira/browse/DRILL-8490): Sender operator fake memory leak result to sql failed  and memory statistics error when ChannelClosedException

## Description

when ChannelClosedException, .ReconnectingConnection#CloseHandler release sendingAccountor reference counter before netty release buffer, so operator was closed before memory is released by netty

## Documentation
  later

## Testing
1. TPCH test condition
(1) script
```
i run sql8 (sql detail as Additional context) with 20 concurrent
tpch test script
```
```

fileName=/data/drill/tpch_sql/1s/shf.txt

random_sql(){
#for i in `seq 1 30`
while true
do

  num=$((RANDOM%22+1))
  if [ -f $fileName ]; then
  echo "$fileName" " is exit"
  exit 0
  else
    $drill_home/sqlline -u \"jdbc:drill:zk=ip:2181/drill/drillbits1_performance_test_shf\" -f tpch_sql8.sql >>/tpch1s_sql${num}.log 2>&1
  fi
done
}
```
(2) parameter

{DRILL_MAX_DIRECT_MEMORY:-"5G"}
open debug : set drill.memory.debug.allocator =true (Check for memory leaks )
(3) sql8

`select   o_year,   sum(case when nation = 'CHINA' then volume else 0 end) / sum(volume) as mkt_share   from (  select   extract(year from o_orderdate) as o_year,   l_extendedprice * 1.0 as volume,   n2.n_name as nation   from hive.tpch1s.part, hive.tpch1s.supplier, hive.tpch1s.lineitem, hive.tpch1s.orders, hive.tpch1s.customer, hive.tpch1s.nation n1, hive.tpch1s.nation n2, hive.tpch1s.region  where   p_partkey = l_partkey   and s_suppkey = l_suppkey   and l_orderkey = o_orderkey   and o_custkey = c_custkey   and c_nationkey = n1.n_nationkey   and n1.n_regionkey = r_regionkey   and r_name = 'ASIA'   and s_nationkey = n2.n_nationkey   and o_orderdate between date '1995-01-01'   and date '1996-12-31'   and p_type = 'LARGE BRUSHED BRASS') as all_nations   group by o_year   order by o_year`

2. test step
(1) run script
(2) when the log contains exception information ,stop script