### PR TITLE
[MINOR UPDATE] update to poi 5.3.0

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Format : Excel</name>
 
   <properties>
-    <poi.version>5.2.5</poi.version>
+    <poi.version>5.3.0</poi.version>
   </properties>
   <dependencies>
     <dependency>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>4.3.0</version>
+      <version>5.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.github.pjfanning</groupId>
       <artifactId>excel-streaming-reader</artifactId>
-      <version>5.0.1</version>
+      <version>5.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <commons.compress.version>1.26.2</commons.compress.version>
     <commons.configuration.version>1.10</commons.configuration.version>
     <commons.io.version>2.16.1</commons.io.version>
-    <commons.lang3.version>3.10</commons.lang3.version>
+    <commons.lang3.version>3.14.0</commons.lang3.version>
     <commons.net.version>3.9.0</commons.net.version>
     <commons.text.version>1.10.0</commons.text.version>
     <commons.validator.version>1.7</commons.validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <codemodel.version>2.6</codemodel.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <commons.cli.version>1.4</commons.cli.version>
-    <commons.codec.version>1.16.0</commons.codec.version>
+    <commons.codec.version>1.17.0</commons.codec.version>
     <commons.collections.version>4.4</commons.collections.version>
     <commons.compress.version>1.26.2</commons.compress.version>
     <commons.configuration.version>1.10</commons.configuration.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
     <commons.cli.version>1.4</commons.cli.version>
     <commons.codec.version>1.16.0</commons.codec.version>
     <commons.collections.version>4.4</commons.collections.version>
-    <commons.compress.version>1.26.1</commons.compress.version>
+    <commons.compress.version>1.26.2</commons.compress.version>
     <commons.configuration.version>1.10</commons.configuration.version>
-    <commons.io.version>2.15.0</commons.io.version>
+    <commons.io.version>2.16.1</commons.io.version>
     <commons.lang3.version>3.10</commons.lang3.version>
     <commons.net.version>3.9.0</commons.net.version>
     <commons.text.version>1.10.0</commons.text.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <kerby.version>1.0.1</kerby.version>
     <libthrift.version>0.18.1</libthrift.version>
     <license.skip>true</license.skip>
-    <log4j.version>2.22.0</log4j.version>
+    <log4j.version>2.23.1</log4j.version>
     <!-- Upgrading logback further breaks JDK 8 build compatibility -->
     <logback.version>1.3.14</logback.version>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
excel-streaming-reader now makes poi-shared-strings optional and Drill doesn't need it (or its h2 dependency).