### PR TITLE
DRILL-8550: Fix Flaky Splunk Tests

### DIFF
--- a/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
+++ b/contrib/storage-splunk/src/test/java/org/apache/drill/exec/store/splunk/SplunkTestSuite.java
@@ -107,14 +107,22 @@ public class SplunkTestSuite extends ClusterTest {
     }
   }
 
+  // Pin the patch version. "splunk/splunk:9.3" is a mutable tag; it was
+  // republished on 2026-07-01 and silently broke CI on every branch. Bump this
+  // deliberately so an upstream push can never turn the build red on its own.
+  //
+  // Talk to splunkd over its default HTTPS listener rather than setting
+  // SPLUNKD_SSL_ENABLE=false. Disabling splunkd SSL is a path Splunk has
+  // regressed repeatedly (see splunk/docker-splunk#639, still open), and it
+  // broke again in 9.3.14. The container's cert is self-signed, so the plugin
+  // configs below turn off certificate and hostname validation.
   @ClassRule
   public static GenericContainer<?> splunk = new GenericContainer<>(
-    DockerImageName.parse("splunk/splunk:9.3")
+    DockerImageName.parse("splunk/splunk:9.3.14")
   )
     .withExposedPorts(8089, 8089)
     .withEnv("SPLUNK_START_ARGS", "--accept-license")
     .withEnv("SPLUNK_PASSWORD", SPLUNK_PASS)
-    .withEnv("SPLUNKD_SSL_ENABLE", "false")
     .withCopyFileToContainer(
       org.testcontainers.utility.MountableFile.forHostPath(
         createDefaultYmlFile().toPath()
@@ -159,8 +167,11 @@ public class SplunkTestSuite extends ClusterTest {
         StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
         SPLUNK_STORAGE_PLUGIN_CONFIG = new SplunkPluginConfig(
           SPLUNK_LOGIN, SPLUNK_PASS,
-          "http", hostname, port,
-          null, null, null, null, false, true, // app, owner, token, cookie, validateCertificates
+          "https", hostname, port,
+          // app, owner, token, cookie, validateCertificates, validateHostname.
+          // The container serves a self-signed cert for a hostname that never matches
+          // the mapped localhost port, so both checks must be off.
+          null, null, null, null, false, false,
           "1", "now",
           null,
           4,
@@ -181,8 +192,9 @@ public class SplunkTestSuite extends ClusterTest {
 
         SPLUNK_STORAGE_PLUGIN_CONFIG_WITH_USER_TRANSLATION = new SplunkPluginConfig(
           null, null, // username, password
-          "http", hostname, port,
-          null, null, null, null, false, false, // app, owner, token, cookie, validateCertificates
+          "https", hostname, port,
+          // app, owner, token, cookie, validateCertificates, validateHostname
+          null, null, null, null, false, false,
           "1", "now",
           credentialsProvider,
           4,


### PR DESCRIPTION
## Description

The Splunk unit tests have been failing consistently on CI. The `splunk/splunk:9.3` tag was republished on 2026-07-01 to point at 9.3.14. Identical test code passed on 2026-06-26 against 9.3.13 and fails on 9.3.14, so the image is the only variable.

9.3.14 serves HTTPS on the management port despite `SPLUNKD_SSL_ENABLE=false`, so the plaintext client failed every connection with `Unexpected end of file from server`.  Shockingly, despite Splunk's incredible commitments to code and design quality, disabling splunkd SSL is a path Splunk has regressed repeatedly, so this talks to the default HTTPS listener instead and turns off certificate and hostname validation for the self-signed container cert.

The patch version is now pinned so an upstream push cannot break the build on its own.

Also corrects the constructor argument comment, which listed five names for six values and hid `validateHostname=true` on the shared-user config.

## Changes
- `SplunkTestSuite`: pin image to `splunk/splunk:9.3.14`, drop `SPLUNKD_SSL_ENABLE=false`, connect over `https`, and set `validateCertificates=false` / `validateHostname=false` on both plugin configs.

## Documentation
No user-facing changes; test-only.

## Testing
`contrib/storage-splunk` test sources compile. The suite requires Docker to run the Splunk container.

Cherry-picked from https://github.com/apache/drill/pull/3037 (commit 24cbbdf).