### PR TITLE
DRILL-8534: Update Kafka to Version 3.9

### DIFF
--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -31,7 +31,8 @@
   <name>Drill : Contrib : Storage : Kafka</name>
 
   <properties>
-    <kafka.version>2.8.2</kafka.version>
+    <kafka.version>3.9.0</kafka.version>
+    <kafka_scala.version>3.9.0</kafka_scala.version>
     <kafka.TestSuite>**/TestKafkaSuite.class</kafka.TestSuite>
   </properties>
 
@@ -80,7 +81,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.13</artifactId>
-      <version>${kafka.version}</version>
+      <version>${kafka_scala.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuite.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuite.java
@@ -42,7 +42,6 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,8 +82,8 @@ public class TestKafkaSuite extends BaseTest {
         embeddedKafkaCluster = new EmbeddedKafkaCluster();
         zkClient = KafkaZkClient.apply(embeddedKafkaCluster.getZkServer().getConnectionString(),
             false, SESSION_TIMEOUT, CONN_TIMEOUT, 0, Time.SYSTEM,
-            "kafka.server", "SessionExpireListener",
-            Option.<String>empty(), Option.<ZKClientConfig>empty());
+            "kafka.server", new ZKClientConfig(),
+            "kafka.server", "SessionExpireListener", false, false);
         createTopicHelper(TestQueryConstants.JSON_TOPIC, 1);
         createTopicHelper(TestQueryConstants.AVRO_TOPIC, 1);
         KafkaMessageGenerator generator = new KafkaMessageGenerator(embeddedKafkaCluster.getKafkaBrokerList(), StringSerializer.class);


### PR DESCRIPTION
# [DRILL-8534](https://issues.apache.org/jira/browse/DRILL-8534): Update Kafka to Version 3.9

## Description
This PR updates the Kafka client to use version 3.9.1 which is the latest version that supports Java 11. 

## Documentation
No user facing changes.

## Testing
Ran existing unit tests.