### PR TITLE
[MINOR UPDATE] Bump Delta Lake to Version 4.0

### DIFF
--- a/contrib/format-deltalake/pom.xml
+++ b/contrib/format-deltalake/pom.xml
@@ -40,12 +40,12 @@
     <dependency>
       <groupId>io.delta</groupId>
       <artifactId>delta-storage</artifactId>
-      <version>3.0.0</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.delta</groupId>
       <artifactId>delta-standalone_2.13</artifactId>
-      <version>3.0.0</version>
+      <version>3.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
# [MINOR UPDAT]: Bump Delta Lake to Version 4.0

## Description
Update Delta Lake libraries to version 4.0

## Documentation
No user facing changes.

## Testing
Ran existing unit tests.