### PR TITLE
DRILL-8513: Right Hash Join with empty Left table ruturns 0 result

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -42,13 +42,13 @@ public class HashJoinProbeTemplate extends ProbeTemplate<HashJoinPOP> {
                                  IterOutcome leftStartState, HashPartition[] partitions, int cycleNum,
                                  VectorContainer container, AbstractHashBinaryRecordBatch.SpilledPartition[] spilledInners,
                                  boolean buildSideIsEmpty, int numPartitions, int rightHVColPosition) throws SchemaChangeException {
-    super.setup(probeBatch, leftStartState, partitions, cycleNum, container, spilledInners,
-      buildSideIsEmpty, numPartitions);
     this.outgoingBatch = outgoing;
     this.joinType = joinRelType;
     this.joinControl = new JoinControl(outgoing.getPopConfig().getJoinControl());
     this.semiJoin = semiJoin;
     this.numberOfBuildSideColumns = semiJoin ? 0 : rightHVColPosition; // position (0 based) of added column == #columns
+    super.setup(probeBatch, leftStartState, partitions, cycleNum, container, spilledInners,
+      buildSideIsEmpty, numPartitions);
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
@@ -106,6 +106,11 @@ public class TestHashJoin extends PopUnitTestBase {
   }
 
   @Test
+  public void emptyLeftSideOnRightJoin() throws Throwable {
+    testHJMockScanCommon("/join/hj_right_outer_empty_left_input.json", 5);
+  }
+
+  @Test
   public void simpleEqualityJoin() throws Throwable {
     // Function checks hash join with single equality condition
     try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();

--- a/exec/java-exec/src/test/resources/join/hj_right_outer_empty_left_input.json
+++ b/exec/java-exec/src/test/resources/join/hj_right_outer_empty_left_input.json
@@ -1,0 +1,42 @@
+{
+  head:{
+    type:"APACHE_DRILL_PHYSICAL",
+    version:"1",
+    generator:{
+      type:"manual"
+    }
+  },
+  graph:[
+    {
+      @id:1,
+      pop:"mock-sub-scan",
+      entries:[
+        {records: 0, types: [
+          {name: "id", type: "INT", mode: "REQUIRED"}
+        ]}
+      ]
+    },
+    {
+      @id:2,
+      pop:"mock-sub-scan",
+      entries:[
+        {records: 5, types: [
+          {name: "id1", type: "INT", mode: "REQUIRED"}
+        ]}
+      ]
+    },
+    {
+      @id: 3,
+      left: 1,
+      right: 2,
+      pop: "hash-join",
+      joinType: "RIGHT",
+      conditions: [ {relationship: "==", left: "id", right: "id1"} ]
+    },
+    {
+      @id: 4,
+      child: 3,
+      pop: "screen"
+    }
+  ]
+}


### PR DESCRIPTION
# [DRILL-8513](https://issues.apache.org/jira/browse/DRILL-8513): Right Hash Join with empty Left table ruturns 0 result

## Description

Drill returns no results on the right Hash Join if the probe(left) table is empty.

The root cause is simple. Stack-trace of the point of failure:
```
changeToFinalProbeState:123, HashJoinProbeTemplate (org.apache.drill.exec.physical.impl.join)
setup:105, ProbeTemplate (org.apache.drill.exec.physical.impl.join) <---- The issue comes from here. Because the changeToFinalProbeState() is called before all necessary variables are initialized by the HashJoinProbeTemplate#setup() method.  
setup:45, HashJoinProbeTemplate (org.apache.drill.exec.physical.impl.join) 
setupProbe:108, HashJoinBatch (org.apache.drill.exec.physical.impl.join)
innerNext:585, AbstractHashBinaryRecordBatch (org.apache.drill.exec.physical.impl.join)
```
`HashJoinProbeTemplate#setup()` calls it's super `#setup()` before `joinType` set and it makes `#changeToFinalProbeState()` set incorrect `ProbeState`. This code change comes from https://github.com/apache/drill/pull/2599

The solution is as simple as the bug: to call `ProbeTemplate#setup(`) at the end of `HashJoinProbeTemplate#setup()`.
## Documentation
\- 

## Testing
New unit test with an empty left input for HashJoin.
