### PR TITLE
DRILL-8260: added platforms (linux/amd64,linux/arm64) on docker build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -18,18 +18,21 @@
 #
 
 docker build \
+	--platform linux/amd64,linux/arm64 \
 	--build-arg BUILD_BASE_IMAGE=maven:3-openjdk-8 \
 	--build-arg BASE_IMAGE=openjdk:8 \
 	-t apache/drill:$DOCKER_TAG-openjdk-8 \
 	.
 
 docker build \
+	--platform linux/amd64,linux/arm64 \
 	--build-arg BUILD_BASE_IMAGE=maven:3-openjdk-11 \
 	--build-arg BASE_IMAGE=openjdk:11 \
 	-t apache/drill:$DOCKER_TAG-openjdk-11 \
 	.
 
 docker build \
+	--platform linux/amd64,linux/arm64 \
 	--build-arg BUILD_BASE_IMAGE=maven:3-openjdk-17 \
 	--build-arg BASE_IMAGE=openjdk:17-slim-bullseye \
 	-t apache/drill:$DOCKER_TAG-openjdk-17 \


### PR DESCRIPTION
# [DRILL-8260](https://issues.apache.org/jira/browse/DRILL-8260): added platforms (linux/amd64,linux/arm64) on docker build

## Description

Added the following platforms in the build file from the hooks folder: linux/amd64 and linux/arm64

## Documentation
Now Apache Drill Docker image is available for both linux/arm64 and linux/amd64

## Testing
Built images locally
