### PR TITLE
DRILL-8502: some boot options with drill.exec.options prefix are missed in configuration options

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import org.apache.drill.exec.store.sys.store.provider.InMemoryStoreProvider;
-import org.apache.drill.exec.util.AssertionUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -323,7 +322,8 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.ENABLE_ALIASES_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
       new OptionDefinition(ExecConstants.STORAGE_PLUGIN_RETRY_ATTEMPTS_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
       new OptionDefinition(ExecConstants.STORAGE_PLUGIN_RETRY_DELAY_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
-      new OptionDefinition(ExecConstants.STORAGE_PLUGIN_AUTO_DISABLE_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false))
+      new OptionDefinition(ExecConstants.STORAGE_PLUGIN_AUTO_DISABLE_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
+      new OptionDefinition(ExecConstants.DRILLBIT_CONTROLS_VALIDATOR)
     };
 
     CaseInsensitiveMap<OptionDefinition> map = Arrays.stream(definitions)
@@ -332,11 +332,6 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
         Function.identity(),
         (o, n) -> n,
         CaseInsensitiveMap::newHashMap));
-
-
-    if (AssertionUtil.isAssertionsEnabled()) {
-      map.put(ExecConstants.DRILLBIT_CONTROL_INJECTIONS, new OptionDefinition(ExecConstants.DRILLBIT_CONTROLS_VALIDATOR));
-    }
 
     return map;
   }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -561,6 +561,7 @@ drill.exec.options: {
     drill.exec.storage.implicit.row_group_length.column.label: "rgl",
     drill.exec.storage.implicit.row_group_start.column.label: "rgs",
     drill.exec.storage.implicit.suffix.column.label: "suffix",
+    drill.exec.testing.controls: "{}",
     exec.bulk_load_table_list.bulk_size: 1000,
     exec.enable_aliases: true,
     exec.enable_bulk_load_table_list: false,

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -561,7 +561,6 @@ drill.exec.options: {
     drill.exec.storage.implicit.row_group_length.column.label: "rgl",
     drill.exec.storage.implicit.row_group_start.column.label: "rgs",
     drill.exec.storage.implicit.suffix.column.label: "suffix",
-    drill.exec.testing.controls: "{}",
     exec.bulk_load_table_list.bulk_size: 1000,
     exec.enable_aliases: true,
     exec.enable_bulk_load_table_list: false,
@@ -570,11 +569,9 @@ drill.exec.options: {
     exec.errors.verbose: false,
     exec.except_add_agg_below: false,
 
-    exec.hashagg.max_batches_in_memory: 65536,
     exec.hashagg.mem_limit: 0,
     exec.hashagg.min_batches_per_partition: 2,
     exec.hashagg.num_partitions: 32,
-    exec.hashagg.num_rows_in_batch: 128,
     exec.hashagg.use_memory_prediction: true,
 
     exec.hashjoin.bloom_filter.fpp: 0.75,
@@ -584,7 +581,6 @@ drill.exec.options: {
     exec.hashjoin.hash_double_factor: 2.0,
     exec.hashjoin.hash_table_calc_type: "LEAN",
     exec.hashjoin.max_batches_in_memory: 0,
-    exec.hashjoin.mem_limit: 0,
     exec.hashjoin.num_partitions: 32,
     exec.hashjoin.num_rows_in_batch: 1024,
     exec.hashjoin.runtime_filter.max.waiting.time: 300, #400 ms
@@ -793,9 +789,7 @@ drill.exec.options: {
 
     exec.query.max_rows: 0,
     exec.query.return_result_set_for_ddl: true,
-    exec.query.return_result_set_for_ddl: true,
     exec.query.rowkeyjoin_batchsize: 128,
-    exec.return_result_set_for_ddl: true,
 
     # ========= rm related options ===========
     exec.rm.queryTags: "",


### PR DESCRIPTION
# [DRILL-8502](https://issues.apache.org/jira/browse/DRILL-8502): Some boot options with drill.exec.options prefix are missed in configuration options
## Description
This PR removes 3 unused properties and 1 duplicate property and makes `drill.exec.options.drill.exec.testing.controls` visible all the time, not only when assertions mode is enabled. 

During an investigation of the Drill configuration system, I noticed Drill has several system options(`drill.exec.options.*` properties), which are absent in `SystemOptionManager`, but present in `DrillConfig`:
```sql
apache drill> select name from sys.boot where name like 'drill.exec.options%' AND name not in (select concat('drill.exec.options.', name) from sys.internal_options union all select concat('drill.exec.options.', name) from sys.options);
+-------------------------------------------------------+
|                         name                          |
+-------------------------------------------------------+
| drill.exec.options.drill.exec.testing.controls        |
| drill.exec.options.exec.hashagg.max_batches_in_memory |
| drill.exec.options.exec.hashagg.num_rows_in_batch     |
| drill.exec.options.exec.hashjoin.mem_limit            |
| drill.exec.options.exec.return_result_set_for_ddl     |
+-------------------------------------------------------+
```

I've analyzed the Drill code and concluded:
1. `drill.exec.options.drill.exec.testing.controls` - ~~is set to empty in `drill-module.conf` in `java-exec` jar. This property becomes available only when an assertions mode is enabled. All the other time this option is never used and should not be initialized. Even with enabled assertions mode a `null` value is acceptable.~~ 
  `DRILLBIT_CONTROLS_VALIDATOR` along with its default value is added to `SystemOptionManager` only when an assertions mode is enabled, but all the other time, `drill.exec.options.drill.exec.testing.controls` is present only in `DrillConfig`. I think it's a little confusing, that a system option may be present, but may not. So I reverted a change that adds logic of adding the validator when the assertions mode is enabled. Commit which brings this logic: https://github.com/apache/drill/commit/2af6340da24cf40cc3512b728a460b84eb610dce#diff-f17deea2cf176841c1056a79613481f2b9c42f29eaa151958eaabf14169d3e24R118-R120
3. `drill.exec.options.exec.hashagg.max_batches_in_memory` - is set to 65536 in `drill-module.conf` in `java-exec` jar. This property is never used.
4. ` drill.exec.options.exec.hashagg.num_rows_in_batch` - is set to 128 in `drill-module.conf` in `java-exec` jar. This property is never used.
5. `drill.exec.options.exec.hashjoin.mem_limit` - is set to 0 in `drill-module.conf` in `java-exec` jar. This property is never used.
6. `drill.exec.options.exec.return_result_set_for_ddl` - is set to `true`. This property is probably a typo of `drill.exec.options.exec.query.return_result_set_for_ddl`.