### PR TITLE
Drillbit fails to start with NoSuchFieldError: sizeClass due to un-relocated Netty classes from hadoop-aws

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -138,6 +138,15 @@
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-bundle</artifactId>
         </exclusion>
+        <!--
+         Drill already pulls in the fine-grained AWS SDK v2 modules
+         (s3, dynamodb, sts, aws-core) at ${aws.java.sdk.version}, so the
+         bundle is redundant as well as harmful.
+       -->
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>bundle</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION

# [DRILL-8547](https://issues.apache.org/jira/browse/DRILL-8547): Drillbit fails to start with NoSuchFieldError: sizeClass due to un-relocated Netty classes from hadoop-aws

## Description

Drillbit fails to start with java.lang.NoSuchFieldError: sizeClass immediately after distribution build. The root cause is an un-relocated (old) copy of io.netty.buffer.PoolArena shipped inside software.amazon.awssdk:bundle:2.24.6, which is a transitive dependency of org.apache.hadoop:hadoop-aws:3.4.1 declared in distribution/pom.xml.

This old PoolArena class shadows Drill's own netty-buffer-4.1.118.Final on the classpath, causing PooledByteBufAllocatorL$InnerAllocator to fail when it accesses the sizeClass field that only exists in the newer netty version.

Error Stack Trace:
```
Exception in thread "main" java.lang.NoSuchFieldError: sizeClass
        at io.netty.buffer.PooledByteBufAllocatorL$InnerAllocator.<init>(PooledByteBufAllocatorL.java:112)
        at io.netty.buffer.PooledByteBufAllocatorL.<init>(PooledByteBufAllocatorL.java:58)
        at org.apache.drill.exec.memory.AllocationManager.<clinit>(AllocationManager.java:63)
        at org.apache.drill.exec.memory.BaseAllocator.<clinit>(BaseAllocator.java:49)
        at org.apache.drill.exec.memory.RootAllocatorFactory.newRoot(RootAllocatorFactory.java:45)
        at org.apache.drill.exec.memory.RootAllocatorFactory.newRoot(RootAllocatorFactory.java:40)
        at org.apache.drill.exec.server.BootStrapContext.<init>(BootStrapContext.java:90)
        at org.apache.drill.exec.server.Drillbit.<init>(Drillbit.java:173)
        at org.apache.drill.exec.server.Drillbit.start(Drillbit.java:579)
        at org.apache.drill.exec.server.Drillbit.start(Drillbit.java:559)
        at org.apache.drill.exec.server.Drillbit.main(Drillbit.java:555)
```
## Test
 1. Start Drill (e.g., ./drillbit.sh start).  
 2. The NoSuchFieldError appears immediately during startup.