### PR TITLE
[CI] use ubuntu 22 for checkstyle/protobuf job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           "
   checkstyle_protobuf:
     name: Run checkstyle and generate protobufs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'apache/drill'
     steps:
       - name: Checkout


### PR DESCRIPTION
Subjob is failing in today's builds - make tool issues when running protobuf bits.

GitHub CI recently moved to unbuntu 24 for 'latest' install.

eg
https://github.com/apache/drill/actions/runs/12504907055/job/34889343661