### PR TITLE
DRILL-8523: Remove Support for Java 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,8 @@ jobs:
     strategy:
       matrix:
         # Java versions to run unit tests
-        java: [ '8', '11', '17' ]
+        java: [ '11', '17', '21' ]
         profile: ['default-hadoop']
-        include:
-          - java: '8'
-            profile: 'hadoop-2'
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
           cache: 'maven'
       # Caches built protobuf library
       - name: Cache protobufs

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassCompilerSelector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassCompilerSelector.java
@@ -17,10 +17,6 @@
  */
 package org.apache.drill.exec.compile;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Map;
-
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
@@ -34,6 +30,12 @@ import org.apache.drill.exec.server.options.TypeValidators.BooleanValidator;
 import org.apache.drill.exec.server.options.TypeValidators.LongValidator;
 import org.apache.drill.exec.server.options.TypeValidators.StringValidator;
 import org.codehaus.commons.compiler.CompileException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Selects between the two supported Java compilers: Janino and
@@ -65,7 +67,7 @@ import org.codehaus.commons.compiler.CompileException;
  */
 
 public class ClassCompilerSelector {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ClassCompilerSelector.class);
+  private static final Logger logger = LoggerFactory.getLogger(ClassCompilerSelector.class);
 
   public enum CompilerPolicy {
     DEFAULT, JDK, JANINO;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/QueryClassLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/QueryClassLoader.java
@@ -17,32 +17,33 @@
  */
 package org.apache.drill.exec.compile;
 
+import com.google.common.collect.MapMaker;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
+import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.server.options.OptionSet;
+import org.codehaus.commons.compiler.CompileException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
-import org.apache.drill.exec.exception.ClassTransformationException;
-import org.apache.drill.exec.server.options.OptionSet;
-import org.codehaus.commons.compiler.CompileException;
-
-import com.google.common.collect.MapMaker;
-
 /**
  * Per-compilation unit class loader that holds both caching and compilation
  * steps. */
 
 public class QueryClassLoader extends URLClassLoader {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryClassLoader.class);
+  static final Logger logger = LoggerFactory.getLogger(QueryClassLoader.class);
 
-  private ClassCompilerSelector compilerSelector;
+  private final ClassCompilerSelector compilerSelector;
 
   private AtomicLong index = new AtomicLong(0);
 
-  private ConcurrentMap<String, byte[]> customClasses = new MapMaker().concurrencyLevel(4).makeMap();
+  private final ConcurrentMap<String, byte[]> customClasses = new MapMaker().concurrencyLevel(4).makeMap();
 
   public QueryClassLoader(DrillConfig config, OptionSet sessionOptions) {
     super(new URL[0], Thread.currentThread().getContextClassLoader());

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -17,29 +17,26 @@
  */
 package org.apache.drill;
 
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.calcite.jdbc.DynamicSchema;
-import org.apache.drill.exec.alias.AliasRegistryProvider;
-import org.apache.drill.exec.ops.ViewExpansionContext;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
 import io.netty.buffer.DrillBuf;
+import org.apache.calcite.jdbc.DynamicSchema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.LogicalPlanPersistence;
 import org.apache.drill.common.scanner.ClassPathScanner;
 import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.common.types.TypeProtos;
-import org.apache.drill.exec.expr.holders.ValueHolder;
-import org.apache.drill.exec.vector.ValueHolderHelper;
-import org.apache.drill.test.TestTools;
 import org.apache.drill.exec.ExecTest;
+import org.apache.drill.exec.alias.AliasRegistryProvider;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.expr.holders.ValueHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.ops.ViewExpansionContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.planner.sql.DrillOperatorTable;
@@ -55,16 +52,18 @@ import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistryImpl;
 import org.apache.drill.exec.store.sys.store.provider.LocalPersistentStoreProvider;
 import org.apache.drill.exec.testing.ExecutionControls;
+import org.apache.drill.exec.vector.ValueHolderHelper;
+import org.apache.drill.test.TestTools;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
+import org.mockito.ArgumentMatchers;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.Resources;
-import org.mockito.Matchers;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -131,11 +130,11 @@ public class PlanningBase extends ExecTest {
     when(context.getManagedBuffer()).thenReturn(allocator.buffer(4));
     when(context.getConstantValueHolder(eq("0.03"),
         eq(TypeProtos.MinorType.VARDECIMAL),
-        Matchers.<Function<DrillBuf, ValueHolder>>any()))
+        ArgumentMatchers.<Function<DrillBuf, ValueHolder>>any()))
       .thenReturn(ValueHolderHelper.getVarDecimalHolder(allocator.buffer(4), "0.03"));
     when(context.getConstantValueHolder(eq("0.01"),
         eq(TypeProtos.MinorType.VARDECIMAL),
-        Matchers.<Function<DrillBuf, ValueHolder>>any()))
+        ArgumentMatchers.<Function<DrillBuf, ValueHolder>>any()))
       .thenReturn(ValueHolderHelper.getVarDecimalHolder(allocator.buffer(4), "0.01"));
     when(context.getOption(anyString())).thenCallRealMethod();
     when(context.getViewExpansionContext()).thenReturn(viewExpansionContext);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassTransformation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassTransformation.java
