### PR TITLE
DRILL-8515: Upgrade to HBase client 2.6.1

### DIFF
--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <phoenix.version>5.1.3</phoenix.version>
     <!-- Limit the HBase minicluster version to 2.4.x to avoid a dependency conflict. -->
-    <hbase.minicluster.version>2.6.1</hbase.minicluster.version>
+    <hbase.minicluster.version>2.4.17</hbase.minicluster.version>
     <skipTests>false</skipTests>
   </properties>
 

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <phoenix.version>5.1.3</phoenix.version>
     <!-- Limit the HBase minicluster version to 2.4.x to avoid a dependency conflict. -->
-    <hbase.minicluster.version>2.4.17</hbase.minicluster.version>
+    <hbase.minicluster.version>2.6.1</hbase.minicluster.version>
     <skipTests>false</skipTests>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <guava.version>32.1.2-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <hbase.version>2.5.5-hadoop3</hbase.version>
+    <hbase.version>2.6.1-hadoop3</hbase.version>
     <hikari.version>4.0.3</hikari.version>
     <!--
       Currently, Hive storage plugin only supports Apache Hive 3.1.3 or vendor specific variants of the
@@ -2943,7 +2943,7 @@
       </activation>
       <properties>
         <hadoop.version>2.10.2</hadoop.version>
-        <hbase.version>2.5.5</hbase.version>
+        <hbase.version>2.6.1</hbase.version>
       </properties>
       <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Description

[DRILL-8515](https://issues.apache.org/jira/browse/DRILL-8515)

Upgrade HBase client due to issues with zookeeper upgrade - #2893 

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
(Please describe how this PR has been tested.)
