### PR TITLE
[MINOR UPDATE]: Update Drill Version in UDF Tests

### DIFF
--- a/exec/java-exec/src/test/resources/drill-udf/pom.xml
+++ b/exec/java-exec/src/test/resources/drill-udf/pom.xml
@@ -32,7 +32,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <jar.finalName>${project.name}</jar.finalName>
     <custom.buildDirectory>${project.basedir}/target</custom.buildDirectory>
-    <drill.version>1.21.0</drill.version>
+    <drill.version>1.22.0</drill.version>
     <include.files>**/*.java</include.files>
     <include.resources>**/*.conf</include.resources>
   </properties>


### PR DESCRIPTION
# [MINOR UPDATE]: Update Drill Version in UDF Tests

## Description
Bumps Drill version in UDF tests to 1.22. 

## Documentation
No user facing changes.

## Testing
Ran existing unit tests