### PR TITLE
[MINOR UPDATE] upgrade jackson to 2.18.3

### DIFF
--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -216,6 +216,7 @@
               <artifact>com.fasterxml.jackson.core:*</artifact>
               <excludes>
                 <exclude>module-info.class</exclude>
+                <exclude>META-INF/versions/22/**</exclude>
               </excludes>
             </filter>
           </filters>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -750,6 +750,7 @@
                 <exclude>META-INF/**/*.properties</exclude>
                 <exclude>META-INF/services/com.fasterxml.*</exclude>
                 <exclude>META-INF/services/javax.ws.*</exclude>
+                <exclude>META-INF/versions/22/**</exclude>
                 <exclude>module-info.class</exclude>
                 <exclude>org/apache/commons/pool2/**</exclude>
                 <exclude>org/apache/directory/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <httpdlog-parser.version>5.10.0</httpdlog-parser.version>
     <iceberg.version>0.12.1</iceberg.version>
-    <jackson.version>2.16.1</jackson.version>
+    <jackson.version>2.18.3</jackson.version>
     <janino.version>3.1.11</janino.version>
     <javassist.version>3.29.2-GA</javassist.version>
     <javax.el.version>3.0.0</javax.el.version>


### PR DESCRIPTION
Jackson 2.18.3 has a number of bug fixes. I am a Jackson contributor and would strongly recommend that you at least get off 2.16.1.

Release Notes:
https://github.com/FasterXML/jackson/wiki/Jackson-Releases

* upgrade to maven-shade-plugin 3.6.0 because it handles multi-release jars better (build failed with maven-shade-plugin 3.5.0 due to the fact that jackson-core has classes for Java 22 users)