### PR TITLE
DRILL-8506: Ignore JSON Elements with Empty Keys

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ObjectParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ObjectParser.java
@@ -238,8 +238,8 @@ public abstract class ObjectParser extends AbstractElementParser {
    */
   private ElementParser detectValueParser(String key, TokenIterator tokenizer) {
     if (key.isEmpty()) {
-      throw errorFactory().structureError(
-          "Drill does not allow empty keys in JSON key/value pairs");
+      logger.warn("Ignoring empty key: {}", key);
+      return DummyValueParser.INSTANCE;
     }
     ElementParser fieldParser = onField(key, tokenizer);
     if (fieldParser == null) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestBasics.java
@@ -17,12 +17,6 @@
  */
 package org.apache.drill.exec.store.easy.json.loader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import org.apache.drill.categories.JsonTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -34,6 +28,12 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Category(JsonTest.class)
 public class TestBasics extends BaseJsonLoaderTest {
@@ -176,12 +176,22 @@ public class TestBasics extends BaseJsonLoaderTest {
 
   @Test
   public void testEmptyKey() {
-    expectError("{\"\": 10}", "does not allow empty keys");
+    JsonLoaderFixture loader = new JsonLoaderFixture();
+    loader.jsonOptions.skipMalformedRecords = true;
+    loader.open("{\"\": 10}");
+    RowSet results = loader.next();
+    assertNotNull(results);
+    assertEquals(1, results.rowCount());
   }
 
   @Test
   public void testBlankKey() {
-    expectError("{\"  \": 10}", "does not allow empty keys");
+    JsonLoaderFixture loader = new JsonLoaderFixture();
+    loader.jsonOptions.skipMalformedRecords = true;
+    loader.open("{\"  \": 10}");
+    RowSet results = loader.next();
+    assertNotNull(results);
+    assertEquals(1, results.rowCount());
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-8506](https://issues.apache.org/jira/browse/DRILL-8506): Ignore JSON Elements with Empty Keys

## Description
If Drill encounters a JSON field with an empty key, currently Drill throws an exception.   This behavior prevents Drill from reading the rest of the data.  This PR modifies Drill's behavior by simply ignoring JSON data with empty keys.   Drill will generate a log warning message when this happens.

## Documentation
No significant user facing changes.

## Testing
Ran existing unit tests.