### PR TITLE
DRILL-8505: Fix Docker Hub automated container image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,15 @@
 # {docker|podman} build \
 #    --build-arg BUILD_BASE_IMAGE=maven:3.8.2-openjdk-11 \
 #    --build-arg BASE_IMAGE=openjdk:11 \
-#    -t apache/drill-openjdk-11 
+#    -t apache/drill-openjdk-11
 
-# Unless otherwise specified, the intermediate container image will be 
+# Unless otherwise specified, the intermediate container image will be
 # based on the following default.
-ARG BUILD_BASE_IMAGE=maven:3.8.2-openjdk-8
+ARG BUILD_BASE_IMAGE=maven:3-openjdk-17
 
 # Unless otherwise specified, the final container image will be based on
 # the following default.
-ARG BASE_IMAGE=openjdk:8
+ARG BASE_IMAGE=openjdk:17
 
 # Uses intermediate image for building Drill to reduce target image size
 FROM $BUILD_BASE_IMAGE as build
@@ -44,7 +44,7 @@ WORKDIR /src
 COPY . .
 
 # Builds Drill
-RUN mvn -Dmaven.artifact.threads=5 -T1C clean install -DskipTests
+RUN mvn clean install -DskipTests
 
 # Get project version and copy built binaries into /opt/drill directory
 RUN VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
@@ -54,7 +54,7 @@ RUN VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --n
 
 # Target image
 
-# Set the BASE_IMAGE build arg when you invoke docker build.  
+# Set the BASE_IMAGE build arg when you invoke docker build.
 FROM $BASE_IMAGE
 
 # Starts Drill in embedded mode and connects to Sqlline

--- a/hooks/build
+++ b/hooks/build
@@ -21,7 +21,6 @@ docker build \
 	--build-arg BUILD_BASE_IMAGE=maven:3-openjdk-8 \
 	--build-arg BASE_IMAGE=openjdk:8 \
 	-t apache/drill:$DOCKER_TAG-openjdk-8 \
-	-t apache/drill:$DOCKER_TAG \
 	.
 
 docker build \
@@ -34,4 +33,5 @@ docker build \
 	--build-arg BUILD_BASE_IMAGE=maven:3-openjdk-17 \
 	--build-arg BASE_IMAGE=openjdk:17-slim-bullseye \
 	-t apache/drill:$DOCKER_TAG-openjdk-17 \
+	-t apache/drill:$DOCKER_TAG \
 	.


### PR DESCRIPTION
# [DRILL-8505](https://issues.apache.org/jira/browse/DRILL-8505): Fix Docker Hub automated container image builds

## Description

1. Use a single threaded Maven build to avoid thread-unsafe Maven plugin issues.
2. Move the _latest_ and _master_ tags to OpenJDK 17. Images based on on all three of OpenJDK 8, 11 and 17 continue to be published and tagged accordingly but the "default" tags of _latest_ and _master_ are repointed to OpenJDK 17. This affects the _master_ image as soon as this PR is merged, while the _latest_ image will only change with the next Drill release.

## Documentation
N/A

## Testing
Manual test of the Docker Hub automated build based on the temporary drill-8505 branch in the apache/drill repo. The temporary branch are resulting container image on Docker Hub are to be cleaned up after this PR is finalised.

![image](https://github.com/user-attachments/assets/4063a2ee-00b7-4e5f-a57f-a3a6f6369dea)
