### PR TITLE
DRILL-8526: Hive Predicate Push Down for ORC and Parquet

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveScan.java
@@ -70,7 +70,7 @@ public class HiveScan extends AbstractGroupScan {
   private List<LogicalInputSplit> inputSplits;
 
   protected List<SchemaPath> columns;
-
+  private boolean filterPushedDown = false;
   @JsonCreator
   public HiveScan(@JsonProperty("userName") final String userName,
                   @JsonProperty("hiveReadEntry") final HiveReadEntry hiveReadEntry,
@@ -152,6 +152,16 @@ public class HiveScan extends AbstractGroupScan {
   public boolean supportsPartitionFilterPushdown() {
     List<FieldSchema> partitionKeys = hiveReadEntry.getTable().getPartitionKeys();
     return !(partitionKeys == null || partitionKeys.size() == 0);
+  }
+
+  @JsonIgnore
+  public void setFilterPushedDown(boolean isPushedDown) {
+    this.filterPushedDown = isPushedDown;
+  }
+
+  @JsonIgnore
+  public boolean isFilterPushedDown() {
+    return filterPushedDown;
   }
 
   @Override

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
@@ -48,6 +48,7 @@ import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.hive.readers.filter.HivePushFilterIntoScan;
 import org.apache.drill.exec.store.hive.schema.HiveSchemaFactory;
 import com.google.common.collect.ImmutableSet;
 
@@ -199,6 +200,10 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
         if (options.getBoolean(ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS) ||
             options.getBoolean(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER)) {
           ruleBuilder.add(ConvertHiveParquetScanToDrillParquetScan.INSTANCE);
+        }
+        if (options.getBoolean(ExecConstants.HIVE_OPTIMIZE_SCAN_FILTER_PUSHDOWN)) {
+          ruleBuilder.add(HivePushFilterIntoScan.FILTER_ON_PROJECT);
+          ruleBuilder.add(HivePushFilterIntoScan.FILTER_ON_SCAN);
         }
         return ruleBuilder.build();
       }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HiveCompareFunctionsProcessor.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HiveCompareFunctionsProcessor.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.filter;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.drill.common.FunctionNames;
+import org.apache.drill.common.expression.CastExpression;
+import org.apache.drill.common.expression.ConvertExpression;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.expression.ValueExpressions;
+import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
+import org.apache.drill.common.expression.ValueExpressions.DateExpression;
+import org.apache.drill.common.expression.ValueExpressions.DoubleExpression;
+import org.apache.drill.common.expression.ValueExpressions.FloatExpression;
+import org.apache.drill.common.expression.ValueExpressions.IntExpression;
+import org.apache.drill.common.expression.ValueExpressions.LongExpression;
+import org.apache.drill.common.expression.ValueExpressions.QuotedString;
+import org.apache.drill.common.expression.ValueExpressions.TimeExpression;
+import org.apache.drill.common.expression.ValueExpressions.TimeStampExpression;
+import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+
+import java.sql.Timestamp;
+import java.util.regex.Pattern;
+
+public class HiveCompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpression, RuntimeException> {
+
+  // to check that function name starts with convert_from disregarding the case and has encoding after
+  private static final Pattern convertFromPattern = Pattern.compile(String.format("^%s(.+)", ConvertExpression.CONVERT_FROM), Pattern.CASE_INSENSITIVE);
+
+  private Object value;
+  private PredicateLeaf.Type valueType;
+  private boolean success;
+  private SchemaPath path;
+  private String functionName;
+
+  public static boolean isCompareFunction(String functionName) {
+    return COMPARE_FUNCTIONS_TRANSPOSE_MAP.keySet().contains(functionName);
+  }
+  public static boolean isIsFunction(String funcName) {
+    return IS_FUNCTIONS_SET.contains(funcName);
+  }
+
+  public static HiveCompareFunctionsProcessor createFunctionsProcessorInstance(FunctionCall call, boolean nullComparatorSupported) {
+    String functionName = call.getName();
+    HiveCompareFunctionsProcessor evaluator = new HiveCompareFunctionsProcessor(functionName);
+
+    return createFunctionsProcessorInstanceInternal(call, nullComparatorSupported, evaluator);
+  }
+
+  protected static <T extends HiveCompareFunctionsProcessor> T createFunctionsProcessorInstanceInternal(FunctionCall call,
+                                                                                                    boolean nullComparatorSupported,
+                                                                                                    T evaluator) {
+    LogicalExpression nameArg = call.arg(0);
+    LogicalExpression valueArg = call.argCount() >= 2 ? call.arg(1) : null;
+    if (valueArg != null) { // binary function
+      if (VALUE_EXPRESSION_CLASSES.contains(nameArg.getClass())) {
+        LogicalExpression swapArg = valueArg;
+        valueArg = nameArg;
+        nameArg = swapArg;
+        evaluator.setFunctionName(COMPARE_FUNCTIONS_TRANSPOSE_MAP.get(evaluator.getFunctionName()));
+      }
+      evaluator.setSuccess(nameArg.accept(evaluator, valueArg));
+    } else if (nullComparatorSupported && call.arg(0) instanceof SchemaPath) {
+      evaluator.setPath((SchemaPath) nameArg);
+    }
+    evaluator.setSuccess(true);
+    return evaluator;
+  }
+
+  public HiveCompareFunctionsProcessor(String functionName) {
+    this.success = false;
+    this.functionName = functionName;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  protected void setSuccess(boolean success) {
+    this.success = success;
+  }
+
+  public SchemaPath getPath() {
+    return path;
+  }
+
+  protected void setPath(SchemaPath path) {
+    this.path = path;
+  }
+
+  public String getFunctionName() {
+    return functionName;
+  }
+
+  protected void setFunctionName(String functionName) {
+    this.functionName = functionName;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  public void setValue(Object value) {
+    this.value = value;
+  }
+
+  public PredicateLeaf.Type getValueType() {
+    return valueType;
+  }
+
+  public void setValueType(PredicateLeaf.Type valueType) {
+    this.valueType = valueType;
+  }
+
+  @Override
+  public Boolean visitCastExpression(CastExpression e, LogicalExpression valueArg) throws RuntimeException {
+    if (e.getInput() instanceof CastExpression || e.getInput() instanceof SchemaPath) {
+      return e.getInput().accept(this, valueArg);
+    }
+    return false;
+  }
+  @Override
+  public Boolean visitUnknown(LogicalExpression e, LogicalExpression valueArg) throws RuntimeException {
+    return false;
+  }
+
+  @Override
+  public Boolean visitSchemaPath(SchemaPath path, LogicalExpression valueArg) throws RuntimeException {
+    if (valueArg instanceof QuotedString) {
+      this.value = ((QuotedString) valueArg).getString();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.STRING;
+      return true;
+    }
+
+    if (valueArg instanceof IntExpression) {
+      int expValue = ((IntExpression) valueArg).getInt();
+      this.value = ((Integer) expValue).longValue();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.LONG;
+      return true;
+    }
+
+    if (valueArg instanceof LongExpression) {
+      this.value = ((LongExpression) valueArg).getLong();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.LONG;
+      return true;
+    }
+
+    if (valueArg instanceof FloatExpression) {
+      this.value = ((FloatExpression) valueArg).getFloat();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.FLOAT;
+      return true;
+    }
+
+    if (valueArg instanceof DoubleExpression) {
+      this.value = ((DoubleExpression) valueArg).getDouble();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.FLOAT;
+      return true;
+    }
+
+    if (valueArg instanceof BooleanExpression) {
+      this.value = ((BooleanExpression) valueArg).getBoolean();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.BOOLEAN;
+      return true;
+    }
+
+    if (valueArg instanceof DateExpression) {
+      this.value = ((DateExpression) valueArg).getDate();
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.LONG;
+      return true;
+    }
+
+    if (valueArg instanceof TimeStampExpression) {
+      long timeStamp = ((TimeStampExpression) valueArg).getTimeStamp();
+      this.value = new Timestamp(timeStamp);
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.TIMESTAMP;
+      return true;
+    }
+
+    if (valueArg instanceof ValueExpressions.VarDecimalExpression) {
+      double v = ((ValueExpressions.VarDecimalExpression) valueArg).getBigDecimal().doubleValue();
+      this.value = new HiveDecimalWritable(String.valueOf(v));
+      this.path = path;
+      this.valueType = PredicateLeaf.Type.DECIMAL;
+      return true;
+    }
+    return false;
+  }
+
+  private static final ImmutableSet<Class<? extends LogicalExpression>> VALUE_EXPRESSION_CLASSES;
+  static {
+    ImmutableSet.Builder<Class<? extends LogicalExpression>> builder = ImmutableSet.builder();
+    VALUE_EXPRESSION_CLASSES = builder
+        .add(BooleanExpression.class)
+        .add(DateExpression.class)
+        .add(DoubleExpression.class)
+        .add(FloatExpression.class)
+        .add(IntExpression.class)
+        .add(LongExpression.class)
+        .add(QuotedString.class)
+        .add(TimeExpression.class)
+        .build();
+  }
+
+  private static final ImmutableMap<String, String> COMPARE_FUNCTIONS_TRANSPOSE_MAP;
+  static {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    COMPARE_FUNCTIONS_TRANSPOSE_MAP = builder
+        // binary functions
+        .put(FunctionNames.LIKE, FunctionNames.LIKE)
+        .put(FunctionNames.EQ, FunctionNames.EQ)
+        .put(FunctionNames.NE, FunctionNames.NE)
+        .put(FunctionNames.GE, FunctionNames.LE)
+        .put(FunctionNames.GT, FunctionNames.LT)
+        .put(FunctionNames.LE, FunctionNames.GE)
+        .put(FunctionNames.LT, FunctionNames.GT)
+        .build();
+  }
+
+  // shows whether function is simplified IS FALSE
+  public static boolean isNot(FunctionCall call, String funcName) {
+    return !call.args().isEmpty()
+        && FunctionNames.NOT.equals(funcName);
+  }
+  private static final ImmutableSet<String> IS_FUNCTIONS_SET;
+  static {
+    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+    IS_FUNCTIONS_SET = builder
+        .add(FunctionNames.IS_NOT_NULL)
+        .add("isNotNull")
+        .add("is not null")
+        .add(FunctionNames.IS_NULL)
+        .add("isNull")
+        .add("is null")
+        .add(FunctionNames.IS_TRUE)
+        .add(FunctionNames.IS_NOT_TRUE)
+        .add(FunctionNames.IS_FALSE)
+        .add(FunctionNames.IS_NOT_FALSE)
+        .build();
+  }
+
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HiveFilter.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HiveFilter.java
@@ -1,0 +1,29 @@
+package org.apache.drill.exec.store.hive.readers.filter;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hive.com.esotericsoftware.kryo.Kryo;
+import org.apache.hive.com.esotericsoftware.kryo.io.Output;
+
+public class HiveFilter {
+  private SearchArgument searchArgument;
+
+  public HiveFilter(SearchArgument searchArgument) {
+    this.searchArgument = searchArgument;
+  }
+
+  public SearchArgument getSearchArgument() {
+    return searchArgument;
+  }
+
+  public String getSearchArgumentString() {
+    return toKryo(searchArgument);
+  }
+
+  private static String toKryo(SearchArgument sarg) {
+    Output out = new Output(4 * 1024, 10 * 1024 * 1024);
+    new Kryo().writeObject(out, sarg);
+    out.close();
+    return Base64.encodeBase64String(out.toBytes());
+  }
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HiveFilterBuilder.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HiveFilterBuilder.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.filter;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.FunctionNames;
+import org.apache.drill.common.expression.BooleanOperator;
+import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
+import org.apache.drill.exec.store.hive.HiveScan;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class HiveFilterBuilder extends AbstractExprVisitor<SearchArgument.Builder, Void,
+    RuntimeException> {
+  private static final Logger logger = LoggerFactory.getLogger(HiveFilterBuilder.class);
+
+  final private HiveScan groupScan;
+
+  final private LogicalExpression le;
+
+  private boolean allExpressionsConverted = false;
+
+  private static Boolean nullComparatorSupported;
+
+  private SearchArgument.Builder builder;
+
+  private HashMap<String, SqlTypeName> dataTypeMap;
+
+  HiveFilterBuilder(HiveScan groupScan, LogicalExpression le,
+      HashMap<String, SqlTypeName> dataTypeMap) {
+    this.groupScan = groupScan;
+    this.le = le;
+    this.dataTypeMap = dataTypeMap;
+    this.builder = SearchArgumentFactory.newBuilder();
+  }
+
+  public HiveFilter parseTree() {
+    SearchArgument.Builder accept = le.accept(this, null);
+    SearchArgument searchArgument = builder.build();
+    if (accept != null) {
+      searchArgument = accept.build();
+    }
+    return new HiveFilter(searchArgument);
+  }
+
+  public boolean isAllExpressionsConverted() {
+    return allExpressionsConverted;
+  }
+
+  @Override
+  public SearchArgument.Builder visitUnknown(LogicalExpression e, Void value) throws RuntimeException {
+    allExpressionsConverted = false;
+    return null;
+  }
+
+  @Override
+  public SearchArgument.Builder visitSchemaPath(SchemaPath path, Void value) throws RuntimeException {
+    if (path instanceof FieldReference) {
+      String fieldName = path.getAsNamePart().getName();
+      SqlTypeName sqlTypeName = dataTypeMap.get(fieldName);
+      switch (sqlTypeName) {
+      case BOOLEAN:
+        PredicateLeaf.Type valueType = convertLeafType(sqlTypeName);
+        builder.startNot().equals(fieldName, valueType, false).end();
+        break;
+      default:
+        // otherwise, we don't know what to do so make it a maybe or do nothing
+        builder.literal(SearchArgument.TruthValue.YES_NO_NULL);
+      }
+    }
+    return builder;
+  }
+
+  @Override
+  public SearchArgument.Builder visitBooleanOperator(BooleanOperator op, Void value) throws RuntimeException {
+    return visitFunctionCall(op, value);
+  }
+
+  @Override
+  public SearchArgument.Builder visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
+    String functionName = call.getName();
+    List<LogicalExpression> args = call.args();
+    if (HiveCompareFunctionsProcessor.isCompareFunction(functionName) || HiveCompareFunctionsProcessor.isIsFunction(functionName) || HiveCompareFunctionsProcessor.isNot(call, functionName)) {
+      if (nullComparatorSupported == null) {
+        //For Support Hive Different versions
+        nullComparatorSupported =
+            groupScan.getHiveConf().getBoolean("drill.hive.supports.null" + ".comparator", true);
+      }
+      HiveCompareFunctionsProcessor processor =
+          HiveCompareFunctionsProcessor.createFunctionsProcessorInstance(call,
+              nullComparatorSupported);
+      if (processor.isSuccess()) {
+        return buildSearchArgument(processor);
+      }
+    } else {
+      switch (functionName) {
+      case FunctionNames.AND:
+        builder.startAnd();
+        break;
+      case FunctionNames.OR:
+        builder.startOr();
+        break;
+      default:
+        logger.warn("Unsupported logical operator:{} for push down", functionName);
+        return builder;
+      }
+      for (int i = 0; i < args.size(); ++i) {
+        args.get(i).accept(this, null);
+      }
+      builder.end();
+    }
+    return builder;
+  }
+
+
+  private SearchArgument.Builder buildSearchArgument(HiveCompareFunctionsProcessor processor) {
+    String functionName = processor.getFunctionName();
+    SchemaPath field = processor.getPath();
+    Object fieldValue = processor.getValue();
+    PredicateLeaf.Type valueType = processor.getValueType();
+    SqlTypeName sqlTypeName = dataTypeMap.get(field.getAsNamePart().getName());
+    if (fieldValue == null) {
+      valueType = convertLeafType(sqlTypeName);
+    }
+    if (valueType == null) {
+      return builder;
+    }
+    switch (functionName) {
+    case FunctionNames.EQ:
+      builder.startAnd().equals(field.getAsNamePart().getName(), valueType, fieldValue).end();
+      break;
+    case FunctionNames.NE:
+      builder.startNot().equals(field.getAsNamePart().getName(), valueType, fieldValue).end();
+      break;
+    case FunctionNames.GE:
+      builder.startNot().lessThan(field.getAsNamePart().getName(), valueType, fieldValue).end();
+      break;
+    case FunctionNames.GT:
+      builder.startNot().lessThanEquals(field.getAsNamePart().getName(), valueType, fieldValue).end();
+      break;
+    case FunctionNames.LE:
+      builder.startAnd().lessThanEquals(field.getAsNamePart().getName(), valueType, fieldValue).end();
+      break;
+    case FunctionNames.LT:
+      builder.startAnd().lessThan(field.getAsNamePart().getName(), valueType, fieldValue).end();
+      break;
+    case FunctionNames.IS_NULL:
+    case "isNull":
+    case "is null":
+      builder.startAnd().isNull(field.getAsNamePart().getName(), valueType).end();
+      break;
+    case FunctionNames.IS_NOT_NULL:
+    case "isNotNull":
+    case "is not null":
+      builder.startNot().isNull(field.getAsNamePart().getName(), valueType).end();
+      break;
+    case FunctionNames.IS_NOT_TRUE:
+    case FunctionNames.IS_FALSE:
+    case FunctionNames.NOT:
+      builder.startNot().equals(field.getAsNamePart().getName(), valueType, true).end();
+      break;
+    case FunctionNames.IS_TRUE:
+    case FunctionNames.IS_NOT_FALSE:
+      builder.startNot().equals(field.getAsNamePart().getName(), valueType, false).end();
+      break;
+    }
+    return builder;
+  }
+
+  private PredicateLeaf.Type convertLeafType(SqlTypeName sqlTypeName) {
+    PredicateLeaf.Type type = null;
+    switch (sqlTypeName) {
+    case BOOLEAN:
+      type = PredicateLeaf.Type.BOOLEAN;
+      break;
+    case TINYINT:
+    case SMALLINT:
+    case INTEGER:
+    case BIGINT:
+      type = PredicateLeaf.Type.LONG;
+      break;
+    case DOUBLE:
+    case FLOAT:
+      type = PredicateLeaf.Type.FLOAT;
+      break;
+    case DECIMAL:
+      type = PredicateLeaf.Type.DECIMAL;
+      break;
+    case DATE:
+      type = PredicateLeaf.Type.DATE;
+      break;
+    case TIMESTAMP:
+      type = PredicateLeaf.Type.TIMESTAMP;
+      break;
+    case CHAR:
+    case VARCHAR:
+      type = PredicateLeaf.Type.STRING;
+      break;
+    default:
+      logger.warn("Not support push down type:" + sqlTypeName.getName());
+    }
+    return type;
+  }
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HivePushFilterIntoScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/filter/HivePushFilterIntoScan.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.filter;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.exec.planner.logical.DrillOptiq;
+import org.apache.drill.exec.planner.logical.DrillParseContext;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+import org.apache.drill.exec.planner.physical.FilterPrel;
+import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.planner.physical.ProjectPrel;
+import org.apache.drill.exec.planner.physical.ScanPrel;
+import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.hive.HiveScan;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg.SARG_PUSHDOWN;
+
+public abstract class HivePushFilterIntoScan extends StoragePluginOptimizerRule {
+
+  private HivePushFilterIntoScan(RelOptRuleOperand operand, String description) {
+    super(operand, description);
+  }
+
+  public static final StoragePluginOptimizerRule FILTER_ON_SCAN =
+      new HivePushFilterIntoScan(RelOptHelper.some(FilterPrel.class,
+          RelOptHelper.any(ScanPrel.class)), "HivePushFilterIntoScan:Filter_On_Scan") {
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      final ScanPrel scan = call.rel(1);
+      final FilterPrel filter = call.rel(0);
+      final RexNode condition = filter.getCondition();
+
+      HiveScan groupScan = (HiveScan) scan.getGroupScan();
+      if (groupScan.isFilterPushedDown()) {
+        /*
+         * The rule can get triggered again due to the transformed "scan => filter" sequence
+         * created by the earlier execution of this rule when we could not do a complete
+         * conversion of Optiq Filter's condition to Hive Filter. In such cases, we rely upon
+         * this flag to not do a re-processing of the rule on the already transformed call.
+         */
+        return;
+      }
+
+      doPushFilterToScan(call, filter, null, scan, groupScan, condition);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      final ScanPrel scan = call.rel(1);
+      if (scan.getGroupScan() instanceof HiveScan) {
+        return super.matches(call);
+      }
+      return false;
+    }
+  };
+
+
+  public static final StoragePluginOptimizerRule FILTER_ON_PROJECT =
+      new HivePushFilterIntoScan(RelOptHelper.some(FilterPrel.class,
+          RelOptHelper.some(ProjectPrel.class, RelOptHelper.any(ScanPrel.class))),
+          "HivePushFilterIntoScan:Filter_On_Project") {
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      final ScanPrel scan = call.rel(2);
+      final ProjectPrel project = call.rel(1);
+      final FilterPrel filter = call.rel(0);
+
+      HiveScan groupScan = (HiveScan) scan.getGroupScan();
+      if (groupScan.isFilterPushedDown()) {
+        /*
+         * The rule can get triggered again due to the transformed "scan => filter" sequence
+         * created by the earlier execution of this rule when we could not do a complete
+         * conversion of Optiq Filter's condition to Hive Filter. In such cases, we rely upon
+         * this flag to not do a re-processing of the rule on the already transformed call.
+         */
+        return;
+      }
+
+      // convert the filter to one that references the child of the project
+      final RexNode condition = RelOptUtil.pushPastProject(filter.getCondition(), project);
+
+      doPushFilterToScan(call, filter, project, scan, groupScan, condition);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      final ScanPrel scan = call.rel(2);
+      if (scan.getGroupScan() instanceof HiveScan) {
+        return super.matches(call);
+      }
+      return false;
+    }
+  };
+
+
+  protected void doPushFilterToScan(final RelOptRuleCall call, final FilterPrel filter,
+      final ProjectPrel project, final ScanPrel scan, final HiveScan groupScan,
+      final RexNode condition) {
+
+    HashMap<String, SqlTypeName> dataTypeMap = new HashMap<>();
+    List<RelDataTypeField> fieldList = scan.getRowType().getFieldList();
+    for (RelDataTypeField relDataTypeField : fieldList) {
+      String name = relDataTypeField.getName();
+      SqlTypeName sqlTypeName = relDataTypeField.getValue().getSqlTypeName();
+      dataTypeMap.put(name, sqlTypeName);
+    }
+
+    final LogicalExpression conditionExp = DrillOptiq.toDrill(new DrillParseContext(PrelUtil.getPlannerSettings(call.getPlanner())),
+            scan, condition);
+    final HiveFilterBuilder orcFilterBuilder = new HiveFilterBuilder(groupScan, conditionExp, dataTypeMap);
+    final HiveFilter newScanSpec = orcFilterBuilder.parseTree();
+
+    if (newScanSpec == null) {
+      return; //no filter pushdown ==> No transformation.
+    }
+
+    String searchArgument = newScanSpec.getSearchArgumentString();
+    Map<String, String> confProperties = groupScan.getConfProperties();
+    confProperties.put(SARG_PUSHDOWN, searchArgument);
+    HiveScan newGroupsScan = null;
+    try {
+      newGroupsScan = new HiveScan(groupScan.getUserName(), groupScan.getHiveReadEntry(),
+          groupScan.getStoragePlugin(), groupScan.getColumns(), null, confProperties);
+    } catch (ExecutionSetupException e) {
+      //Why does constructor method HiveScan throw exception?
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
+    newGroupsScan.setFilterPushedDown(true);
+
+    final ScanPrel newScanPrel = new ScanPrel(scan.getCluster(), filter.getTraitSet(),
+        newGroupsScan, scan.getRowType(), scan.getTable());
+    // Depending on whether is a project in the middle, assign either scan or copy of project to
+    // childRel.
+    final RelNode childRel = project == null ? newScanPrel : project.copy(project.getTraitSet(),
+        ImmutableList.of(newScanPrel));
+    /*
+     * we could not convert the entire filter condition expression into an Hive orc filter.
+     */
+    call.transformTo(filter.copy(filter.getTraitSet(), ImmutableList.of(childRel)));
+
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -651,6 +651,10 @@ public final class ExecConstants {
   public static final OptionValidator HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER_VALIDATOR =
       new BooleanValidator(HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER,
           new OptionDescription("Optimize reads of Parquet-backed external tables from Hive by using Drill native readers instead of the Hive Serde interface. (Drill 1.2+)"));
+  public static final String HIVE_OPTIMIZE_SCAN_FILTER_PUSHDOWN= "store.hive.optimize_scan_filter_pushdown";
+  public static final OptionValidator HIVE_OPTIMIZE_SCAN_FILTER_PUSHDOWN_VALIDATOR =
+      new BooleanValidator(HIVE_OPTIMIZE_SCAN_FILTER_PUSHDOWN,
+          new OptionDescription("Optimize reads of orc and parquet by predicate push down"));
   public static final String HIVE_CONF_PROPERTIES = "store.hive.conf.properties";
   public static final OptionValidator HIVE_CONF_PROPERTIES_VALIDATOR = new StringValidator(HIVE_CONF_PROPERTIES,
       new OptionDescription("Enables the user to specify Hive properties at the session level. Do not set the property values in quotes. Separate the property name and value by =. Separate each property with a new line (\\n). Example: set `store.hive.conf.properties` = 'hive.mapred.supports.subdirectories=true\\nmapred.input.dir.recursive=true'. (Drill 1.14+)"));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -221,6 +221,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.KAFKA_READER_ESCAPE_ANY_CHAR_VALIDATOR),
       new OptionDefinition(ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS_VALIDATOR),
       new OptionDefinition(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER_VALIDATOR),
+      new OptionDefinition(ExecConstants.HIVE_OPTIMIZE_SCAN_FILTER_PUSHDOWN_VALIDATOR),
       new OptionDefinition(ExecConstants.HIVE_CONF_PROPERTIES_VALIDATOR),
       new OptionDefinition(ExecConstants.SLICE_TARGET_OPTION),
       new OptionDefinition(ExecConstants.AFFINITY_FACTOR),

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -711,6 +711,7 @@ drill.exec.options: {
     store.hive.conf.properties: "",
     store.hive.optimize_scan_with_native_readers: false,
     store.hive.parquet.optimize_scan_with_native_reader: false,
+    store.hive.optimize_scan_filter_pushdown: false,
     store.json.all_text_mode: false,
     store.json.enable_v2_reader: true,
     store.json.extended_types: false,


### PR DESCRIPTION
# [DRILL-8526](https://issues.apache.org/jira/browse/DRILL-8526):  Hive Predicate Push Down for ORC and Parquet


## Description
Drill do not  support  filter push down  for  orc  format.When a large amount of data is filtered out, Predicate PushDown can significantly improve the query performance of ORC format. 

I have implemented this featur and supported the data types are as follows:
int
bigint,
INYINT,
SMALLINT,
double,
float,
BOOLEAN
date,
TIMESTAMP,
decimal
string,
varchar
char


## Testing
Through comparative testing , ORC format with filter pushdown achieves nearly a 20x performance improvement over execution without pushdown  on following sql.

1.Import TPCH data. In my test, the amount of Table lineitem was 6001215.
2.set "store.hive.optimize_scan_filter_pushdown =true" by the option on drill web
3. execute sql select * from hive.lineitem_o  where L_ORDERKEY=1;


(1)store.hive.optimize_scan_filter_pushdown =false
![image](https://github.com/user-attachments/assets/f8f19dc2-02ff-4831-bb74-035f565ff49c)

(2)store.hive.optimize_scan_filter_pushdown =true

![image](https://github.com/user-attachments/assets/b35a61c8-80ae-4608-bf2f-3ba787728e2e)


















