### PR TITLE
[MINOR UPDATE] use same version of commons-io in all drill projects

### DIFF
--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>${commons.io.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Relates to #2946 - but might be better to use same commons-io version in all Drill projects