### PR TITLE
DRILL-8511: Overflow appeared when the batch reached rows limit

### DIFF
--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BitColumnWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BitColumnWriter.java
@@ -84,7 +84,7 @@ public class BitColumnWriter extends AbstractFixedWidthWriter {
 
   @Override
   public void setValueCount(int valueCount) {
-    prepareWrite(valueCount);
+    prepareWrite(valueCount - 1);
     mutator.setValueCount(valueCount);
   }
 


### PR DESCRIPTION
# [DRILL-8511](https://issues.apache.org/jira/browse/DRILL-8511): Overflow appeared when the batch reached rows limit

## Description

The size-aware scan framework fails to end the batch.

Framework tries to reallocate the vector on batch end, due to a hidden, minor bug in `BitColumnWriter` - which in general is not notable, but in a specific case, when the initial vector allocation size limit is exceeded and a reader reaches the batch row size limit.

`BitColumnWriter` uses instead of a write index a value count and this causes unexpected vector reallocation (look at the changes).

## Documentation
No changes required.

## Testing
Manual tests
