### PR TITLE
[MINOR UPDATE] Bump Hadoop to 3.4.1

### DIFF
--- a/contrib/storage-phoenix/pom.xml
+++ b/contrib/storage-phoenix/pom.xml
@@ -277,7 +277,14 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-client</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+      </exclusions>
       <scope>test</scope>
+
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <forkCount>1</forkCount>
     <freemarker.version>2.3.30</freemarker.version>
     <guava.version>32.1.2-jre</guava.version>
-    <hadoop.version>3.3.6</hadoop.version>
+    <hadoop.version>3.4.1</hadoop.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hbase.version>2.6.1-hadoop3</hbase.version>
     <hikari.version>4.0.3</hikari.version>


### PR DESCRIPTION
# MINOR UPDATE:  Bump Hadoop to 3.4.1

## Description
Bump Hadoop to 3.4.1

## Documentation
No user facing changes.

## Testing
Ran existing unit tests.