### PR TITLE
Add threadSafe annotation to fmpp Maven Plugin

### DIFF
--- a/tools/fmpp/src/main/java/org/apache/drill/fmpp/mojo/FMPPMojo.java
+++ b/tools/fmpp/src/main/java/org/apache/drill/fmpp/mojo/FMPPMojo.java
@@ -42,6 +42,7 @@ import fmpp.util.MiscUtil;
 /**
  * a maven plugin to run the freemarker generation incrementally
  * (if output has not changed, the files are not touched)
+ * @threadSafe
  * @goal generate
  * @phase generate-sources
  */


### PR DESCRIPTION
Without this annotation Maven assumes the plugin is NOT threadsafe, and any parallel builds spews log warnings

Fixes: #2928