### PR TITLE
DRILL-8524: Drill Adding Duplicate Parameters in Offset Paginator

### DIFF
--- a/contrib/storage-http/pom.xml
+++ b/contrib/storage-http/pom.xml
@@ -100,14 +100,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>10</source>
-          <target>10</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/contrib/storage-http/pom.xml
+++ b/contrib/storage-http/pom.xml
@@ -31,7 +31,7 @@
   <name>Drill : Contrib : Storage : HTTP</name>
 
   <properties>
-    <okhttp.version>4.9.3</okhttp.version>
+    <okhttp.version>4.12.0</okhttp.version>
   </properties>
 
   <dependencies>
@@ -99,6 +99,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>10</source>
+          <target>10</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/OffsetPaginator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/paginator/OffsetPaginator.java
@@ -73,11 +73,8 @@ public class OffsetPaginator extends Paginator {
       throw new NoSuchElementException();
     }
 
-    builder.removeAllEncodedQueryParameters(offsetParam);
-    builder.removeAllEncodedQueryParameters(limitParam);
-
-    builder.addQueryParameter(offsetParam, String.valueOf(offset));
-    builder.addQueryParameter(limitParam, String.valueOf(pageSize));
+    builder.setEncodedQueryParameter(offsetParam, String.valueOf(offset));
+    builder.setEncodedQueryParameter(limitParam, String.valueOf(pageSize));
     offset += pageSize;
 
     return builder.build().url().toString();


### PR DESCRIPTION
# [DRILL-8524](https://issues.apache.org/jira/browse/DRILL-XXXX): Drill Adding Duplicate Parameters in Offset Paginator

## Description
This PR fixes a minor bug with the Offset paginator.  When the URL params have a `$` or other control character, the pagination was not properly updating the URL and adding duplicate parameters to the URL.  This PR solves that. 

Additionally, this PR bumps OkHTTP to the latest version. 

## Documentation
No user facing changes.

## Testing
Tested against user provided API.  Ran existing unit tests.