@@ -17,15 +17,10 @@
  */
 package org.apache.drill.exec.compile;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.compile.bytecode.ValueHolderReplacementVisitor;
-import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.exec.compile.ClassTransformer.ClassSet;
+import org.apache.drill.exec.compile.bytecode.ValueHolderReplacementVisitor;
 import org.apache.drill.exec.compile.sig.GeneratorMapping;
 import org.apache.drill.exec.compile.sig.MappingSet;
 import org.apache.drill.exec.exception.ClassTransformationException;
@@ -33,6 +28,7 @@ import org.apache.drill.exec.expr.ClassGenerator;
 import org.apache.drill.exec.expr.CodeGenerator;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.options.SessionOptionManager;
+import org.apache.drill.test.BaseTestQuery;
 import org.codehaus.commons.compiler.CompileException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,9 +36,15 @@ import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class TestClassTransformation extends BaseTestQuery {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestClassTransformation.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestClassTransformation.class);
 
   private static final int ITERATION_COUNT = Integer.parseInt(System.getProperty("TestClassTransformation.iteration", "1"));
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestNestedDateTimeTimestamp.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestNestedDateTimeTimestamp.java
@@ -23,7 +23,6 @@ import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.test.TestBuilder;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -37,23 +36,21 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.TreeMap;
 
 /**
  * For DRILL-6242, output for Date, Time, Timestamp should use different classes
+ *
+ * Note that Drill treats all timestanps as naive (without timezone information).  When running tests locally,
+ * these tests may fail if the local timezone is not UTC.  To run tests on a machine with a non-UTC timezone,
+ * you should run the tests with the following command:
+ *
+ * mvn test -Duser.timezone=UTC
  */
 @Category(FlakyTest.class)
 public class TestNestedDateTimeTimestamp extends BaseTestQuery {
   private static final String              DATAFILE       = "cp.`datetime.parquet`";
   private static final Map<String, Object> expectedRecord = new TreeMap<String, Object>();
-
-  @BeforeClass
-  public static void setUpTimeZone() {
-    // Certain tests in this class fail if your machine is not set to UTC.  This method
-    // sets the default timezone to UTC when these tests are run.
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-  }
 
   static {
     /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestNestedDateTimeTimestamp.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestNestedDateTimeTimestamp.java
@@ -17,6 +17,16 @@
  */
 package org.apache.drill.exec.physical.impl;
 
+import org.apache.drill.categories.FlakyTest;
+import org.apache.drill.exec.expr.fn.impl.DateUtility;
+import org.apache.drill.exec.rpc.user.QueryDataBatch;
+import org.apache.drill.test.BaseTestQuery;
+import org.apache.drill.test.TestBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,16 +37,8 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.TreeMap;
-
-import org.apache.drill.categories.FlakyTest;
-import org.apache.drill.exec.expr.fn.impl.DateUtility;
-import org.apache.drill.exec.rpc.user.QueryDataBatch;
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.drill.test.TestBuilder;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 /**
  * For DRILL-6242, output for Date, Time, Timestamp should use different classes
@@ -45,6 +47,13 @@ import org.junit.experimental.categories.Category;
 public class TestNestedDateTimeTimestamp extends BaseTestQuery {
   private static final String              DATAFILE       = "cp.`datetime.parquet`";
   private static final Map<String, Object> expectedRecord = new TreeMap<String, Object>();
+
+  @BeforeClass
+  public static void setUpTimeZone() {
+    // Certain tests in this class fail if your machine is not set to UTC.  This method
+    // sets the default timezone to UTC when these tests are run.
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+  }
 
   static {
     /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.physical.impl.writer;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import org.apache.calcite.util.Pair;
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.categories.ParquetTest;
@@ -30,8 +32,6 @@ import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.parquet.ParquetFormatConfig;
 import org.apache.drill.exec.util.JsonStringArrayList;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.TestBuilder;
@@ -41,16 +41,18 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.Period;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -1002,6 +1004,8 @@ public class TestParquetWriter extends ClusterTest {
   // Only attempt this test on Linux / amd64 because com.rdblue.brotli-codec
   // only bundles natives for Mac and Linux on AMD64.  See PARQUET-1975.
   @Test
+  @EnabledIfSystemProperty(named = "os.arch", matches = "(amd64|x86_64)")
+  @DisabledOnOs({ OS.WINDOWS, OS.MAC })
   public void testTPCHReadWriteBrotli() throws Exception {
     try {
       client.alterSession(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, "brotli");

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
@@ -56,7 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/accessor/GenericAccessorTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/accessor/GenericAccessorTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/fragment/FragmentStatusReporterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/fragment/FragmentStatusReporterTest.java
@@ -34,11 +34,11 @@ import static org.apache.drill.exec.proto.UserBitShared.FragmentState.CANCELLATI
 import static org.apache.drill.exec.proto.UserBitShared.FragmentState.FAILED;
 import static org.apache.drill.exec.proto.UserBitShared.FragmentState.RUNNING;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class FragmentStatusReporterTest extends BaseTest {
@@ -93,14 +93,14 @@ public class FragmentStatusReporterTest extends BaseTest {
   @Test
   public void testClose() throws Exception {
     statusReporter.close();
-    verifyZeroInteractions(foremanTunnel);
+    verifyNoInteractions(foremanTunnel);
   }
 
   @Test
   public void testCloseClosed() throws Exception {
     statusReporter.close();
     statusReporter.close();
-    verifyZeroInteractions(foremanTunnel);
+    verifyNoInteractions(foremanTunnel);
   }
 
   @Test

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -33,7 +33,7 @@
        "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
   <properties>
     <package.namespace.prefix>oadd.</package.namespace.prefix>
-    <jdbc-all-jar.maxsize>55000000</jdbc-all-jar.maxsize>
+    <jdbc-all-jar.maxsize>56000000</jdbc-all-jar.maxsize>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2929,7 +2929,7 @@
         <jdk>[9,)</jdk>
       </activation>
       <properties>
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
         <junit.args>
           --add-opens java.base/java.lang=ALL-UNNAMED
           --add-opens java.base/java.net=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,6 @@
         </dependencies>
         <configuration>
           <includes>**/*.java</includes>
-          <encoding>UTF-8</encoding>
           <failsOnError>true</failsOnError>
           <consoleOutput>true</consoleOutput>
           <includeResources>true</includeResources>
@@ -886,6 +885,7 @@
       <version>${junit.platform.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite-engine</artifactId>
@@ -929,6 +929,12 @@
       <artifactId>mockito-inline</artifactId>
       <version>${mockito_inline.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>mockito-core</artifactId>
+          <groupId>org.mockito</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>de.huxhorn.lilith</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,7 @@
     <log4j.version>2.23.1</log4j.version>
     <!-- Upgrading logback further breaks JDK 8 build compatibility -->
     <logback.version>1.3.15</logback.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <maven.min.version>3.6.3</maven.min.version>
     <maven.version>3.8.4</maven.version>
     <memoryMb>3072</memoryMb>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <httpdlog-parser.version>5.10.0</httpdlog-parser.version>
     <iceberg.version>0.12.1</iceberg.version>
     <jackson.version>2.18.3</jackson.version>
-    <janino.version>3.1.11</janino.version>
+    <janino.version>3.1.12</janino.version>
     <javassist.version>3.29.2-GA</javassist.version>
     <javax.el.version>3.0.0</javax.el.version>
     <javax.validation.api>2.0.1.Final</javax.validation.api>
@@ -118,7 +118,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.min.version>3.6.3</maven.min.version>
     <maven.version>3.8.4</maven.version>
-    <memoryMb>3072</memoryMb>
+    <memoryMb>4096</memoryMb>
     <metrics.version>4.2.19</metrics.version>
     <mockito.version>5.17.0</mockito.version>
     <mockito_inline.version>5.2.0</mockito_inline.version>
@@ -629,6 +629,7 @@
               -XX:MaxDirectMemorySize=${directMemoryMb}M
               -Djava.net.preferIPv4Stack=true
               -Djava.awt.headless=true
+              -Duser.timezone=UTC
               -ea
               ${junit.args}
               -Djdk.attach.allowAttachSelf=true

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
     <memoryMb>3072</memoryMb>
     <metrics.version>4.2.19</metrics.version>
     <mockito.version>5.17.0</mockito.version>
+    <mockito_inline.version>5.2.0</mockito_inline.version>
     <mongo.version>4.11.1</mongo.version>
     <msgpack.version>0.6.6</msgpack.version>
     <netty.tcnative.classifier />
@@ -918,7 +919,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>${mockito.version}</version>
+      <version>${mockito_inline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <maven.version>3.8.4</maven.version>
     <memoryMb>3072</memoryMb>
     <metrics.version>4.2.19</metrics.version>
-    <mockito.version>3.11.2</mockito.version>
+    <mockito.version>5.17.0</mockito.version>
     <mongo.version>4.11.1</mongo.version>
     <msgpack.version>0.6.6</msgpack.version>
     <netty.tcnative.classifier />

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
     <log4j.version>2.23.1</log4j.version>
     <!-- Upgrading logback further breaks JDK 8 build compatibility -->
     <logback.version>1.3.15</logback.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <maven.min.version>3.6.3</maven.min.version>
     <maven.version>3.8.4</maven.version>
     <memoryMb>3072</memoryMb>
@@ -163,27 +163,27 @@
       <subscribe>user-subscribe@drill.apache.org</subscribe>
       <unsubscribe>user-unsubscribe@drill.apache.org</unsubscribe>
       <post>user@drill.apache.org</post>
-      <archive>http://mail-archives.apache.org/mod_mbox/drill-user/</archive>
+      <archive>https://mail-archives.apache.org/mod_mbox/drill-user/</archive>
     </mailingList>
     <mailingList>
       <name>Developer List</name>
       <subscribe>dev-subscribe@drill.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@drill.apache.org</unsubscribe>
       <post>dev@drill.apache.org</post>
-      <archive>http://mail-archives.apache.org/mod_mbox/drill-dev/</archive>
+      <archive>https://mail-archives.apache.org/mod_mbox/drill-dev/</archive>
     </mailingList>
     <mailingList>
       <name>Commits List</name>
       <subscribe>commits-subscribe@drill.apache.org</subscribe>
       <unsubscribe>commits-unsubscribe@drill.apache.org</unsubscribe>
       <post>commits@drill.apache.org</post>
-      <archive>http://mail-archives.apache.org/mod_mbox/drill-commits/</archive>
+      <archive>https://mail-archives.apache.org/mod_mbox/drill-commits/</archive>
     </mailingList>
     <mailingList>
       <name>Issues List</name>
       <subscribe>issues-subscribe@drill.apache.org</subscribe>
       <unsubscribe>issues-unsubscribe@drill.apache.org</unsubscribe>
-      <archive>http://mail-archives.apache.org/mod_mbox/drill-issues/</archive>
+      <archive>https://mail-archives.apache.org/mod_mbox/drill-issues/</archive>
     </mailingList>
   </mailingLists>
 
@@ -914,6 +914,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>6.4.1</version>
+        <version>12.1.1</version>
       </plugin>
     </plugins>
   </reporting>
@@ -505,7 +505,7 @@
                   <version>[${maven.version.min},4)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[1.8,18)</version>
+                  <version>[1.8,22)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,8 @@
     <!-- Upgrading logback further breaks JDK 8 build compatibility -->
     <logback.version>1.3.15</logback.version>
     <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <maven.min.version>3.6.3</maven.min.version>
     <maven.version>3.8.4</maven.version>
     <memoryMb>3072</memoryMb>
@@ -2929,6 +2931,8 @@
         <jdk>[9,)</jdk>
       </activation>
       <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
         <junit.args>
           --add-opens java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
# [DRILL-8523](https://issues.apache.org/jira/browse/DRILL-8523): Remove Support for Java 8

## Description
This PR removes the CI actions for Java 8 and effectively ends Drill's support for Java 8.  As a consequence of that, Drill no longer supports Hadoop 2.   The profile is still in the pom.xml file should anyone want to build Drill for Hadoop 2, but we are no longer running CI with those tests.

This seems to have the added benefit of fixing the flaky Hive tests in the Hadoop-2 runs.

This PR also adds CI tests for Java 21. 

## Documentation
No user facing changes.

## Testing
Ran existing unit tests.