### PR TITLE
[MINOR UPDATE] remove jitpack.io repo lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,11 +197,6 @@
         <checksumPolicy>fail</checksumPolicy>
       </snapshots>
     </repository>
-
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
   </repositories>
 
   <issueManagement>
@@ -791,12 +786,6 @@
       </plugins>
     </pluginManagement>
   </build>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </pluginRepository>
-  </pluginRepositories>
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
Not ideal to get jars from this repo. If we really need it for 1 or 2 jars, we should isolate to those places.