### PR TITLE
DRILL-8503: Add Configuration Option to Skip Host Validation for Splunk

### DIFF
--- a/contrib/storage-splunk/README.md
+++ b/contrib/storage-splunk/README.md
@@ -3,21 +3,22 @@ This plugin enables Drill to query Splunk.
 
 ## Configuration
 
-| Option               | Default   | Description                                                     | Since |
-| -------------------- | --------- | --------------------------------------------------------------- | ----- |
-| type                 | (none)    | Set to "splunk" to use this plugin                              | 1.19  |
-| username             | null      | Splunk username to be used by Drill                             | 1.19  |
-| password             | null      | Splunk password to be used by Drill                             | 1.19  |
-| scheme               | https     | The scheme with which to access the Splunk host                 | 2.0   |
-| hostname             | localhost | Splunk host to be queried by Drill                              | 1.19  |
-| port                 | 8089      | TCP port over which Drill will connect to Splunk                | 1.19  |
-| earliestTime         | null      | Global earliest record timestamp default                        | 1.19  |
-| latestTime           | null      | Global latest record timestamp default                          | 1.19  |
-| app                  | null      | The application context of the service[^1]                      | 2.0   |
-| owner                | null      | The owner context of the service[^1]                            | 2.0   |
-| token                | null      | A Splunk authentication token to use for the session[^2]        | 2.0   |
-| cookie               | null      | A valid login cookie                                            | 2.0   |
-| validateCertificates | true      | Whether the Splunk client will validates the server's SSL cert  | 2.0   |
+| Option                | Default   | Description                                                     | Since |
+|-----------------------| --------- | --------------------------------------------------------------- | ----- |
+| type                  | (none)    | Set to "splunk" to use this plugin                              | 1.19  |
+| username              | null      | Splunk username to be used by Drill                             | 1.19  |
+| password              | null      | Splunk password to be used by Drill                             | 1.19  |
+| scheme                | https     | The scheme with which to access the Splunk host                 | 2.0   |
+| hostname              | localhost | Splunk host to be queried by Drill                              | 1.19  |
+| port                  | 8089      | TCP port over which Drill will connect to Splunk                | 1.19  |
+| earliestTime          | null      | Global earliest record timestamp default                        | 1.19  |
+| latestTime            | null      | Global latest record timestamp default                          | 1.19  |
+| app                   | null      | The application context of the service[^1]                      | 2.0   |
+| owner                 | null      | The owner context of the service[^1]                            | 2.0   |
+| token                 | null      | A Splunk authentication token to use for the session[^2]        | 2.0   |
+| cookie                | null      | A valid login cookie                                            | 2.0   |
+| validateCertificates  | true      | Whether the Splunk client will validates the server's SSL cert  | 2.0   |
+| validateHostname      | true      | Whether the Splunk client will validate the server's host name  | 1.22  |
 
 [^1]: See [this Splunk documentation](https://docs.splunk.com/Documentation/Splunk/latest/Admin/Apparchitectureandobjectownership) for more information.
 [^2]: See [this Splunk documentation](https://docs.splunk.com/Documentation/Splunk/latest/Security/CreateAuthTokens) for more information.

--- a/contrib/storage-splunk/pom.xml
+++ b/contrib/storage-splunk/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.splunk</groupId>
       <artifactId>splunk</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.plugins</groupId>

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkConnection.java
@@ -118,7 +118,7 @@ public class SplunkConnection {
   public Service connect() {
     HttpService.setValidateCertificates(validateCertificates);
     HttpService.setSslSecurityProtocol(SSLSecurityProtocol.TLSv1_2);
-    
+
     if (! validateCertificates) {
       try {
         HttpService.setSSLSocketFactory(createAllTrustingSSLFactory());

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkPluginConfig.java
@@ -20,6 +20,8 @@ package org.apache.drill.exec.store.splunk;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.common.PlanStringBuilder;
@@ -49,6 +51,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
   private final String token;
   private final String cookie;
   private final boolean validateCertificates;
+  private final boolean validateHostname;
   private final Integer reconnectRetries;
   private final boolean writable;
   private final Integer writerBatchSize;
@@ -64,6 +67,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
                             @JsonProperty("token") String token,
                             @JsonProperty("cookie") String cookie,
                             @JsonProperty("validateCertificates") boolean validateCertificates,
+                            @JsonProperty("validateHostname") boolean validateHostname,
                             @JsonProperty("earliestTime") String earliestTime,
                             @JsonProperty("latestTime") String latestTime,
                             @JsonProperty("credentialsProvider") CredentialsProvider credentialsProvider,
@@ -82,6 +86,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
     this.cookie = cookie;
     this.writable = writable;
     this.validateCertificates = validateCertificates;
+    this.validateHostname = validateHostname;
     this.earliestTime = earliestTime;
     this.latestTime = latestTime == null ? "now" : latestTime;
     this.reconnectRetries = reconnectRetries;
@@ -99,6 +104,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
     this.writable = that.writable;
     this.cookie = that.cookie;
     this.validateCertificates = that.validateCertificates;
+    this.validateHostname = that.validateHostname;
     this.earliestTime = that.earliestTime;
     this.latestTime = that.latestTime;
     this.reconnectRetries = that.reconnectRetries;
@@ -188,8 +194,15 @@ public class SplunkPluginConfig extends StoragePluginConfig {
   }
 
   @JsonProperty("validateCertificates")
+  @JsonInclude(Include.NON_DEFAULT)
   public boolean getValidateCertificates() {
     return validateCertificates;
+  }
+
+  @JsonProperty("validateHostname")
+  @JsonInclude(Include.NON_DEFAULT)
+  public boolean getValidateHostname() {
+    return validateHostname;
   }
 
   @JsonProperty("earliestTime")
@@ -234,6 +247,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       Objects.equals(token, thatConfig.token) &&
       Objects.equals(cookie, thatConfig.cookie) &&
       Objects.equals(validateCertificates, thatConfig.validateCertificates) &&
+      Objects.equals(validateHostname, thatConfig.validateHostname) &&
       Objects.equals(earliestTime, thatConfig.earliestTime) &&
       Objects.equals(latestTime, thatConfig.latestTime) &&
       Objects.equals(authMode, thatConfig.authMode);
@@ -252,6 +266,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       cookie,
       writable,
       validateCertificates,
+      validateHostname,
       earliestTime,
       latestTime,
       authMode
@@ -271,6 +286,7 @@ public class SplunkPluginConfig extends StoragePluginConfig {
       .field("token", token)
       .field("cookie", cookie)
       .field("validateCertificates", validateCertificates)
+      .field("validateHostname", validateHostname)
       .field("earliestTime", earliestTime)
       .field("latestTime", latestTime)
       .field("Authentication Mode", authMode)

--- a/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkUtils.java
+++ b/contrib/storage-splunk/src/main/java/org/apache/drill/exec/store/splunk/SplunkUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.drill.exec.store.splunk;
 
-import java.util.Arrays;
-
 public class SplunkUtils {
   /**
    * These are special fields that alter the queries sent to Splunk.
@@ -54,9 +52,13 @@ public class SplunkUtils {
      * @param unknownField The field to be pushed down
      * @return true if the field is a special field, false if not.
      */
-    public static boolean includes(String field) {
-      return Arrays.stream(SplunkUtils.SPECIAL_FIELDS.values())
-        .anyMatch(special -> field.equals(special.name()));
+    public static boolean includes(String unknownField) {
+      for (SPECIAL_FIELDS field : SPECIAL_FIELDS.values()) {
+        if (field.field.equals(unknownField)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 }

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkConnectionTest.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkConnectionTest.java
@@ -54,6 +54,7 @@ public class SplunkConnectionTest extends SplunkBaseTest {
         SPLUNK_STORAGE_PLUGIN_CONFIG.getToken(),
         SPLUNK_STORAGE_PLUGIN_CONFIG.getCookie(),
         SPLUNK_STORAGE_PLUGIN_CONFIG.getValidateCertificates(),
+        SPLUNK_STORAGE_PLUGIN_CONFIG.getValidateHostname(),
         SPLUNK_STORAGE_PLUGIN_CONFIG.getEarliestTime(),
         SPLUNK_STORAGE_PLUGIN_CONFIG.getLatestTime(),
         null,

--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -94,7 +94,7 @@ public class SplunkTestSuite extends ClusterTest {
         SPLUNK_STORAGE_PLUGIN_CONFIG = new SplunkPluginConfig(
           SPLUNK_LOGIN, SPLUNK_PASS,
           "http", hostname, port,
-          null, null, null, null, false, // app, owner, token, cookie, validateCertificates
+          null, null, null, null, false, true, // app, owner, token, cookie, validateCertificates
           "1", "now",
           null,
           4,
@@ -116,7 +116,7 @@ public class SplunkTestSuite extends ClusterTest {
         SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION = new SplunkPluginConfig(
           null, null, // username, password
           "http", hostname, port,
-          null, null, null, null, false, // app, owner, token, cookie, validateCertificates
+          null, null, null, null, false, false, // app, owner, token, cookie, validateCertificates
           "1", "now",
           credentialsProvider,
           4,


### PR DESCRIPTION
# [DRILL-8503](https://issues.apache.org/jira/browse/DRILL-8503): Add Configuration Option to Skip Host Validation for Splunk

## Description
in corporate installations, sometimes the organization will use self-signed certificates which can cause problems.  This PR adds an option to bypass host validation for SSL connections in Splunk.  The "correct" way to fix this would be to provide better SSL information, to include the certificate in the Splunk connection, however, Splunk's SDK does not allow for this and there are several open issues and PRs relating to this.  

This PR also bumps the Splunk SDK version to the latest version which is 1.9.5.  

## Documentation
An additional configuration option: `validateHostnames` has been added to the Splunk configuration.  I updated the README.md file with this information and will be updating the documentation once this has been merged.

## Testing
Ran existing unit tests and tested manually. 