### PR TITLE
[MINOR UPDATE] upgrade Phoenix to 5.2.1

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/UserExceptionUtils.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserExceptionUtils.java
@@ -33,7 +33,8 @@ public class UserExceptionUtils {
     return String.format("[Hint: %s]", text);
   }
   public static String getUserHint(final Throwable ex) {
-    if (ex.getMessage().startsWith("Error getting user info for current user")) {
+    final String message = ex.getMessage();
+    if (message != null && message.startsWith("Error getting user info for current user")) {
       //User does not exist hint
       return decorateHint(USER_DOES_NOT_EXIST);
     } else {

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -330,6 +330,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apiguardian</groupId>
+      <artifactId>apiguardian-api</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -29,9 +29,9 @@
   <name>Drill : Contrib : Storage : Phoenix</name>
 
   <properties>
-    <phoenix.version>5.1.3</phoenix.version>
-    <!-- Limit the HBase minicluster version to 2.4.x to avoid a dependency conflict. -->
-    <hbase.minicluster.version>2.4.17</hbase.minicluster.version>
+    <phoenix.version>5.2.1</phoenix.version>
+    <!-- Limit the HBase minicluster version to 2.5.x to avoid a dependency conflict. -->
+    <hbase.minicluster.version>2.5.10</hbase.minicluster.version>
     <skipTests>false</skipTests>
   </properties>
 

--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -122,11 +122,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>
-      <artifactId>phoenix-hbase-compat-2.4.1</artifactId>
-      <version>${phoenix.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-core</artifactId>
       <version>${phoenix.version}</version>
       <exclusions>
@@ -198,7 +193,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>
-      <artifactId>phoenix-hbase-compat-2.4.0</artifactId>
+      <artifactId>phoenix-hbase-compat-2.4.1</artifactId>
       <version>${phoenix.version}</version>
       <scope>test</scope>
     </dependency>

--- a/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePlugin.java
+++ b/contrib/storage-phoenix/src/main/java/org/apache/drill/exec/store/phoenix/PhoenixStoragePlugin.java
@@ -43,12 +43,12 @@ import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.phoenix.rules.PhoenixConvention;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.drill.exec.util.ImpersonationUtil;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.tephra.shaded.com.google.common.collect.ImmutableSet;
 
 public class PhoenixStoragePlugin extends AbstractStoragePlugin {
 


### PR DESCRIPTION
relates to #2967 

phoenix 5.2.1 uses HBase 2.5 and Zookeeper 3.8

https://mvnrepository.com/artifact/org.apache.phoenix/phoenix/5.2.1