### PR TITLE
[MINOR-UPDATE] Upgrade to msgpack 0.9

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,7 +54,7 @@
 
     <dependency>
       <groupId>org.msgpack</groupId>
-      <artifactId>msgpack</artifactId>
+      <artifactId>msgpack-core</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <metrics.version>4.2.19</metrics.version>
     <mockito.version>5.23.0</mockito.version>
     <mongo.version>5.5.1</mongo.version>
-    <msgpack.version>0.6.6</msgpack.version>
+    <msgpack.version>0.9.12</msgpack.version>
     <nashorn.version>15.4</nashorn.version>
     <netty.tcnative.classifier />
     <netty.tcnative.version>2.0.65.Final</netty.tcnative.version>
@@ -1032,7 +1032,7 @@
       </dependency>
       <dependency>
         <groupId>org.msgpack</groupId>
-        <artifactId>msgpack</artifactId>
+        <artifactId>msgpack-core</artifactId>
         <version>${msgpack.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
# MINOR UDPATE Upgrade to msgpack 0.9

## Description

Upgrading from 0.6.6 released in 2012 and having a transitive dependency to junit 4.10 at runtime to 0.9.12 released this year without this junit dependency at runtime

## Documentation
N/A

## Testing
compilation passed locally of the whole project
common module test are passing
