### PR TITLE
[DRAFT] Bump Hive to Version 4.0

### DIFF
--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -54,6 +54,10 @@
           <groupId>org.apache.hive</groupId>
           <artifactId>hive-exec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -93,6 +97,13 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-hbase-handler</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
+
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -146,6 +157,11 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apiguardian</groupId>
+      <artifactId>apiguardian-api</artifactId>
+      <version>1.1.2</version> <!-- Use the latest compatible version -->
     </dependency>
     <dependency>
       <groupId>org.apache.drill</groupId>
@@ -249,6 +265,10 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+          </exclusion>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-1.2-api</artifactId>

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
@@ -17,21 +17,10 @@
  */
 package org.apache.drill.exec.store.hive;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.type.TypeReference;
-
+import com.google.common.collect.ImmutableSet;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.commons.lang3.StringEscapeUtils;
-
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
@@ -49,12 +38,20 @@ import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
 import org.apache.drill.exec.store.hive.schema.HiveSchemaFactory;
-import com.google.common.collect.ImmutableSet;
-
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.thrift.transport.TTransportException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class HiveStoragePlugin extends AbstractStoragePlugin {
 
@@ -186,7 +183,7 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
   public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerContext, PlannerPhase phase) {
     switch (phase) {
       case PARTITION_PRUNING:
-        final String defaultPartitionValue = hiveConf.get(ConfVars.DEFAULTPARTITIONNAME.varname);
+        final String defaultPartitionValue = hiveConf.get(ConfVars.DEFAULT_PARTITION_NAME.varname);
         ImmutableSet.Builder<StoragePluginOptimizerRule> ruleBuilder = ImmutableSet.builder();
         ruleBuilder.add(HivePushPartitionFilterIntoScan.getFilterOnProject(optimizerContext, defaultPartitionValue));
         ruleBuilder.add(HivePushPartitionFilterIntoScan.getFilterOnScan(optimizerContext, defaultPartitionValue));

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestFixture.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestFixture.java
@@ -17,15 +17,6 @@
  */
 package org.apache.drill.exec.hive;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Consumer;
-
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistry.PluginException;
@@ -37,6 +28,15 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.session.SessionState;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
@@ -133,8 +133,8 @@ public class HiveTestFixture {
    *         from pluginConf or driverConf
    */
   public String getWarehouseDir() {
-    String warehouseDir = pluginConf.get(ConfVars.METASTOREWAREHOUSE.varname);
-    return nonNull(warehouseDir) ? warehouseDir : driverConf.get(ConfVars.METASTOREWAREHOUSE.varname);
+    String warehouseDir = pluginConf.get(ConfVars.METASTORE_WAREHOUSE.varname);
+    return nonNull(warehouseDir) ? warehouseDir : driverConf.get(ConfVars.METASTORE_WAREHOUSE.varname);
   }
 
   public static class Builder {
@@ -153,22 +153,22 @@ public class HiveTestFixture {
       String warehouseDir = new File(baseDir, "warehouse").getAbsolutePath();
       // Drill Hive Storage plugin defaults
       pluginName("hive");
-      pluginOption(ConfVars.METASTOREURIS, "");
-      pluginOption(ConfVars.METASTORECONNECTURLKEY, jdbcUrl);
-      pluginOption(ConfVars.METASTOREWAREHOUSE, warehouseDir);
+      pluginOption(ConfVars.METASTORE_URIS, "");
+      pluginOption(ConfVars.METASTORE_CONNECT_URL_KEY, jdbcUrl);
+      pluginOption(ConfVars.METASTORE_WAREHOUSE, warehouseDir);
       pluginOption(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
       // Hive Driver defaults
-      driverOption(ConfVars.METASTORECONNECTURLKEY, jdbcUrl);
+      driverOption(ConfVars.METASTORE_CONNECT_URL_KEY, jdbcUrl);
       driverOption(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
-      driverOption(ConfVars.METASTOREWAREHOUSE, warehouseDir);
+      driverOption(ConfVars.METASTORE_WAREHOUSE, warehouseDir);
       driverOption("mapred.job.tracker", "local");
-      driverOption(ConfVars.SCRATCHDIR, createDirWithPosixPermissions(baseDir, "scratch_dir").getAbsolutePath());
-      driverOption(ConfVars.LOCALSCRATCHDIR, createDirWithPosixPermissions(baseDir, "local_scratch_dir").getAbsolutePath());
-      driverOption(ConfVars.DYNAMICPARTITIONINGMODE, "nonstrict");
+      driverOption(ConfVars.SCRATCH_DIR, createDirWithPosixPermissions(baseDir, "scratch_dir").getAbsolutePath());
+      driverOption(ConfVars.LOCAL_SCRATCH_DIR, createDirWithPosixPermissions(baseDir, "local_scratch_dir").getAbsolutePath());
+      driverOption(ConfVars.DYNAMIC_PARTITIONING_MODE, "nonstrict");
       driverOption(ConfVars.METASTORE_AUTO_CREATE_ALL, Boolean.toString(true));
       driverOption(ConfVars.METASTORE_SCHEMA_VERIFICATION, Boolean.toString(false));
       driverOption(ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING, Boolean.toString(false));
-      driverOption(HiveConf.ConfVars.HIVESESSIONSILENT, Boolean.toString(true));
+      driverOption(HiveConf.ConfVars.HIVE_SESSION_SILENT, Boolean.toString(true));
       driverOption(ConfVars.HIVE_CBO_ENABLED, Boolean.toString(false));
     }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
@@ -17,6 +17,15 @@
  */
 package org.apache.drill.exec.hive;
 
+import org.apache.drill.test.QueryBuilder;
+import org.apache.drill.test.TestTools;
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
+import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
+import org.apache.hadoop.util.ComparableVersion;
+import org.apache.hive.common.util.HiveVersionInfo;
+import org.junit.AssumptionViolatedException;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,14 +33,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
-
-import org.apache.drill.test.QueryBuilder;
-import org.apache.drill.test.TestTools;
-import org.apache.hadoop.hive.ql.Driver;
-import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
-import org.apache.hadoop.util.ComparableVersion;
-import org.apache.hive.common.util.HiveVersionInfo;
-import org.junit.AssumptionViolatedException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -53,13 +54,12 @@ public class HiveTestUtilities {
     CommandProcessorResponse response;
     try {
       response = hiveDriver.run(query);
-    } catch (Exception e) {
-       throw new RuntimeException(e);
-    }
-
-    if (response.getResponseCode() != 0 ) {
+    } catch (CommandProcessorException cpe) {
       throw new RuntimeException(String.format("Failed to execute command '%s', errorMsg = '%s'",
-          query, response.getErrorMessage()));
+          query, cpe.getMessage()));
+    }
+    catch (Exception e) {
+       throw new RuntimeException(e);
     }
   }
 
@@ -131,7 +131,8 @@ public class HiveTestUtilities {
    * @return {@code true} if current version is supported by Hive, {@code false} otherwise
    */
   public static boolean supportedJavaVersion() {
-    return System.getProperty("java.version").startsWith("1.8");
+    return true;
+    //return System.getProperty("java.version").startsWith("1.8");
   }
 
   /**

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
@@ -17,12 +17,6 @@
  */
 package org.apache.drill.exec.impersonation.hive;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.impersonation.BaseTestImpersonation;
@@ -38,10 +32,16 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.Driver;
 import org.junit.BeforeClass;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
 import static org.apache.drill.exec.hive.HiveTestUtilities.createDirWithPosixPermissions;
 import static org.apache.drill.exec.hive.HiveTestUtilities.executeQuery;
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_URIS;
 
 public class BaseTestHiveImpersonation extends BaseTestImpersonation {
   protected static final String hivePluginName = "hive";
@@ -79,21 +79,20 @@ public class BaseTestHiveImpersonation extends BaseTestImpersonation {
 
     // Configure metastore persistence db location on local filesystem
     final String dbUrl = String.format("jdbc:derby:;databaseName=%s;create=true",  metaStoreDBDir.getAbsolutePath());
-    hiveConf.set(ConfVars.METASTORECONNECTURLKEY.varname, dbUrl);
-
-    hiveConf.set(ConfVars.SCRATCHDIR.varname, "file://" + scratchDir.getAbsolutePath());
-    hiveConf.set(ConfVars.LOCALSCRATCHDIR.varname, localScratchDir.getAbsolutePath());
+    hiveConf.set(ConfVars.METASTORE_CONNECT_URL_KEY.varname, dbUrl);
+    hiveConf.set(ConfVars.SCRATCH_DIR.varname, "file://" + scratchDir.getAbsolutePath());
+    hiveConf.set(ConfVars.LOCAL_SCRATCH_DIR.varname, localScratchDir.getAbsolutePath());
     hiveConf.set(ConfVars.METASTORE_SCHEMA_VERIFICATION.varname, "false");
     hiveConf.set(ConfVars.METASTORE_AUTO_CREATE_ALL.varname, "true");
     hiveConf.set(ConfVars.HIVE_CBO_ENABLED.varname, "false");
     hiveConf.set(ConfVars.HIVESTATSAUTOGATHER.varname, "false");
     hiveConf.set(ConfVars.HIVESTATSCOLAUTOGATHER.varname, "false");
-    hiveConf.set(ConfVars.HIVESESSIONSILENT.varname, "true");
+    hiveConf.set(ConfVars.HIVE_SESSION_SILENT.varname, "true");
 
     // Set MiniDFS conf in HiveConf
     hiveConf.set(FS_DEFAULT_NAME_KEY, dfsConf.get(FS_DEFAULT_NAME_KEY));
 
-    whDir = hiveConf.get(ConfVars.METASTOREWAREHOUSE.varname);
+    whDir = hiveConf.get(ConfVars.METASTORE_WAREHOUSE.varname);
     FileSystem.mkdirs(fs, new Path(whDir), new FsPermission((short) 0777));
 
     dirTestWatcher.copyResourceToRoot(Paths.get("student.txt"));
@@ -122,7 +121,7 @@ public class BaseTestHiveImpersonation extends BaseTestImpersonation {
     }
     final int port = (int) metaStoreUtilsClass.getDeclaredMethod("findFreePort").invoke(null);
 
-    hiveConf.set(METASTOREURIS.varname, "thrift://localhost:" + port);
+    hiveConf.set(METASTORE_URIS.varname, "thrift://localhost:" + port);
 
     metaStoreUtilsClass.getDeclaredMethod("startMetaStore", int.class, hadoopThriftAuthBridgeClass, confClass)
         .invoke(null, port, hadoopThriftAuthBridge, hiveConf);
@@ -238,5 +237,4 @@ expectedTableTypes, ClientFixture client) throws Exception {
     executeQuery(driver, String.format(tblDef, db, tbl));
     executeQuery(driver, String.format("LOAD DATA LOCAL INPATH '%s' INTO TABLE %s.%s", data, db, tbl));
   }
-
 }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestSqlStdBasedAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestSqlStdBasedAuthorization.java
@@ -45,7 +45,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_AUTHORIZATION_E
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_CBO_ENABLED;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS;
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_URIS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AUTO_CREATE_ALL;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION;
@@ -100,7 +100,7 @@ public class TestSqlStdBasedAuthorization extends BaseTestHiveImpersonation {
 
   private static Map<String, String> getHivePluginConfig() {
     final Map<String, String> hiveConfig = Maps.newHashMap();
-    hiveConfig.put(METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname));
+    hiveConfig.put(METASTORE_URIS.varname, hiveConf.get(METASTORE_URIS.varname));
     hiveConfig.put(FS_DEFAULT_NAME_KEY, dfsConf.get(FS_DEFAULT_NAME_KEY));
     hiveConfig.put(HIVE_SERVER2_ENABLE_DOAS.varname, hiveConf.get(HIVE_SERVER2_ENABLE_DOAS.varname));
     hiveConfig.put(METASTORE_EXECUTE_SET_UGI.varname, hiveConf.get(METASTORE_EXECUTE_SET_UGI.varname));

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
@@ -17,16 +17,11 @@
  */
 package org.apache.drill.exec.impersonation.hive;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import org.apache.drill.test.ClientFixture;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -40,20 +35,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static org.apache.drill.exec.hive.HiveTestUtilities.executeQuery;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.drill.exec.hive.HiveTestUtilities.executeQuery;
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMICPARTITIONINGMODE;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMIC_PARTITIONING_MODE;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_CBO_ENABLED;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_METASTORE_AUTHENTICATOR_MANAGER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_METASTORE_AUTHORIZATION_AUTH_READS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_METASTORE_AUTHORIZATION_MANAGER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS;
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AUTO_CREATE_ALL;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_URIS;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation {
@@ -184,12 +184,12 @@ public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation
     hiveConf.set(HIVE_METASTORE_AUTHORIZATION_MANAGER.varname, StorageBasedAuthorizationProvider.class.getName());
     hiveConf.set(HIVE_METASTORE_AUTHORIZATION_AUTH_READS.varname, "true");
     hiveConf.set(METASTORE_EXECUTE_SET_UGI.varname, "true");
-    hiveConf.set(DYNAMICPARTITIONINGMODE.varname, "nonstrict");
+    hiveConf.set(DYNAMIC_PARTITIONING_MODE.varname, "nonstrict");
   }
 
   private static Map<String, String> getHivePluginConfig() {
     final Map<String, String> hiveConfig = Maps.newHashMap();
-    hiveConfig.put(METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname));
+    hiveConfig.put(METASTORE_URIS.varname, hiveConf.get(METASTORE_URIS.varname));
     hiveConfig.put(FS_DEFAULT_NAME_KEY, dfsConf.get(FS_DEFAULT_NAME_KEY));
     hiveConfig.put(HIVE_SERVER2_ENABLE_DOAS.varname, hiveConf.get(HIVE_SERVER2_ENABLE_DOAS.varname));
     hiveConfig.put(METASTORE_EXECUTE_SET_UGI.varname, hiveConf.get(METASTORE_EXECUTE_SET_UGI.varname));

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -32,7 +32,7 @@
   <name>Drill : Contrib : Storage : Hive : Exec Shaded</name>
 
   <properties>
-    <hive.parquet.version>1.15.1</hive.parquet.version>
+    <hive.parquet.version>1.15.2</hive.parquet.version>
   </properties>
 
   <dependencyManagement>
@@ -91,6 +91,10 @@
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>tomcat</groupId>
@@ -202,16 +206,6 @@
             </relocation>
           </relocations>
           <filters>
-            <filter>
-              <artifact>org.apache.hive:hive-exec</artifact>
-              <excludes>
-                <!-- This exclusion can be removed once hive-exec uses parquet-hadoop-bundle 1.8.2 or higher.
-                 It can be so, for example, after upgrading Hive to 3.0. To check if it's safe to remove the exclusion
-                 you can use TestHiveStorage.readFromAlteredPartitionedTableWithEmptyGroupType() test case. -->
-                <exclude>org/apache/parquet/**</exclude>
-                <exclude>shaded/parquet/org/**</exclude>
-              </excludes>
-            </filter>
             <filter>
               <artifact>com.fasterxml.jackson.core:*</artifact>
               <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <commons.text.version>1.10.0</commons.text.version>
     <commons.validator.version>1.7</commons.validator.version>
     <curator.version>5.5.0</curator.version>
-    <derby.version>10.14.2.0</derby.version>
+    <derby.version>10.17.1.0</derby.version>
     <directMemoryMb>3072</directMemoryMb>
     <docker.repository>apache/drill</docker.repository>
     <excludedGroups />
@@ -89,7 +89,7 @@
       Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated,
       for example parquet-hadoop-bundle and derby dependencies.
     -->
-    <hive.version>3.1.3</hive.version>
+    <hive.version>4.0.1</hive.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpdlog-parser.version>5.10.0</httpdlog-parser.version>
     <iceberg.version>0.12.1</iceberg.version>


### PR DESCRIPTION
# [DRILL-XXXX](https://issues.apache.org/jira/browse/DRILL-XXXX): Bump Hive to Version 4.0

## Description
Drill used Hive libraries version 3.1.  These libraries were not compatible with Java > 8, so all the unit tests were being skipped.   This proposed PR updates the Hive libraries to version 4 which is compatible with Java 11. 

## Documentation
No user facing changes other than this allows Drill to be used with the latest version of Hive.

## Testing
Ran existing unit tests.